### PR TITLE
Reuse email threads in Email microservice

### DIFF
--- a/email/src/main/java/greencity/config/EmailServiceConfig.java
+++ b/email/src/main/java/greencity/config/EmailServiceConfig.java
@@ -1,0 +1,77 @@
+package greencity.config;
+
+import greencity.service.EmailService;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration for the {@link EmailService}.
+ */
+@Configuration
+public class EmailServiceConfig {
+    /**
+     * Initial amount of threads for send email thread pool.
+     * It is set to 1 to improve the first task in the queue handling performance.
+     */
+    private static final int BASE_THREADS_AMOUNT = 1;
+    /**
+     * The maximum amount of threads up to which send email thread pool will be expanded.
+     * It is set to amount of processors due to low simultaneous task submission expected
+     * but can be changed according to Brian Goetz's law when needed.
+     */
+    private static final int MAX_THREADS_AMOUNT = Runtime.getRuntime().availableProcessors();
+    /**
+     * Keep alive time for idle threads.
+     * When the amount of threads in the send email thread pool is higher than BASE_THREADS_AMOUNT
+     * idling threads will be destroyed after this amount of time.
+     */
+    private static final IdleTimeout IDLE_TIMEOUT = new IdleTimeout(10, TimeUnit.SECONDS);
+    /**
+     * The maximum amount of tasks in the send email thread pool queue.
+     * It is set to 100 due to low simultaneous task submission expected
+     * but can be changed on demand.
+     */
+    private static final int MAX_TASKS_IN_QUEUE = 100;
+
+    /**
+     * Executor that is used for sending MIME emails in separate threads.
+     *
+     * @return Executor which is a cached thread pool.
+     */
+    @Bean
+    public Executor sendEmailExecutor() {
+        return new ThreadPoolExecutor(
+            BASE_THREADS_AMOUNT,
+            MAX_THREADS_AMOUNT,
+            IDLE_TIMEOUT.getIdleTime(),
+            IDLE_TIMEOUT.getIdleTimeUnit(),
+            new ArrayBlockingQueue<>(MAX_TASKS_IN_QUEUE)
+        );
+    }
+
+    /**
+     * This class represents the amount of time needed for idle thread destruction
+     * in the send email thread pool.
+     * The main purpose of this class is to ship the amount of time with the according
+     * time unit, so the type system can help us not to misuse one of the parameters
+     * without any relation to the another one.
+     */
+    @Getter
+    @RequiredArgsConstructor
+    private static final class IdleTimeout {
+        /**
+         * Keep alive time required for thread destruction.
+         */
+        private final long idleTime;
+        /**
+         * Time unit that describes the amount of time required for thread destruction.
+         */
+        private final TimeUnit idleTimeUnit;
+    }
+}

--- a/email/src/main/java/greencity/service/impl/EmailServiceImpl.java
+++ b/email/src/main/java/greencity/service/impl/EmailServiceImpl.java
@@ -14,10 +14,12 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -33,6 +35,7 @@ import org.thymeleaf.context.Context;
 public class EmailServiceImpl implements EmailService {
     private final JavaMailSender javaMailSender;
     private final ITemplateEngine templateEngine;
+    private final Executor executor;
     private final String clientLink;
     private final String ecoNewsLink;
     private final String serverLink;
@@ -44,12 +47,14 @@ public class EmailServiceImpl implements EmailService {
     @Autowired
     public EmailServiceImpl(JavaMailSender javaMailSender,
                             ITemplateEngine templateEngine,
+                            @Qualifier("sendEmailExecutor") Executor executor,
                             @Value("${client.address}") String clientLink,
                             @Value("${econews.address}") String ecoNewsLink,
                             @Value("${address}") String serverLink,
                             @Value("${sender.email.address}") String senderEmailAddress) {
         this.javaMailSender = javaMailSender;
         this.templateEngine = templateEngine;
+        this.executor = executor;
         this.clientLink = clientLink;
         this.ecoNewsLink = ecoNewsLink;
         this.serverLink = serverLink;
@@ -175,6 +180,6 @@ public class EmailServiceImpl implements EmailService {
         } catch (MessagingException e) {
             log.error(e.getMessage());
         }
-        new Thread(() -> javaMailSender.send(mimeMessage)).start();
+        executor.execute(() -> javaMailSender.send(mimeMessage));
     }
 }

--- a/email/src/test/java/greencity/service/impl/EmailServiceImplTest.java
+++ b/email/src/test/java/greencity/service/impl/EmailServiceImplTest.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executors;
 import javax.mail.Session;
 import javax.mail.internet.MimeMessage;
 import org.junit.Before;
@@ -32,7 +33,7 @@ public class EmailServiceImplTest {
     @Before
     public void setup() {
         initMocks(this);
-        service = new EmailServiceImpl(javaMailSender, templateEngine,
+        service = new EmailServiceImpl(javaMailSender, templateEngine, Executors.newCachedThreadPool(),
             "http://localhost:4200", "http://localhost:4200", "http://localhost:8080",
             "test@email.com");
         placeAuthorDto = PlaceAuthorDto.builder()


### PR DESCRIPTION
Starting a new thread for each incoming email is quite an expensive
operation so thread pool can be used here for thread reusing for
the purpose of performance improvement. Since we do not require any
response from the email sending operation Executor interface is used.