### PR TITLE
changed endpoint post "habit/custom"

### DIFF
--- a/core/src/main/resources/messages.properties
+++ b/core/src/main/resources/messages.properties
@@ -35,6 +35,8 @@ greenCity.validation.bad.discountValues=Length of discount values list can not b
 greenCity.validation.bad.comma.separated.numbers=Non-empty string can contain numbers separated by a comma only
 greenCity.validation.user.created=User was created. Verification letter has been sent to your email address
 greenCity.validation.empty.tags=At least one tag
+greenCity.validation.min.tags=Length of tag list can not be less than {min}
+greenCity.validation.max.tags=Length of tag list can not be more than {max}
 /*headerforall*/
 greenCity.current.language=En
 /*forallpages*/

--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -745,7 +745,7 @@ public class ModelUtils {
                     .name("use shopper")
                     .build()))
             .image("https://csb10032000a548f571.blob.core.windows.net/allfiles/photo_2021-06-01_15-39-56.jpg")
-            .tags(Set.of("Reusable"))
+            .tagIds(Set.of(20L))
             .build();
     }
 

--- a/dao/src/main/java/greencity/repository/HabitTranslationRepo.java
+++ b/dao/src/main/java/greencity/repository/HabitTranslationRepo.java
@@ -81,4 +81,13 @@ public interface HabitTranslationRepo extends JpaRepository<HabitTranslation, Lo
         + "INNER JOIN languages AS l ON l.id = ht.language_id "
         + "WHERE lower(t.name) IN (:tags) AND l.code = :languageCode")
     Page<HabitTranslation> findAllByTagsAndLanguageCode(Pageable pageable, List<String> tags, String languageCode);
+
+    /**
+     * Method return {@link List} of {@link HabitTranslation} by habit.
+     *
+     * @param habit {@link Habit}.
+     * @return {@link List} of {@link HabitTranslation}.
+     * @author Lilia Mokhnatska
+     */
+    List<HabitTranslation> findAllByHabit(Habit habit);
 }

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -148,5 +148,6 @@
     <include file="db/changelog/logs/сh-add-new-column-habit-assign-Mokhnatska.xml"/>
     <include file="db/changelog/logs/ch-update-fact-of-the-day-translations-Vatuliak.xml"/>
     <include file="db/changelog/logs/ch-update-habit-translation-Vatuliak.xml"/>
+    <include file="db/changelog/logs/ch-update-habit-translations-Mokhnatska.xml"/>
 </databaseChangeLog>
 

--- a/dao/src/main/resources/db/changelog/logs/ch-update-habit-translations-Mokhnatska.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-update-habit-translations-Mokhnatska.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet id="Mokhnatska-7" author="Lilia Mokhnatska">
+        <modifyDataType tableName="habit_translation" columnName="description" newDataType="text"/>
+    </changeSet>
+</databaseChangeLog>

--- a/service-api/src/main/java/greencity/constant/ServiceValidationConstants.java
+++ b/service-api/src/main/java/greencity/constant/ServiceValidationConstants.java
@@ -47,6 +47,8 @@ public final class ServiceValidationConstants {
     public static final String RATE_MIN_VALUE = "{greenCity.validation.min.rate}";
     public static final String RATE_MAX_VALUE = "{greenCity.validation.max.rate}";
     public static final String HABIT_COMPLEXITY = "{greenCity.validation.habit.complexity}";
+    public static final String TAG_LIST_MIN_LENGTH = "{greenCity.validation.min.tags}";
+    public static final String TAG_LIST_MAX_LENGTH = "{greenCity.validation.max.tags}";
 
     private ServiceValidationConstants() {
     }

--- a/service-api/src/main/java/greencity/dto/habit/AddCustomHabitDtoRequest.java
+++ b/service-api/src/main/java/greencity/dto/habit/AddCustomHabitDtoRequest.java
@@ -3,11 +3,18 @@ package greencity.dto.habit;
 import greencity.constant.ServiceValidationConstants;
 import greencity.dto.habittranslation.HabitTranslationDto;
 import greencity.dto.shoppinglistitem.CustomShoppingListItemResponseDto;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.util.List;
 import java.util.Set;
 
@@ -26,5 +33,8 @@ public class AddCustomHabitDtoRequest {
     private List<HabitTranslationDto> habitTranslations;
     private String image;
     private List<CustomShoppingListItemResponseDto> customShoppingListItemDto;
-    private Set<String> tags;
+    @Valid
+    @Size(min = 1, message = ServiceValidationConstants.TAG_LIST_MIN_LENGTH)
+    @Size(max = 3, message = ServiceValidationConstants.TAG_LIST_MAX_LENGTH)
+    private Set<Long> tagIds;
 }

--- a/service-api/src/main/java/greencity/dto/habit/AddCustomHabitDtoResponse.java
+++ b/service-api/src/main/java/greencity/dto/habit/AddCustomHabitDtoResponse.java
@@ -10,9 +10,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.util.List;
 import java.util.Set;
 
@@ -33,5 +35,8 @@ public class AddCustomHabitDtoResponse {
     private Integer defaultDuration;
     private List<CustomShoppingListItemResponseDto> customShoppingListItemDto;
     private List<HabitTranslationDto> habitTranslations;
-    private Set<String> tags;
+    @Valid
+    @Size(min = 1, message = ServiceValidationConstants.TAG_LIST_MIN_LENGTH)
+    @Size(max = 3, message = ServiceValidationConstants.TAG_LIST_MAX_LENGTH)
+    private Set<Long> tagIds;
 }

--- a/service-api/src/test/java/greencity/ModelUtils.java
+++ b/service-api/src/test/java/greencity/ModelUtils.java
@@ -189,7 +189,7 @@ public class ModelUtils {
             .complexity(1)
             .image("")
             .defaultDuration(14)
-            .tags(Set.of(""))
+            .tagIds(Set.of(20L))
             .build();
     }
 
@@ -199,7 +199,7 @@ public class ModelUtils {
             .complexity(1)
             .image("")
             .defaultDuration(14)
-            .tags(Set.of(""))
+            .tagIds(Set.of(20L))
             .build();
     }
 }

--- a/service-api/src/test/java/greencity/dto/habit/AddCustomHabitDtoRequestTest.java
+++ b/service-api/src/test/java/greencity/dto/habit/AddCustomHabitDtoRequestTest.java
@@ -82,4 +82,67 @@ class AddCustomHabitDtoRequestTest {
             Arguments.of(-1),
             Arguments.of(0));
     }
+
+    @Test
+    void invalidNumberOfTagsIdNullInAddCustomHabitDtoRequestTest() {
+        var dto = AddCustomHabitDtoRequest.builder()
+            .tagIds(null)
+            .build();
+
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        final Validator validator = factory.getValidator();
+
+        Set<ConstraintViolation<AddCustomHabitDtoRequest>> constraintViolations =
+            validator.validate(dto);
+
+        assertEquals(1, constraintViolations.size());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("provideFieldsAndValidValuesForTagsIds")
+    void validNumberOfTagsIdsInAddCustomHabitDtoRequestTest(Set<Long> tagIds) {
+        var dto = AddCustomHabitDtoRequest.builder()
+            .tagIds(tagIds)
+            .build();
+
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        final Validator validator = factory.getValidator();
+
+        Set<ConstraintViolation<AddCustomHabitDtoRequest>> constraintViolations =
+            validator.validate(dto);
+
+        assertEquals(1, constraintViolations.size());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("provideFieldsAndInvalidValuesForTagsIds")
+    void invalidNumberOfTagsIdsInAddCustomHabitDtoRequestTest(Set<Long> tagIds) {
+        var dto = AddCustomHabitDtoRequest.builder()
+            .tagIds(tagIds)
+            .build();
+
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        final Validator validator = factory.getValidator();
+
+        Set<ConstraintViolation<AddCustomHabitDtoRequest>> constraintViolations =
+            validator.validate(dto);
+
+        assertEquals(2, constraintViolations.size());
+    }
+
+    private static Stream<Arguments> provideFieldsAndValidValuesForTagsIds() {
+        return Stream.of(
+            Arguments.of(Set.of(1L)),
+            Arguments.of(Set.of(1L, 2L, 3L)),
+            Arguments.of(Set.of(1L, 2L)));
+    }
+
+    private static Stream<Arguments> provideFieldsAndInvalidValuesForTagsIds() {
+        return Stream.of(
+            Arguments.of(Set.of(1L, 2L, 3L, 4L)),
+            Arguments.of(Set.of()),
+            Arguments.of(Set.of(1L, 2L, 3L, 4L, 5L, 6L)));
+    }
 }

--- a/service-api/src/test/java/greencity/dto/habit/AddCustomHabitDtoResponseTest.java
+++ b/service-api/src/test/java/greencity/dto/habit/AddCustomHabitDtoResponseTest.java
@@ -82,4 +82,52 @@ class AddCustomHabitDtoResponseTest {
             Arguments.of(-1),
             Arguments.of(0));
     }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("provideFieldsAndValidValuesForTagsIds")
+    void validNumberOfTagsIdsInAddCustomHabitDtoResponseTest(Set<Long> tagIds) {
+        var dto = AddCustomHabitDtoResponse.builder()
+            .tagIds(tagIds)
+            .build();
+
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        final Validator validator = factory.getValidator();
+
+        Set<ConstraintViolation<AddCustomHabitDtoResponse>> constraintViolations =
+            validator.validate(dto);
+
+        assertEquals(1, constraintViolations.size());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("provideFieldsAndInvalidValuesForTagsIds")
+    void invalidNumberOfTagsIdsInAddCustomHabitDtoResponseTest(Set<Long> tagIds) {
+        var dto = AddCustomHabitDtoResponse.builder()
+            .tagIds(tagIds)
+            .build();
+
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        final Validator validator = factory.getValidator();
+
+        Set<ConstraintViolation<AddCustomHabitDtoResponse>> constraintViolations =
+            validator.validate(dto);
+
+        assertEquals(2, constraintViolations.size());
+    }
+
+    private static Stream<Arguments> provideFieldsAndValidValuesForTagsIds() {
+        return Stream.of(
+            Arguments.of(Set.of(1L)),
+            Arguments.of(Set.of(1L, 2L, 3L)),
+            Arguments.of(Set.of(1L, 2L)));
+    }
+
+    private static Stream<Arguments> provideFieldsAndInvalidValuesForTagsIds() {
+        return Stream.of(
+            Arguments.of(Set.of(1L, 2L, 3L, 4L)),
+            Arguments.of(Set.of()),
+            Arguments.of(Set.of(1L, 2L, 3L, 4L, 5L, 6L)));
+    }
 }

--- a/service/src/main/java/greencity/mapping/CustomShoppingListResponseDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/CustomShoppingListResponseDtoMapper.java
@@ -1,0 +1,35 @@
+package greencity.mapping;
+
+import greencity.dto.shoppinglistitem.CustomShoppingListItemResponseDto;
+import greencity.entity.CustomShoppingListItem;
+import org.modelmapper.AbstractConverter;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class CustomShoppingListResponseDtoMapper
+    extends AbstractConverter<CustomShoppingListItem, CustomShoppingListItemResponseDto> {
+    @Override
+    protected CustomShoppingListItemResponseDto convert(CustomShoppingListItem customShoppingListItem) {
+        return CustomShoppingListItemResponseDto.builder()
+            .id(customShoppingListItem.getId())
+            .text(customShoppingListItem.getText())
+            .status(customShoppingListItem.getStatus())
+            .build();
+    }
+
+    /**
+     * Method that build {@link List} of {@link CustomShoppingListItemResponseDto}
+     * from {@link List} of {@link CustomShoppingListItemResponseDto}.
+     *
+     * @param itemList {@link List} of {@link CustomShoppingListItemResponseDto}
+     * @return {@link List} of {@link CustomShoppingListItemResponseDto}
+     * @author Lilia Mokhnatska
+     */
+    public List<CustomShoppingListItemResponseDto> mapAllToList(
+        List<CustomShoppingListItem> itemList) {
+        return itemList.stream().map(this::convert).collect(Collectors.toList());
+    }
+}

--- a/service/src/main/java/greencity/mapping/HabitTranslationDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/HabitTranslationDtoMapper.java
@@ -1,0 +1,34 @@
+package greencity.mapping;
+
+import greencity.dto.habittranslation.HabitTranslationDto;
+import greencity.entity.HabitTranslation;
+import org.modelmapper.AbstractConverter;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class HabitTranslationDtoMapper extends AbstractConverter<HabitTranslation, HabitTranslationDto> {
+    @Override
+    protected HabitTranslationDto convert(HabitTranslation habitTranslation) {
+        return HabitTranslationDto.builder()
+            .description(habitTranslation.getDescription())
+            .habitItem(habitTranslation.getHabitItem())
+            .name(habitTranslation.getName())
+            .languageCode(habitTranslation.getLanguage().getCode())
+            .build();
+    }
+
+    /**
+     * Method that build {@link List} of {@link HabitTranslationDto} from
+     * {@link List} of {@link HabitTranslation}.
+     *
+     * @param habitTranslationList {@link List} of {@link HabitTranslation}
+     * @return {@link List} of {@link HabitTranslationDto}
+     * @author Lilia Mokhnatska
+     */
+    public List<HabitTranslationDto> mapAllToList(List<HabitTranslation> habitTranslationList) {
+        return habitTranslationList.stream().map(this::convert).collect(Collectors.toList());
+    }
+}

--- a/service/src/main/java/greencity/service/HabitServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitServiceImpl.java
@@ -5,7 +5,6 @@ import greencity.dto.PageableDto;
 import greencity.dto.habit.AddCustomHabitDtoRequest;
 import greencity.dto.habit.AddCustomHabitDtoResponse;
 import greencity.dto.habit.HabitDto;
-import greencity.dto.habittranslation.HabitTranslationDto;
 import greencity.dto.shoppinglistitem.ShoppingListItemDto;
 import greencity.entity.CustomShoppingListItem;
 import greencity.entity.Habit;

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -2464,7 +2464,17 @@ public class ModelUtils {
         return HabitTranslationDto.builder()
             .description(HABIT_TRANSLATION_DESCRIPTION)
             .habitItem(HABIT_ITEM)
-            .name("використовувати бавовняну сумку")
+            .name(HABIT_TRANSLATION_NAME)
+            .build();
+    }
+
+    public static HabitTranslation getHabitTranslationForServiceTest() {
+        return HabitTranslation.builder()
+            .id(1L)
+            .description(HABIT_TRANSLATION_DESCRIPTION)
+            .habitItem(HABIT_ITEM)
+            .name(HABIT_TRANSLATION_NAME)
+            .habit(getCustomHabitForServiceTest())
             .build();
     }
 
@@ -2486,7 +2496,7 @@ public class ModelUtils {
                     .name(HABIT_TRANSLATION_NAME)
                     .build()))
             .image(IMAGE_LINK)
-            .tags(Set.of(TAG_TRANSLATION_NAME))
+            .tagIds(Set.of(20L))
             .build();
     }
 
@@ -2507,15 +2517,40 @@ public class ModelUtils {
                     .habitItem(HABIT_ITEM)
                     .languageCode("ua")
                     .name(HABIT_TRANSLATION_NAME)
-                    .build()))
+                    .build(),
+
+                    HabitTranslationDto.builder()
+                        .description(HABIT_TRANSLATION_DESCRIPTION)
+                        .habitItem(HABIT_ITEM)
+                        .languageCode("en")
+                        .name(HABIT_TRANSLATION_NAME)
+                        .build()))
             .image(IMAGE_LINK)
-            .tags(Set.of(TAG_TRANSLATION_NAME))
+            .tagIds(Set.of(20L))
+            .build();
+    }
+
+    public static CustomShoppingListItemResponseDto getCustomShoppingListItemResponseDtoForServiceTest() {
+        return CustomShoppingListItemResponseDto.builder()
+            .id(1L)
+            .status(ShoppingListItemStatus.ACTIVE)
+            .text(SHOPPING_LIST_TEXT)
+            .build();
+    }
+
+    public static CustomShoppingListItem getCustomShoppingListItemForServiceTest() {
+        return CustomShoppingListItem.builder()
+            .id(1L)
+            .habit(getCustomHabitForServiceTest())
+            .status(ShoppingListItemStatus.ACTIVE)
+            .text(SHOPPING_LIST_TEXT)
+            .user(getUser())
             .build();
     }
 
     public static Tag getTagHabitForServiceTest() {
         return Tag.builder().id(1L).type(TagType.HABIT)
-            .tagTranslations(List.of(TagTranslation.builder().id(2L).name("News")
+            .tagTranslations(List.of(TagTranslation.builder().id(20L).name("Reusable")
                 .language(Language.builder().id(1L).code("en").build()).build()))
             .build();
     }

--- a/service/src/test/java/greencity/mapping/CustomShoppingListResponseDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/CustomShoppingListResponseDtoMapperTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
-public class CustomShoppingListResponseDtoMapperTest {
+class CustomShoppingListResponseDtoMapperTest {
 
     @InjectMocks
     private CustomShoppingListResponseDtoMapper customShoppingListResponseDtoMapper;

--- a/service/src/test/java/greencity/mapping/CustomShoppingListResponseDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/CustomShoppingListResponseDtoMapperTest.java
@@ -1,0 +1,50 @@
+package greencity.mapping;
+
+import greencity.ModelUtils;
+import greencity.dto.shoppinglistitem.CustomShoppingListItemResponseDto;
+import greencity.entity.CustomShoppingListItem;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class CustomShoppingListResponseDtoMapperTest {
+
+    @InjectMocks
+    private CustomShoppingListResponseDtoMapper customShoppingListResponseDtoMapper;
+
+    @Test
+    void convertTest() {
+        CustomShoppingListItem customShoppingListItem =
+            ModelUtils.getCustomShoppingListItem();
+
+        CustomShoppingListItemResponseDto expected = CustomShoppingListItemResponseDto.builder()
+            .id(customShoppingListItem.getId())
+            .status(customShoppingListItem.getStatus())
+            .text(customShoppingListItem.getText())
+            .build();
+        assertEquals(expected, customShoppingListResponseDtoMapper.convert(customShoppingListItem));
+    }
+
+    @Test
+    void mapAllToListTest() {
+        CustomShoppingListItem customShoppingListItem =
+            ModelUtils.getCustomShoppingListItem();
+
+        List<CustomShoppingListItem> customShoppingListItemList =
+            List.of(customShoppingListItem);
+
+        CustomShoppingListItemResponseDto expected = CustomShoppingListItemResponseDto.builder()
+            .id(customShoppingListItem.getId())
+            .status(customShoppingListItem.getStatus())
+            .text(customShoppingListItem.getText())
+            .build();
+        List<CustomShoppingListItemResponseDto> expectedList = List.of(expected);
+        assertEquals(expectedList, customShoppingListResponseDtoMapper.mapAllToList(customShoppingListItemList));
+    }
+}

--- a/service/src/test/java/greencity/mapping/HabitTranslationDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/HabitTranslationDtoMapperTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
-public class HabitTranslationDtoMapperTest {
+class HabitTranslationDtoMapperTest {
     @InjectMocks
     private HabitTranslationDtoMapper habitTranslationDtoMapper;
 

--- a/service/src/test/java/greencity/mapping/HabitTranslationDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/HabitTranslationDtoMapperTest.java
@@ -1,0 +1,50 @@
+package greencity.mapping;
+
+import greencity.ModelUtils;
+import greencity.dto.habittranslation.HabitTranslationDto;
+import greencity.entity.HabitTranslation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class HabitTranslationDtoMapperTest {
+    @InjectMocks
+    private HabitTranslationDtoMapper habitTranslationDtoMapper;
+
+    @Test
+    void convertTest() {
+        HabitTranslation habitTranslation = ModelUtils.getHabitTranslationForServiceTest();
+        habitTranslation.setLanguage(ModelUtils.getLanguage());
+
+        HabitTranslationDto expected = HabitTranslationDto.builder()
+            .description(habitTranslation.getDescription())
+            .habitItem(habitTranslation.getHabitItem())
+            .name(habitTranslation.getName())
+            .languageCode("en")
+            .build();
+        assertEquals(expected, habitTranslationDtoMapper.convert(habitTranslation));
+    }
+
+    @Test
+    void mapAllToListTest() {
+        HabitTranslation habitTranslation = ModelUtils.getHabitTranslationForServiceTest();
+        habitTranslation.setLanguage(ModelUtils.getLanguage());
+
+        List<HabitTranslation> habitTranslationList = List.of(habitTranslation);
+
+        HabitTranslationDto expected = HabitTranslationDto.builder()
+            .description(habitTranslation.getDescription())
+            .habitItem(habitTranslation.getHabitItem())
+            .name(habitTranslation.getName())
+            .languageCode("en")
+            .build();
+        List<HabitTranslationDto> expectedList = List.of(expected);
+        assertEquals(expectedList, habitTranslationDtoMapper.mapAllToList(habitTranslationList));
+    }
+}


### PR DESCRIPTION




## Summary Of Issue :
A custom habit is saved only for the language for which it was created.  Need to write the same text  for English and Ukrainian languages in habit translation.

Need to add opotunity create 1, 2 or 3 tags for one custom habit.

Need to change number of charecters to 63206 for field description in habit-translation. 

**Issue Link**
https://github.com/ita-social-projects/GreenCity/issues/5616
https://github.com/ita-social-projects/GreenCity/issues/5633
https://github.com/ita-social-projects/GreenCity/issues/5652


## Summary Of Changes :
1)changed AddCustomHabitDtoRequest and AddCustomHabitDtoResponse
2)created CustomShoppingListResponseDtoMapper
3)created HabitTranslationDtoMapper
4) changed method in HabitServiceImpl
5) changed type of field description in habit-translation table changed and added new tests 




## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [ ] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers