### PR TITLE
Implement homepage habit items statistics representation

### DIFF
--- a/src/main/java/greencity/config/SecurityConfig.java
+++ b/src/main/java/greencity/config/SecurityConfig.java
@@ -92,6 +92,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 "/place/info/favorite/**",
                 "/place/statuses/**",
                 "/user/emailNotifications/**",
+                "/user/activatedUsersAmount",
+                "/habit/todayStatisticsForAllHabitItems",
                 "/place/about/{id}/**",
                 "/specification/**",
                 "/newsSubscriber/unsubscribe",

--- a/src/main/java/greencity/controller/HabitStatisticController.java
+++ b/src/main/java/greencity/controller/HabitStatisticController.java
@@ -2,12 +2,14 @@ package greencity.controller;
 
 import greencity.constant.HttpStatuses;
 import greencity.dto.habitstatistic.AddHabitStatisticDto;
+import greencity.dto.habitstatistic.HabitItemsAmountStatisticDto;
 import greencity.dto.habitstatistic.HabitStatisticDto;
 import greencity.dto.habitstatistic.UpdateHabitStatisticDto;
 import greencity.entity.Habit;
 import greencity.entity.HabitStatistic;
 import greencity.service.HabitStatisticService;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import java.util.List;
@@ -74,5 +76,30 @@ public class HabitStatisticController {
         @PathVariable Long habitId) {
         return ResponseEntity.status(HttpStatus.OK)
             .body(habitStatisticService.findAllByHabitId(habitId));
+    }
+
+    /**
+     * Returns statistics for all not taken habit items in the system for today.
+     * Data is returned as an array of key-value-pairs mapped to {@link HabitItemsAmountStatisticDto},
+     * where key is the name of habit item and value is not taken amount of these items.
+     * Language of habit items is defined by the `language` parameter.
+     *
+     * @param language - Name of habit item localization language(e.x. "en" or "uk").
+     * @return {@link List} of {@link HabitItemsAmountStatisticDto}s contain those key-value pairs.
+     */
+    @ApiOperation(value = "Get today's statistic for all habit items")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = HttpStatuses.OK, response = List.class),
+        @ApiResponse(code = 303, message = HttpStatuses.SEE_OTHER),
+        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
+    })
+    @GetMapping("/statistic/todayStatisticsForAllHabitItems")
+    public ResponseEntity<List<HabitItemsAmountStatisticDto>> getTodayStatisticsForAllHabitItems(
+        @ApiParam(value = "Requested language code")
+        @RequestParam(defaultValue = "en") String language
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(habitStatisticService.getTodayStatisticsForAllHabitItems(language));
     }
 }

--- a/src/main/java/greencity/controller/UserController.java
+++ b/src/main/java/greencity/controller/UserController.java
@@ -592,4 +592,23 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK).body(userService
             .deleteUserGoals(ids));
     }
+
+    /**
+     * Counts all users by user {@link UserStatus} ACTIVATED.
+     *
+     * @return amount of users with {@link UserStatus} ACTIVATED.
+     * @author Shevtsiv Rostyslav
+     */
+    @ApiOperation(value = "Get all activated users amount")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = HttpStatuses.OK, response = Long.class),
+        @ApiResponse(code = 303, message = HttpStatuses.SEE_OTHER),
+        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
+    })
+    @GetMapping("/activatedUsersAmount")
+    public ResponseEntity<Long> getActivatedUsersAmount() {
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(userService.getActivatedUsersAmount());
+    }
 }

--- a/src/main/java/greencity/dto/habitstatistic/HabitItemsAmountStatisticDto.java
+++ b/src/main/java/greencity/dto/habitstatistic/HabitItemsAmountStatisticDto.java
@@ -1,0 +1,15 @@
+package greencity.dto.habitstatistic;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HabitItemsAmountStatisticDto {
+    private String habitItem;
+    private long notTakenItems;
+}

--- a/src/main/java/greencity/repository/UserRepo.java
+++ b/src/main/java/greencity/repository/UserRepo.java
@@ -2,6 +2,7 @@ package greencity.repository;
 
 import greencity.entity.User;
 import greencity.entity.enums.EmailNotification;
+import greencity.entity.enums.UserStatus;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -63,4 +64,11 @@ public interface UserRepo extends JpaRepository<User, Long>, JpaSpecificationExe
     @Modifying
     @Query(value = "UPDATE User SET refreshTokenKey=:refreshTokenKey WHERE id=:id")
     int updateUserRefreshToken(String refreshTokenKey, Long id);
+
+    /**
+     * Counts all users by user {@link UserStatus}.
+     *
+     * @return amount of user with given {@link UserStatus}.
+     */
+    long countAllByUserStatus(UserStatus userStatus);
 }

--- a/src/main/java/greencity/service/HabitStatisticService.java
+++ b/src/main/java/greencity/service/HabitStatisticService.java
@@ -72,4 +72,15 @@ public interface HabitStatisticService {
      * @return list of {@link HabitDto} instances.
      */
     List<HabitDto> findAllHabitsAndTheirStatistics(Long id, Boolean status, String language);
+
+    /**
+     * Returns statistics for all not taken habit items in the system for today.
+     * Data is returned as an array of key-value-pairs mapped to {@link HabitItemsAmountStatisticDto},
+     * where key is the name of habit item and value is not taken amount of these items.
+     * Language of habit items is defined by the `language` parameter.
+     *
+     * @param language - Name of habit item localization language(e.x. "en" or "uk").
+     * @return {@link List} of {@link HabitItemsAmountStatisticDto}s contain those key-value pairs.
+     */
+    List<HabitItemsAmountStatisticDto> getTodayStatisticsForAllHabitItems(String language);
 }

--- a/src/main/java/greencity/service/UserService.java
+++ b/src/main/java/greencity/service/UserService.java
@@ -240,4 +240,12 @@ public interface UserService {
      * @author Bogdan Kuzenko
      */
     List<CustomGoalResponseDto> getAvailableCustomGoals(User user);
+
+    /**
+     * Counts all users by user {@link UserStatus} ACTIVATED.
+     *
+     * @return amount of users with {@link UserStatus} ACTIVATED.
+     * @author Shevtsiv Rostyslav
+     */
+    long getActivatedUsersAmount();
 }

--- a/src/main/java/greencity/service/impl/HabitStatisticServiceImpl.java
+++ b/src/main/java/greencity/service/impl/HabitStatisticServiceImpl.java
@@ -22,6 +22,7 @@ import java.time.Period;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -268,5 +269,19 @@ public class HabitStatisticServiceImpl implements HabitStatisticService {
         habitDictionaryDto.setHabitItem(habitDictionaryTranslation.getHabitItem());
         habitDictionaryDto.setName(habitDictionaryTranslation.getName());
         return habitDictionaryTranslation;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<HabitItemsAmountStatisticDto> getTodayStatisticsForAllHabitItems(String language) {
+        return habitStatisticRepo.getStatisticsForAllHabitItemsByDate(new Date(), language).stream()
+            .map(it ->
+                HabitItemsAmountStatisticDto.builder()
+                    .habitItem((String) it.get(0))
+                    .notTakenItems((long) it.get(1))
+                    .build()
+            ).collect(Collectors.toList());
     }
 }

--- a/src/main/java/greencity/service/impl/UserServiceImpl.java
+++ b/src/main/java/greencity/service/impl/UserServiceImpl.java
@@ -472,6 +472,14 @@ public class UserServiceImpl implements UserService {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getActivatedUsersAmount() {
+        return userRepo.countAllByUserStatus(UserStatus.ACTIVATED);
+    }
+
+    /**
      * Method check is in user habit.
      *
      * @param userId      Id current user.

--- a/src/test/java/greencity/controller/HabitStatisticControllerTest.java
+++ b/src/test/java/greencity/controller/HabitStatisticControllerTest.java
@@ -1,0 +1,111 @@
+package greencity.controller;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import greencity.dto.habitstatistic.HabitItemsAmountStatisticDto;
+import greencity.repository.HabitStatisticRepo;
+import java.util.Collections;
+import java.util.List;
+import javax.persistence.Tuple;
+import javax.persistence.TupleElement;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@RunWith(SpringRunner.class)
+public class HabitStatisticControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private HabitStatisticRepo habitStatisticRepo;
+    private static final String habitStatisticLink = "/habit/statistic/todayStatisticsForAllHabitItems";
+
+    @Test
+    @WithMockUser
+    public void getTodayStatisticsForAllHabitItemsStatusCodeTest() throws Exception {
+        mockMvc.perform(get(habitStatisticLink))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    public void getTodayStatisticsForAllHabitItemsWithLanguageCodeTest() throws Exception {
+        mockMvc.perform(get(habitStatisticLink + "?language=en"))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    public void getTodayStatisticsForAllHabitItemsSingleHabitTest() throws Exception {
+        when(habitStatisticRepo.getStatisticsForAllHabitItemsByDate(any(), anyString()))
+            .thenReturn(Collections.singletonList(new Tuple() {
+                @Override
+                public <X> X get(TupleElement<X> tupleElement) {
+                    return null;
+                }
+
+                @Override
+                public <X> X get(String alias, Class<X> type) {
+                    return null;
+                }
+
+                @Override
+                public Object get(String alias) {
+                    return null;
+                }
+
+                @Override
+                public <X> X get(int i, Class<X> type) {
+                    return null;
+                }
+
+                @Override
+                public Object get(int i) {
+                    if (i == 0) {
+                        return "foo";
+                    } else if (i == 1) {
+                        return 42L;
+                    }
+                    return null;
+                }
+
+                @Override
+                public Object[] toArray() {
+                    return new Object[0];
+                }
+
+                @Override
+                public List<TupleElement<?>> getElements() {
+                    return null;
+                }
+            }));
+        MvcResult requestResult = mockMvc.perform(get(habitStatisticLink))
+            .andExpect(status().isOk()).andReturn();
+        TypeReference<List<HabitItemsAmountStatisticDto>> typeRef =
+            new TypeReference<List<HabitItemsAmountStatisticDto>>() {
+            };
+        String responseContent = requestResult.getResponse().getContentAsString();
+        List<HabitItemsAmountStatisticDto> habitItemAndItsStatistic =
+            new ObjectMapper().readValue(responseContent, typeRef);
+        assertEquals(1, habitItemAndItsStatistic.size());
+        assertEquals("foo", habitItemAndItsStatistic.get(0).getHabitItem());
+        assertEquals(42L, habitItemAndItsStatistic.get(0).getNotTakenItems());
+    }
+}

--- a/src/test/java/greencity/controller/UserControllerTest.java
+++ b/src/test/java/greencity/controller/UserControllerTest.java
@@ -12,11 +12,14 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
@@ -61,5 +64,21 @@ public class UserControllerTest {
         when(userService.deleteUserGoals("1")).thenReturn(Collections.emptyList());
         mockMvc.perform(delete("/user/1/userGoals").param("ids", "1"))
             .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    public void getAllActivatedUsersAmountStatusCodeTest() throws Exception {
+        mockMvc.perform(get("/user/activatedUsersAmount"))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    public void getAllActivatedUsersAmountWithServiceMockTest() throws Exception {
+        when(userService.getActivatedUsersAmount()).thenReturn(42L);
+        MvcResult requestResult = mockMvc.perform(get("/user/activatedUsersAmount"))
+            .andExpect(status().isOk()).andReturn();
+        assertEquals("42", requestResult.getResponse().getContentAsString());
     }
 }

--- a/src/test/java/greencity/repository/HabitStatisticRepoTest.java
+++ b/src/test/java/greencity/repository/HabitStatisticRepoTest.java
@@ -1,0 +1,81 @@
+package greencity.repository;
+
+import java.util.Date;
+import java.util.List;
+import javax.persistence.Tuple;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@DataJpaTest
+@RunWith(SpringRunner.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class HabitStatisticRepoTest {
+
+    @Autowired
+    private HabitStatisticRepo habitStatisticRepo;
+
+    @Test
+    public void emptyDataSourceTest() {
+        List<Tuple> amountOfAllHabitItems =
+            habitStatisticRepo.getStatisticsForAllHabitItemsByDate(new Date(), "en");
+        assertTrue(amountOfAllHabitItems.isEmpty());
+    }
+
+    @Test
+    @Sql("file:src/test/resources/sql/single_habit_statistic.sql")
+    public void singleHabitStatisticTest() {
+        List<Tuple> amountOfAllHabitItems =
+            habitStatisticRepo.getStatisticsForAllHabitItemsByDate(new Date(), "en");
+        assertEquals(1, amountOfAllHabitItems.size());
+        Tuple tuple = amountOfAllHabitItems.get(0);
+        assertEquals("foo", tuple.get(0));
+        assertEquals(42L, tuple.get(1));
+    }
+
+    @Test
+    @Sql("file:src/test/resources/sql/most_popular_habit_statistic.sql")
+    public void mostPopularHabitStatisticTest() {
+        List<Tuple> amountOfAllHabitItems =
+            habitStatisticRepo.getStatisticsForAllHabitItemsByDate(new Date(), "en");
+        assertEquals(2, amountOfAllHabitItems.size());
+        Tuple mostPopularHabitTuple = amountOfAllHabitItems.get(0);
+        assertEquals("baz", mostPopularHabitTuple.get(0));
+        assertEquals(45L, mostPopularHabitTuple.get(1));
+        Tuple secondByPopularityHabitTuple = amountOfAllHabitItems.get(1);
+        assertEquals("eggs", secondByPopularityHabitTuple.get(0));
+        assertEquals(8L, secondByPopularityHabitTuple.get(1));
+    }
+
+    @Test
+    @Sql("file:src/test/resources/sql/disabled_habit_statistics.sql")
+    public void habitsWithDisabledMostPopularHabitTest() {
+        List<Tuple> amountOfAllHabitItems =
+            habitStatisticRepo.getStatisticsForAllHabitItemsByDate(new Date(), "en");
+        assertEquals(1, amountOfAllHabitItems.size());
+        Tuple tuple = amountOfAllHabitItems.get(0);
+        assertEquals("eggs", tuple.get(0));
+        assertEquals(8L, tuple.get(1));
+    }
+
+    @Test
+    @Sql("file:src/test/resources/sql/outdated_habits_statistic.sql")
+    public void habitsWithOutdatedMostPopularHabitTest() {
+        List<Tuple> amountOfAllHabitItems
+            = habitStatisticRepo.getStatisticsForAllHabitItemsByDate(new Date(), "en");
+        assertEquals(2, amountOfAllHabitItems.size());
+        Tuple mostPopularHabitTuple = amountOfAllHabitItems.get(0);
+        assertEquals("baz", mostPopularHabitTuple.get(0));
+        assertEquals(3L, mostPopularHabitTuple.get(1));
+        Tuple secondByPopularityHabitTuple = amountOfAllHabitItems.get(1);
+        assertEquals("eggs", secondByPopularityHabitTuple.get(0));
+        assertEquals(8L, secondByPopularityHabitTuple.get(1));
+    }
+}

--- a/src/test/java/greencity/service/impl/UserServiceImplTest.java
+++ b/src/test/java/greencity/service/impl/UserServiceImplTest.java
@@ -610,4 +610,11 @@ public class UserServiceImplTest {
         userService.deleteHabitByUserIdAndHabitDictionary(user.getId(), habit.getId());
         verify(habitRepo).updateHabitStatusById(habit.getId(), false);
     }
+
+    @Test
+    public void getActivatedUsersAmountTest() {
+        when(userRepo.countAllByUserStatus(UserStatus.ACTIVATED)).thenReturn(1L);
+        long activatedUsersAmount = userService.getActivatedUsersAmount();
+        assertEquals(1L, activatedUsersAmount);
+    }
 }

--- a/src/test/resources/sql/disabled_habit_statistics.sql
+++ b/src/test/resources/sql/disabled_habit_statistics.sql
@@ -1,0 +1,49 @@
+INSERT INTO users (id,
+                   date_of_registration,
+                   email,
+                   email_notification,
+                   first_name,
+                   last_name,
+                   last_visit,
+                   role,
+                   user_status,
+                   refresh_token_key)
+VALUES (1, current_date, 'foo@bar.com', 1, 'foo', 'bar', current_date, 1, 1, 'quux');
+INSERT INTO users (id,
+                   date_of_registration,
+                   email,
+                   email_notification,
+                   first_name,
+                   last_name,
+                   last_visit,
+                   role,
+                   user_status,
+                   refresh_token_key)
+VALUES (2, current_date, 'baz@bar.com', 1, 'foo', 'barbar', current_date, 1, 1, 'quuxbaz');
+
+INSERT INTO habit_dictionary (id, image)
+VALUES (1, 'foo');
+INSERT INTO habit_dictionary (id, image)
+VALUES (2, 'quux');
+
+INSERT INTO languages (id, code)
+VALUES (1, 'en');
+
+INSERT INTO habit_dictionary_translation (id, name, description, habit_item, language_id, habit_dictionary_id)
+VALUES (1, 'spam', 'eggs', 'foo', 1, 1);
+INSERT INTO habit_dictionary_translation (id, name, description, habit_item, language_id, habit_dictionary_id)
+VALUES (2, 'barbaz', 'barbar', 'eggs', 1, 2);
+
+INSERT INTO habits (id, user_id, habit_dictionary_id, status, create_date)
+VALUES (1, 1, 1, false, current_date); -- This habit is disabled
+INSERT INTO habits (id, user_id, habit_dictionary_id, status, create_date)
+VALUES (2, 1, 2, true, current_date);
+INSERT INTO habits (id, user_id, habit_dictionary_id, status, create_date)
+VALUES (3, 2, 1, false, current_date); -- This habit is disabled
+
+INSERT INTO habit_statistics (id, rate, date, amount_of_items, habit_id)
+VALUES (1, 'quux', current_date, 42, 1);
+INSERT INTO habit_statistics (id, rate, date, amount_of_items, habit_id)
+VALUES (2, 'quux', current_date, 8, 2);
+INSERT INTO habit_statistics (id, rate, date, amount_of_items, habit_id)
+VALUES (3, 'quux', current_date, 3, 3);

--- a/src/test/resources/sql/most_popular_habit_statistic.sql
+++ b/src/test/resources/sql/most_popular_habit_statistic.sql
@@ -1,0 +1,49 @@
+INSERT INTO users (id,
+                   date_of_registration,
+                   email,
+                   email_notification,
+                   first_name,
+                   last_name,
+                   last_visit,
+                   role,
+                   user_status,
+                   refresh_token_key)
+VALUES (1, current_date, 'foo@bar.com', 1, 'foo', 'bar', current_date, 1, 1, 'quux');
+INSERT INTO users (id,
+                   date_of_registration,
+                   email,
+                   email_notification,
+                   first_name,
+                   last_name,
+                   last_visit,
+                   role,
+                   user_status,
+                   refresh_token_key)
+VALUES (2, current_date, 'baz@bar.com', 1, 'foo', 'barbar', current_date, 1, 1, 'quuxbaz');
+
+INSERT INTO languages (id, code)
+VALUES (1, 'en');
+
+INSERT INTO habit_dictionary (id, image)
+VALUES (1, 'foo');
+INSERT INTO habit_dictionary (id, image)
+VALUES (2, 'quux');
+
+INSERT INTO habit_dictionary_translation (id, name, description, habit_item, language_id, habit_dictionary_id)
+VALUES (1, 'foobar', 'bar', 'baz', 1, 1);
+INSERT INTO habit_dictionary_translation (id, name, description, habit_item, language_id, habit_dictionary_id)
+VALUES (2, 'quux', 'bar', 'eggs', 1, 2);
+
+INSERT INTO habits (id, user_id, habit_dictionary_id, status, create_date)
+VALUES (1, 1, 1, true, current_date);
+INSERT INTO habits (id, user_id, habit_dictionary_id, status, create_date)
+VALUES (2, 1, 2, true, current_date);
+INSERT INTO habits (id, user_id, habit_dictionary_id, status, create_date)
+VALUES (3, 2, 1, true, current_date);
+
+INSERT INTO habit_statistics (id, rate, date, amount_of_items, habit_id)
+VALUES (1, 'quux', current_date, 42, 1);
+INSERT INTO habit_statistics (id, rate, date, amount_of_items, habit_id)
+VALUES (2, 'quux', current_date, 8, 2);
+INSERT INTO habit_statistics (id, rate, date, amount_of_items, habit_id)
+VALUES (3, 'quux', current_date, 3, 3);

--- a/src/test/resources/sql/outdated_habits_statistic.sql
+++ b/src/test/resources/sql/outdated_habits_statistic.sql
@@ -1,0 +1,49 @@
+INSERT INTO users (id,
+                   date_of_registration,
+                   email,
+                   email_notification,
+                   first_name,
+                   last_name,
+                   last_visit,
+                   role,
+                   user_status,
+                   refresh_token_key)
+VALUES (1, current_date, 'foo@bar.com', 1, 'foo', 'bar', current_date, 1, 1, 'quux');
+INSERT INTO users (id,
+                   date_of_registration,
+                   email,
+                   email_notification,
+                   first_name,
+                   last_name,
+                   last_visit,
+                   role,
+                   user_status,
+                   refresh_token_key)
+VALUES (2, current_date, 'baz@bar.com', 1, 'foo', 'barbar', current_date, 1, 1, 'quuxbaz');
+
+INSERT INTO languages (id, code)
+VALUES (1, 'en');
+
+INSERT INTO habit_dictionary (id, image)
+VALUES (1, 'foo');
+INSERT INTO habit_dictionary (id, image)
+VALUES (2, 'quux');
+
+INSERT INTO habit_dictionary_translation (id, name, description, habit_item, language_id, habit_dictionary_id)
+VALUES (1, 'foobar', 'bar', 'baz', 1, 1);
+INSERT INTO habit_dictionary_translation (id, name, description, habit_item, language_id, habit_dictionary_id)
+VALUES (2, 'quux', 'bar', 'eggs', 1, 2);
+
+INSERT INTO habits (id, user_id, habit_dictionary_id, status, create_date)
+VALUES (1, 1, 1, true, current_date);
+INSERT INTO habits (id, user_id, habit_dictionary_id, status, create_date)
+VALUES (2, 1, 2, true, current_date);
+INSERT INTO habits (id, user_id, habit_dictionary_id, status, create_date)
+VALUES (3, 2, 1, true, current_date);
+
+INSERT INTO habit_statistics (id, rate, date, amount_of_items, habit_id)
+VALUES (1, 'quux', current_date - 1, 42, 1); -- This statistic is outdated
+INSERT INTO habit_statistics (id, rate, date, amount_of_items, habit_id)
+VALUES (2, 'quux', current_date, 8, 2);
+INSERT INTO habit_statistics (id, rate, date, amount_of_items, habit_id)
+VALUES (3, 'quux', current_date, 3, 3);

--- a/src/test/resources/sql/single_habit_statistic.sql
+++ b/src/test/resources/sql/single_habit_statistic.sql
@@ -1,0 +1,26 @@
+INSERT INTO users (id,
+                   date_of_registration,
+                   email,
+                   email_notification,
+                   first_name,
+                   last_name,
+                   last_visit,
+                   role,
+                   user_status,
+                   refresh_token_key)
+VALUES (1, current_date, 'foo@bar.com', 1, 'foo', 'bar', current_date, 1, 1, 'quux');
+
+INSERT INTO languages (id, code)
+VALUES (1, 'en');
+
+INSERT INTO habit_dictionary (id, image)
+VALUES (1, 'foo');
+
+INSERT INTO habit_dictionary_translation (id, name, description, habit_item, language_id, habit_dictionary_id)
+VALUES (1, 'bar', 'baz', 'foo', 1, 1);
+
+INSERT INTO habits (id, user_id, habit_dictionary_id, status, create_date)
+VALUES (1, 1, 1, true, current_date);
+
+INSERT INTO habit_statistics (id, rate, date, amount_of_items, habit_id)
+VALUES (1, 'quux', current_date, 42, 1);


### PR DESCRIPTION
By now only habit item names and according amount of not taken items are queried from the server, but in the future releases this behavior should be changed for full server-side population of habit statistics, including all the strings user can see on the homepage statistic section, localized according to the user's locale.

All the tests in this commit are passing, but the following SQL-script can be executed for manual testing:
```SQL
INSERT INTO languages (id, code)
VALUES (1, 'en');

INSERT INTO habit_dictionary (id, image)
VALUES (1, 'foo');
INSERT INTO habit_dictionary (id, image)
VALUES (2, 'bar');

INSERT INTO habit_dictionary_translation (id, name, description, habit_item, language_id, habit_dictionary_id)
VALUES (1, 'bar', 'baz', 'bags', 1, 1);
INSERT INTO habit_dictionary_translation (id, name, description, habit_item, language_id, habit_dictionary_id)
VALUES (2, 'bar', 'baz', 'caps', 1, 2);

INSERT INTO habits (id, user_id, habit_dictionary_id, status, create_date)
VALUES (1, null, 1, true, current_date);
INSERT INTO habits (id, user_id, habit_dictionary_id, status, create_date)
VALUES (2, null, 2, true, current_date);

INSERT INTO habit_statistics (id, rate, date, amount_of_items, habit_id)
VALUES (1, 'quux', current_date, 42, 1);
INSERT INTO habit_statistics (id, rate, date, amount_of_items, habit_id)
VALUES (2, 'quux', current_date, 96, 2);
```
After that you should see 2 habit statistics(one for bags and one for cups) on the homepage with numbers 42 and 96 accordingly.

Corresponding pull request for the client-side: https://github.com/ita-social-projects/GreenCityClient/pull/141