### PR TITLE
in endpoint get "habit/{id}" added field isCustomHabit and if isCustomHabit=true than return  customShoppingListItems

### DIFF
--- a/service-api/src/main/java/greencity/dto/habit/HabitDto.java
+++ b/service-api/src/main/java/greencity/dto/habit/HabitDto.java
@@ -2,6 +2,7 @@ package greencity.dto.habit;
 
 import greencity.constant.ServiceValidationConstants;
 import greencity.dto.habittranslation.HabitTranslationDto;
+import greencity.dto.shoppinglistitem.CustomShoppingListItemResponseDto;
 import greencity.dto.shoppinglistitem.ShoppingListItemDto;
 import java.util.List;
 import javax.validation.constraints.Max;
@@ -31,5 +32,7 @@ public class HabitDto {
     private Integer complexity;
     private List<String> tags;
     private List<ShoppingListItemDto> shoppingListItems;
+    private List<CustomShoppingListItemResponseDto> customShoppingListItems;
+    private Boolean isCustomHabit;
     private HabitAssignStatus habitAssignStatus;
 }

--- a/service/src/main/java/greencity/service/HabitServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitServiceImpl.java
@@ -82,7 +82,7 @@ public class HabitServiceImpl implements HabitService {
             .forEach(x -> shoppingListItems.add(modelMapper.map(x, ShoppingListItemDto.class)));
         habitDto.setShoppingListItems(shoppingListItems);
         habitDto.setAmountAcquiredUsers(habitAssignRepo.findAmountOfUsersAcquired(habitDto.getId()));
-        Boolean isCustomHabit = habit.getIsCustomHabit();
+        boolean isCustomHabit = habit.getIsCustomHabit();
         habitDto.setIsCustomHabit(isCustomHabit);
         if (isCustomHabit) {
             habitDto.setCustomShoppingListItems(

--- a/service/src/main/java/greencity/service/HabitServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitServiceImpl.java
@@ -82,6 +82,12 @@ public class HabitServiceImpl implements HabitService {
             .forEach(x -> shoppingListItems.add(modelMapper.map(x, ShoppingListItemDto.class)));
         habitDto.setShoppingListItems(shoppingListItems);
         habitDto.setAmountAcquiredUsers(habitAssignRepo.findAmountOfUsersAcquired(habitDto.getId()));
+        Boolean isCustomHabit = habit.getIsCustomHabit();
+        habitDto.setIsCustomHabit(isCustomHabit);
+        if (isCustomHabit) {
+            habitDto.setCustomShoppingListItems(
+                customShoppingListResponseDtoMapper.mapAllToList(habit.getCustomShoppingListItems()));
+        }
         return habitDto;
     }
 

--- a/service/src/test/java/greencity/service/HabitServiceImplTest.java
+++ b/service/src/test/java/greencity/service/HabitServiceImplTest.java
@@ -106,9 +106,11 @@ class HabitServiceImplTest {
     private CustomShoppingListItemRepo customShoppingListItemRepo;
 
     @Test()
-    void getByIdAndLanguageCode() {
+    void getByIdAndLanguageCodeIsCustomHabitFalse() {
         Habit habit = ModelUtils.getHabit();
+        habit.setIsCustomHabit(false);
         HabitDto habitDto = ModelUtils.getHabitDto();
+        habitDto.setIsCustomHabit(false);
         HabitTranslation habitTranslation = ModelUtils.getHabitTranslation();
         when(habitRepo.findById(1L)).thenReturn(Optional.of(habit));
         when(habitTranslationRepo.findByHabitAndLanguageCode(habit, "en"))
@@ -116,6 +118,32 @@ class HabitServiceImplTest {
         when(modelMapper.map(habitTranslation, HabitDto.class)).thenReturn(habitDto);
         when(habitAssignRepo.findAmountOfUsersAcquired(anyLong())).thenReturn(5L);
         assertEquals(habitDto, habitService.getByIdAndLanguageCode(1L, "en"));
+        verify(habitRepo).findById(1L);
+        verify(habitTranslationRepo).findByHabitAndLanguageCode(habit, "en");
+        verify(modelMapper).map(habitTranslation, HabitDto.class);
+        verify(habitAssignRepo).findAmountOfUsersAcquired(anyLong());
+
+    }
+
+    @Test()
+    void getByIdAndLanguageCodeIsCustomHabitTrue() {
+        Habit habit = ModelUtils.getHabit();
+        habit.setIsCustomHabit(true);
+        habit.setCustomShoppingListItems(List.of(ModelUtils.getCustomShoppingListItem()));
+        HabitDto habitDto = ModelUtils.getHabitDto();
+        habitDto.setIsCustomHabit(true);
+        habitDto.setCustomShoppingListItems(List.of(ModelUtils.getCustomShoppingListItemResponseDto()));
+        HabitTranslation habitTranslation = ModelUtils.getHabitTranslation();
+        when(habitRepo.findById(1L)).thenReturn(Optional.of(habit));
+        when(habitTranslationRepo.findByHabitAndLanguageCode(habit, "en"))
+            .thenReturn(Optional.of(habitTranslation));
+        when(modelMapper.map(habitTranslation, HabitDto.class)).thenReturn(habitDto);
+        when(habitAssignRepo.findAmountOfUsersAcquired(anyLong())).thenReturn(5L);
+        assertEquals(habitDto, habitService.getByIdAndLanguageCode(1L, "en"));
+        verify(habitRepo).findById(1L);
+        verify(habitTranslationRepo).findByHabitAndLanguageCode(habit, "en");
+        verify(modelMapper).map(habitTranslation, HabitDto.class);
+        verify(habitAssignRepo).findAmountOfUsersAcquired(anyLong());
     }
 
     @Test


### PR DESCRIPTION
## Summary Of Issue :
In endpoint get "habit/{id}": 
need to add field "isCustom": boolean that will indicate if habit is standard or custom;
need to add field array with custom shop lists if isCustom=true;


**Issue Link**
https://github.com/ita-social-projects/GreenCity/issues/5545

## Summary Of Changes :
1) added in HabitDto fields customShoppingListItems and isCustomHabit

2) modified method getByIdAndLanguageCode in HabitServiceImpl

3) added and changed tests




## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [ ] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers