### PR TITLE
Fix habit statistics for habit that had been tracked more than one day

### DIFF
--- a/src/main/java/greencity/repository/HabitStatisticRepo.java
+++ b/src/main/java/greencity/repository/HabitStatisticRepo.java
@@ -85,7 +85,7 @@ public interface HabitStatisticRepo extends JpaRepository<HabitStatistic, Long>,
      */
     @Query("SELECT habitDictTranslation.habitItem, SUM(habitStatistic.amountOfItems) "
         + "FROM HabitStatistic habitStatistic "
-        + "        INNER JOIN Habit habit ON habitStatistic.id = habit.id AND habit.statusHabit = TRUE "
+        + "        INNER JOIN Habit habit ON habitStatistic.habit.id = habit.id AND habit.statusHabit = TRUE "
         + "                AND FUNCTION('DATE', habitStatistic.createdOn) = :statisticCreationDate "
         + "        INNER JOIN HabitDictionaryTranslation habitDictTranslation "
         + "                ON habitDictTranslation.habitDictionary.id = habit.habitDictionary.id "

--- a/src/test/java/greencity/repository/HabitStatisticRepoTest.java
+++ b/src/test/java/greencity/repository/HabitStatisticRepoTest.java
@@ -78,4 +78,15 @@ public class HabitStatisticRepoTest {
         assertEquals("eggs", secondByPopularityHabitTuple.get(0));
         assertEquals(8L, secondByPopularityHabitTuple.get(1));
     }
+
+    @Test
+    @Sql("file:src/test/resources/sql/habit_statistics_id_not_match_habit_id.sql")
+    public void habitStatisticIdDoesNotMatchHabitId() {
+        List<Tuple> amountOfAllHabitItems
+            = habitStatisticRepo.getStatisticsForAllHabitItemsByDate(new Date(), "en");
+        assertEquals(1, amountOfAllHabitItems.size());
+        Tuple mostPopularHabitTuple = amountOfAllHabitItems.get(0);
+        assertEquals("baz", mostPopularHabitTuple.get(0));
+        assertEquals(42L, mostPopularHabitTuple.get(1));
+    }
 }

--- a/src/test/resources/sql/habit_statistics_id_not_match_habit_id.sql
+++ b/src/test/resources/sql/habit_statistics_id_not_match_habit_id.sql
@@ -1,0 +1,32 @@
+INSERT INTO users (id,
+                   date_of_registration,
+                   email,
+                   email_notification,
+                   first_name,
+                   last_name,
+                   last_visit,
+                   role,
+                   user_status,
+                   refresh_token_key)
+VALUES (1, current_date, 'foo@bar.com', 1, 'foo', 'bar', current_date, 1, 1, 'quux');
+
+INSERT INTO languages (id, code)
+VALUES (1, 'en');
+
+INSERT INTO habit_dictionary (id, image)
+VALUES (1, 'foo');
+INSERT INTO habit_dictionary (id, image)
+VALUES (2, 'quux');
+
+INSERT INTO habit_dictionary_translation (id, name, description, habit_item, language_id, habit_dictionary_id)
+VALUES (1, 'foobar', 'bar', 'baz', 1, 1);
+INSERT INTO habit_dictionary_translation (id, name, description, habit_item, language_id, habit_dictionary_id)
+VALUES (2, 'quux', 'bar', 'eggs', 1, 2);
+
+INSERT INTO habits (id, user_id, habit_dictionary_id, status, create_date)
+VALUES (1, 1, 1, true, current_date);
+
+-- Note: habit statistic id here does not match habit id
+-- This happens when habit is tracked more than one day
+INSERT INTO habit_statistics (id, rate, date, amount_of_items, habit_id)
+VALUES (2, 'quux', current_date, 42, 1);


### PR DESCRIPTION
The problem was in JPQL query where `habit_statistics` table has been linked in according to `habit` table using primary key `id` of `habit_statistics` instead of foreign key `habit_id`, so when habit was tracked more than one day, `id` of a `habit_statistics` did not match `id` of `habit` anymore and the empty result has been returned.