### PR TITLE
[GreenCity] fix admin email

### DIFF
--- a/dao/src/main/resources/db/changelog/logs/ch-insert-into-users-Korzh.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-insert-into-users-Korzh.xml
@@ -5,7 +5,7 @@
     <changeSet id="Korzh-5" author="Nikita Korzh">
         <insert tableName="users">
             <column name = "date_of_registration" value="1970-01-01 00:00:00.000000"/>
-            <column name="email" value="green.city.ubs@gmail.coml"/>
+            <column name="email" value="green.city.ubs@gmail.com"/>
             <column name="email_notification" value="0"/>
             <column name="name" value="UBS"/>
             <column name="role" value="ROLE_UBS_EMPLOYEE"/>


### PR DESCRIPTION
## Link to issue

https://github.com/ita-social-projects/GreenCity/issues/5336

## Summary of change

The admin's email corrected to green.city.ubs@gmail.com in changelog.

## Testing approach

Checked data in the users table.