### PR TITLE
Avoid extra query when deleting custom goals by id

### DIFF
--- a/src/main/java/greencity/service/impl/CustomGoalServiceImpl.java
+++ b/src/main/java/greencity/service/impl/CustomGoalServiceImpl.java
@@ -108,9 +108,7 @@ public class CustomGoalServiceImpl implements CustomGoalService {
     @Transactional
     @Override
     public CustomGoalResponseDto findById(Long id) {
-        CustomGoal customGoal = customGoalRepo.findById(id)
-            .orElseThrow(() -> new NotFoundException(CUSTOM_GOAL_NOT_FOUND_BY_ID + " " + id));
-        return modelMapper.map(customGoal, CustomGoalResponseDto.class);
+        return modelMapper.map(findOne(id), CustomGoalResponseDto.class);
     }
 
     /**

--- a/src/main/java/greencity/service/impl/CustomGoalServiceImpl.java
+++ b/src/main/java/greencity/service/impl/CustomGoalServiceImpl.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -174,7 +175,11 @@ public class CustomGoalServiceImpl implements CustomGoalService {
      * @author Bogdan Kuzenko.
      */
     private Long delete(Long id) {
-        customGoalRepo.delete(findOne(id));
+        try {
+            customGoalRepo.deleteById(id);
+        } catch (EmptyResultDataAccessException e) {
+            throw new NotFoundException(CUSTOM_GOAL_NOT_FOUND_BY_ID + " " + id);
+        }
         return id;
     }
 


### PR DESCRIPTION
Since the method is meant to delete entities by id we can use built-in `deleteById` method of CrudRepository interface and avoid extra query.