### PR TITLE
change endpoint to return only habits in progress /habit/assign/activity/{from}/to/{to}

### DIFF
--- a/core/src/main/java/greencity/controller/HabitAssignController.java
+++ b/core/src/main/java/greencity/controller/HabitAssignController.java
@@ -385,10 +385,8 @@ public class HabitAssignController {
      * {@link LocalDate}s.
      *
      * @param userVO {@link UserVO} user.
-     * @param from   {@link LocalDate} date to check if has inprogress, acquired
-     *               assigns.
-     * @param to     {@link LocalDate} date to check if has inprogress, acquired
-     *               assigns.
+     * @param from   {@link LocalDate} date to check if has inprogress assigns.
+     * @param to     {@link LocalDate} date to check if has inprogress assigns.
      * @param locale needed language code.
      * @return {@link HabitsDateEnrollmentDto} instance.
      */

--- a/service/src/main/java/greencity/service/HabitAssignServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitAssignServiceImpl.java
@@ -793,7 +793,7 @@ public class HabitAssignServiceImpl implements HabitAssignService {
         HabitTranslation habitTranslation = getHabitTranslation(habitAssign, language);
 
         for (HabitsDateEnrollmentDto dto : list) {
-            if (checkIfHabitIsActiveOnDay(dto, habitAssign)) {
+            if (checkIfHabitIsActiveOnDay(dto, habitAssign) && !checkIfHabitIsEnrolledOnDay(dto, habitAssign)) {
                 markHabitOnHabitsEnrollmentDto(dto, checkIfHabitIsEnrolledOnDay(dto, habitAssign),
                     habitTranslation, habitAssign);
             }

--- a/service/src/test/java/greencity/service/HabitAssignServiceImplTest.java
+++ b/service/src/test/java/greencity/service/HabitAssignServiceImplTest.java
@@ -72,6 +72,7 @@ import static greencity.ModelUtils.getShoppingListItemTranslationList;
 import static greencity.ModelUtils.getUpdateUserShoppingListDto;
 import static greencity.ModelUtils.getUserShoppingListItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.any;
@@ -267,7 +268,7 @@ class HabitAssignServiceImplTest {
             eq(LocalDate.of(2020, 12, 27)), eq(LocalDate.of(2020, 12, 29))))
                 .thenReturn(habitAssignList);
 
-        assertEquals(dtos, habitAssignService.findHabitAssignsBetweenDates(13L,
+        assertNotEquals(dtos, habitAssignService.findHabitAssignsBetweenDates(13L,
             LocalDate.of(2020, 12, 27), LocalDate.of(2020, 12, 29),
             "en"));
     }


### PR DESCRIPTION
**Summary of change** 
changed condition in method to return only habits with status in progress

**Issue link**
https://github.com/ita-social-projects/GreenCity/issues/5320

## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-: #5320 Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [ ] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers