### PR TITLE
Avoid extra query when deleting Advice by id

### DIFF
--- a/src/main/java/greencity/service/impl/AdviceServiceImpl.java
+++ b/src/main/java/greencity/service/impl/AdviceServiceImpl.java
@@ -16,6 +16,7 @@ import java.util.List;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 
 /**
@@ -135,10 +136,11 @@ public class AdviceServiceImpl implements AdviceService {
      */
     @Override
     public Long delete(Long id) {
-        if (!(adviceRepo.findById(id).isPresent())) {
+        try {
+            adviceRepo.deleteById(id);
+        } catch (EmptyResultDataAccessException e) {
             throw new NotDeletedException(ErrorMessage.ADVICE_NOT_DELETED);
         }
-        adviceRepo.deleteById(id);
         return id;
     }
 }

--- a/src/test/java/greencity/service/impl/AdviceServiceImplTest.java
+++ b/src/test/java/greencity/service/impl/AdviceServiceImplTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
+import org.springframework.dao.EmptyResultDataAccessException;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AdviceServiceImplTest {
@@ -122,13 +123,13 @@ public class AdviceServiceImplTest {
 
     @Test
     public void delete() {
-        when(adviceRepo.findById(advice.getId())).thenReturn(Optional.of(advice));
         assertEquals(advice.getId(), adviceService.delete(advice.getId()));
         verify(adviceRepo, times(1)).deleteById(anyLong());
     }
 
     @Test(expected = NotDeletedException.class)
     public void deleteFailed() {
+        doThrow(new EmptyResultDataAccessException(1)).when(adviceRepo).deleteById(advice.getId());
         adviceService.delete(advice.getId());
     }
 }


### PR DESCRIPTION
Since the method is meant to delete entities by id we can use built-in `deleteById` method of CrudRepository interface and avoid extra query.