### PR TITLE
Remove unused CustomGoalService constructor

### DIFF
--- a/src/main/java/greencity/service/impl/CustomGoalServiceImpl.java
+++ b/src/main/java/greencity/service/impl/CustomGoalServiceImpl.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,15 +33,6 @@ public class CustomGoalServiceImpl implements CustomGoalService {
      */
     private CustomGoalRepo customGoalRepo;
     private ModelMapper modelMapper;
-
-    /**
-     * Constructor with parameters.
-     */
-    @Autowired
-    public CustomGoalServiceImpl(ModelMapper modelMapper, CustomGoalRepo customGoalRepo) {
-        this.modelMapper = modelMapper;
-        this.customGoalRepo = customGoalRepo;
-    }
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
There is already one all-arguments constructor defined via Lombok @AllArgsConstructor at the class level, so there is no need to declare an identical constructor manually. Also, this extra constructor impacts on test coverage percentage, because one of them is never invoked during tests.