### PR TITLE
[Bug-Fix]:[#648] Fix incorrect error message when user trying sign in with unregistered email

### DIFF
--- a/core/src/main/java/greencity/constant/ErrorMessage.java
+++ b/core/src/main/java/greencity/constant/ErrorMessage.java
@@ -27,7 +27,8 @@ public final class ErrorMessage {
     public static final String NO_ANY_OWN_SECURITY_TO_DELETE = "No any ownSecurity to delete with this id: ";
     public static final String LOCATION_ALREADY_EXISTS_BY_THIS_COORDINATES =
         "Location by this coordinates already exists.";
-    public static final String BAD_EMAIL_OR_PASSWORD = "Bad email or password";
+    public static final String BAD_EMAIL = "Bad email";
+    public static final String BAD_PASSWORD = "Bad password";
     public static final String USER_NOT_VERIFIED = "User not verified";
     public static final String EMAIL_TOKEN_EXPIRED = "User late with verify. Token is invalid.";
     public static final String REFRESH_TOKEN_NOT_VALID = "Refresh token not valid!";

--- a/core/src/main/java/greencity/exception/exceptions/WrongPasswordException.java
+++ b/core/src/main/java/greencity/exception/exceptions/WrongPasswordException.java
@@ -1,0 +1,13 @@
+package greencity.exception.exceptions;
+
+/**
+ * Exception that user password is wrong.
+ */
+public class WrongPasswordException extends RuntimeException {
+    /**
+     * Constructor.
+     */
+    public WrongPasswordException(String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/greencity/security/service/impl/OwnSecurityServiceImpl.java
+++ b/core/src/main/java/greencity/security/service/impl/OwnSecurityServiceImpl.java
@@ -1,7 +1,5 @@
 package greencity.security.service.impl;
 
-import static greencity.constant.ErrorMessage.*;
-import static greencity.constant.RabbitConstants.VERIFY_EMAIL_ROUTING_KEY;
 import greencity.entity.OwnSecurity;
 import greencity.entity.User;
 import greencity.entity.VerifyEmail;
@@ -31,6 +29,9 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static greencity.constant.ErrorMessage.*;
+import static greencity.constant.RabbitConstants.VERIFY_EMAIL_ROUTING_KEY;
 
 /**
  * {@inheritDoc}
@@ -131,8 +132,11 @@ public class OwnSecurityServiceImpl implements OwnSecurityService {
     @Override
     public SuccessSignInDto signIn(final OwnSignInDto dto) {
         User user = userService.findByEmail(dto.getEmail());
+        if (user == null) {
+            throw new WrongEmailException(USER_NOT_FOUND_BY_EMAIL);
+        }
         if (!isPasswordCorrect(dto, user)) {
-            throw new WrongEmailOrPasswordException(BAD_EMAIL_OR_PASSWORD);
+            throw new WrongPasswordException(BAD_PASSWORD);
         }
         if (user.getVerifyEmail() != null) {
             throw new EmailNotVerified("You should verify the email first, check your email box!");


### PR DESCRIPTION
Fix incorrect error message when user trying sign in with unregistered email.

1. Divided logic a little, at first I check whether there is such user, and then already his password.
2. Added new **WrongPasswordException**.
3. Refactored **ErrorMessage**.