### PR TITLE
User don't see amount of users that acquired habit #5424

### DIFF
--- a/service/src/main/java/greencity/service/HabitAssignServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitAssignServiceImpl.java
@@ -440,6 +440,7 @@ public class HabitAssignServiceImpl implements HabitAssignService {
         changeStatuses(ShoppingListItemStatus.DONE.toString(),
             habitAssign.getId(), shoppingListItems);
         habit.setShoppingListItems(shoppingListItems);
+        habit.setAmountAcquiredUsers(habitAssignRepo.findAmountOfUsersAcquired(habit.getId()));
         return habit;
     }
 

--- a/service/src/test/java/greencity/service/HabitAssignServiceImplTest.java
+++ b/service/src/test/java/greencity/service/HabitAssignServiceImplTest.java
@@ -62,10 +62,28 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static greencity.ModelUtils.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static greencity.ModelUtils.HABIT_ASSIGN_IN_PROGRESS;
+import static greencity.ModelUtils.getFullHabitAssign;
+import static greencity.ModelUtils.getFullHabitAssignDto;
+import static greencity.ModelUtils.getHabitDto;
+import static greencity.ModelUtils.getHabitAssign;
+import static greencity.ModelUtils.getHabitAssignPropertiesDto;
+import static greencity.ModelUtils.getHabitAssignUserShoppingListItemDto;
+import static greencity.ModelUtils.getShoppingListItem;
+import static greencity.ModelUtils.getShoppingListItemTranslationList;
+import static greencity.ModelUtils.getUpdateUserShoppingListDto;
+import static greencity.ModelUtils.getUserShoppingListItem;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class HabitAssignServiceImplTest {

--- a/service/src/test/java/greencity/service/HabitAssignServiceImplTest.java
+++ b/service/src/test/java/greencity/service/HabitAssignServiceImplTest.java
@@ -62,28 +62,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static greencity.ModelUtils.HABIT_ASSIGN_IN_PROGRESS;
-import static greencity.ModelUtils.getFullHabitAssign;
-import static greencity.ModelUtils.getHabitAssign;
-import static greencity.ModelUtils.getHabitAssignPropertiesDto;
-import static greencity.ModelUtils.getHabitAssignUserShoppingListItemDto;
-import static greencity.ModelUtils.getShoppingListItem;
-import static greencity.ModelUtils.getShoppingListItemTranslationList;
-import static greencity.ModelUtils.getUpdateUserShoppingListDto;
-import static greencity.ModelUtils.getUserShoppingListItem;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static greencity.ModelUtils.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class HabitAssignServiceImplTest {
@@ -784,6 +766,24 @@ class HabitAssignServiceImplTest {
         assertEquals(ErrorMessage.HABIT_ASSIGN_NOT_FOUND_WITH_CURRENT_USER_ID_AND_HABIT_ID
             + habitId,
             exception.getMessage());
+    }
+
+    @Test
+    void findHabitByUserIdAndHabitIdTest() {
+        Long userId = 1L;
+        Long habitId = 1L;
+        HabitAssign habitAssign = getFullHabitAssign();
+        when(habitAssignRepo.findByHabitIdAndUserId(habitId, userId)).thenReturn(Optional.of(habitAssign));
+        when(modelMapper.map(habitAssign, HabitAssignDto.class)).thenReturn(getFullHabitAssignDto());
+        when(modelMapper.map(any(HabitTranslation.class), eq(HabitDto.class))).thenReturn(getHabitDto());
+        when(shoppingListItemTranslationRepo.findShoppingListByHabitIdAndByLanguageCode(language, habitId))
+            .thenReturn(getShoppingListItemTranslationList());
+        when(habitAssignRepo.findAmountOfUsersAcquired(habitId)).thenReturn(5L);
+        HabitDto actual = habitAssignService.findHabitByUserIdAndHabitId(userId, habitId, language);
+        assertNotNull(actual.getAmountAcquiredUsers());
+        verify(habitAssignRepo, times(1)).findByHabitIdAndUserId(habitId, userId);
+        verify(shoppingListItemTranslationRepo, times(1)).findShoppingListByHabitIdAndByLanguageCode(language, habitId);
+        verify(habitAssignRepo, times(1)).findAmountOfUsersAcquired(habitId);
     }
 
     @Test


### PR DESCRIPTION
# GreenCity PR
_&lt;User don't see amount of users that acquired habit #5424&gt;_

## Summary Of Changes :fire:
_&lt;Added amount of users that acquired habit in response dto for GET /habit/assign/{habitId}/more&gt;_

## Issue Link :clipboard:
_&lt;[Link to the issue](https://github.com/ita-social-projects/GreenCity/issues/5424)&gt;_

## Added
* _&lt;Setting up amount of users that acquired habit in method findHabitByUserIdAndHabitId&gt;_
* _&lt;Related test&gt;_

## How to test :clipboard:
_&lt;Go to https://greencity.testgreencity.ga/swagger-ui.html#/gt;_
_&ltClick on habit-assign-controllergt;_
_&ltClick on GET /habit/assign/{habitId}/more&gt;_

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
