### PR TITLE
Comment reply liking makes parent id null

### DIFF
--- a/service/src/main/java/greencity/mapping/EcoNewsCommentVOMapper.java
+++ b/service/src/main/java/greencity/mapping/EcoNewsCommentVOMapper.java
@@ -13,25 +13,38 @@ import java.util.stream.Collectors;
 public class EcoNewsCommentVOMapper extends AbstractConverter<EcoNewsComment, EcoNewsCommentVO> {
     @Override
     protected EcoNewsCommentVO convert(EcoNewsComment ecoNewsComment) {
+        EcoNewsCommentVO commentVO = convertWithNullParentComment(ecoNewsComment);
+        EcoNewsComment parentComment = ecoNewsComment.getParentComment();
+
+        if (parentComment != null){
+            EcoNewsCommentVO parentCommentVO = convertWithNullParentComment(parentComment);
+            commentVO.setParentComment(parentCommentVO);
+        }
+
+        return commentVO;
+    }
+
+    private EcoNewsCommentVO convertWithNullParentComment(EcoNewsComment ecoNewsComment) {
         return EcoNewsCommentVO.builder()
-            .id(ecoNewsComment.getId())
-            .user(UserVO.builder()
-                .id(ecoNewsComment.getUser().getId())
-                .role(ecoNewsComment.getUser().getRole())
-                .name(ecoNewsComment.getUser().getName())
-                .build())
-            .modifiedDate(ecoNewsComment.getModifiedDate())
-            .text(ecoNewsComment.getText())
-            .deleted(ecoNewsComment.isDeleted())
-            .currentUserLiked(ecoNewsComment.isCurrentUserLiked())
-            .createdDate(ecoNewsComment.getCreatedDate())
-            .usersLiked(ecoNewsComment.getUsersLiked().stream().map(user -> UserVO.builder()
-                .id(user.getId())
-                .build())
-                .collect(Collectors.toSet()))
-            .ecoNews(EcoNewsVO.builder()
-                .id(ecoNewsComment.getEcoNews().getId())
-                .build())
-            .build();
+                .id(ecoNewsComment.getId())
+                .user(UserVO.builder()
+                        .id(ecoNewsComment.getUser().getId())
+                        .role(ecoNewsComment.getUser().getRole())
+                        .name(ecoNewsComment.getUser().getName())
+                        .build())
+                .modifiedDate(ecoNewsComment.getModifiedDate())
+                .parentComment(null)
+                .text(ecoNewsComment.getText())
+                .deleted(ecoNewsComment.isDeleted())
+                .currentUserLiked(ecoNewsComment.isCurrentUserLiked())
+                .createdDate(ecoNewsComment.getCreatedDate())
+                .usersLiked(ecoNewsComment.getUsersLiked().stream().map(user -> UserVO.builder()
+                                .id(user.getId())
+                                .build())
+                        .collect(Collectors.toSet()))
+                .ecoNews(EcoNewsVO.builder()
+                        .id(ecoNewsComment.getEcoNews().getId())
+                        .build())
+                .build();
     }
 }

--- a/service/src/main/java/greencity/mapping/EcoNewsCommentVOMapper.java
+++ b/service/src/main/java/greencity/mapping/EcoNewsCommentVOMapper.java
@@ -16,7 +16,7 @@ public class EcoNewsCommentVOMapper extends AbstractConverter<EcoNewsComment, Ec
         EcoNewsCommentVO commentVO = convertWithNullParentComment(ecoNewsComment);
         EcoNewsComment parentComment = ecoNewsComment.getParentComment();
 
-        if (parentComment != null){
+        if (parentComment != null) {
             EcoNewsCommentVO parentCommentVO = convertWithNullParentComment(parentComment);
             commentVO.setParentComment(parentCommentVO);
         }
@@ -26,25 +26,25 @@ public class EcoNewsCommentVOMapper extends AbstractConverter<EcoNewsComment, Ec
 
     private EcoNewsCommentVO convertWithNullParentComment(EcoNewsComment ecoNewsComment) {
         return EcoNewsCommentVO.builder()
-                .id(ecoNewsComment.getId())
-                .user(UserVO.builder()
-                        .id(ecoNewsComment.getUser().getId())
-                        .role(ecoNewsComment.getUser().getRole())
-                        .name(ecoNewsComment.getUser().getName())
-                        .build())
-                .modifiedDate(ecoNewsComment.getModifiedDate())
-                .parentComment(null)
-                .text(ecoNewsComment.getText())
-                .deleted(ecoNewsComment.isDeleted())
-                .currentUserLiked(ecoNewsComment.isCurrentUserLiked())
-                .createdDate(ecoNewsComment.getCreatedDate())
-                .usersLiked(ecoNewsComment.getUsersLiked().stream().map(user -> UserVO.builder()
-                                .id(user.getId())
-                                .build())
-                        .collect(Collectors.toSet()))
-                .ecoNews(EcoNewsVO.builder()
-                        .id(ecoNewsComment.getEcoNews().getId())
-                        .build())
-                .build();
+            .id(ecoNewsComment.getId())
+            .user(UserVO.builder()
+                .id(ecoNewsComment.getUser().getId())
+                .role(ecoNewsComment.getUser().getRole())
+                .name(ecoNewsComment.getUser().getName())
+                .build())
+            .modifiedDate(ecoNewsComment.getModifiedDate())
+            .parentComment(null)
+            .text(ecoNewsComment.getText())
+            .deleted(ecoNewsComment.isDeleted())
+            .currentUserLiked(ecoNewsComment.isCurrentUserLiked())
+            .createdDate(ecoNewsComment.getCreatedDate())
+            .usersLiked(ecoNewsComment.getUsersLiked().stream().map(user -> UserVO.builder()
+                .id(user.getId())
+                .build())
+                .collect(Collectors.toSet()))
+            .ecoNews(EcoNewsVO.builder()
+                .id(ecoNewsComment.getEcoNews().getId())
+                .build())
+            .build();
     }
 }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -1078,7 +1078,7 @@ public class ModelUtils {
             .build();
     }
 
-    public static EcoNewsCommentVO getEcoNewsCommentVOWithData() {
+    public static EcoNewsCommentVO getEcoNewsCommentVOWithoutParentWithData() {
         return EcoNewsCommentVO.builder()
             .id(278L)
             .user(UserVO.builder()
@@ -1088,6 +1088,62 @@ public class ModelUtils {
                 .build())
             .modifiedDate(LocalDateTime.now())
             .text("I find this topic very useful!")
+            .deleted(false)
+            .currentUserLiked(true)
+            .createdDate(LocalDateTime.of(2020, 11, 7, 12, 42))
+            .usersLiked(new HashSet<UserVO>(Arrays.asList(
+                UserVO.builder()
+                    .id(76L)
+                    .build(),
+                UserVO.builder()
+                    .id(543L)
+                    .build(),
+                UserVO.builder()
+                    .id(349L)
+                    .build())))
+            .ecoNews(EcoNewsVO.builder()
+                .id(32L)
+                .build())
+            .build();
+    }
+
+    public static EcoNewsCommentVO getEcoNewsCommentVOWithParentWithData() {
+        return EcoNewsCommentVO.builder()
+            .id(278L)
+            .user(UserVO.builder()
+                .id(13L)
+                .role(Role.ROLE_ADMIN)
+                .name("name")
+                .build())
+            .modifiedDate(LocalDateTime.now())
+            .text("I find this topic very useful!")
+            .parentComment(EcoNewsCommentVO.builder()
+                .id(277L)
+                .user(UserVO.builder()
+                    .id(13L)
+                    .role(Role.ROLE_ADMIN)
+                    .name("name")
+                    .build())
+                .modifiedDate(LocalDateTime.now())
+                .text("I find this topic very useful!")
+                .deleted(false)
+                .currentUserLiked(true)
+                .parentComment(null)
+                .createdDate(LocalDateTime.of(2020, 11, 7, 12, 42))
+                .usersLiked(new HashSet<UserVO>(Arrays.asList(
+                    UserVO.builder()
+                        .id(76L)
+                        .build(),
+                    UserVO.builder()
+                        .id(543L)
+                        .build(),
+                    UserVO.builder()
+                        .id(349L)
+                        .build())))
+                .ecoNews(EcoNewsVO.builder()
+                    .id(32L)
+                    .build())
+                .build())
             .deleted(false)
             .currentUserLiked(true)
             .createdDate(LocalDateTime.of(2020, 11, 7, 12, 42))

--- a/service/src/test/java/greencity/mapping/EcoNewsCommentVOMapperTest.java
+++ b/service/src/test/java/greencity/mapping/EcoNewsCommentVOMapperTest.java
@@ -18,8 +18,39 @@ class EcoNewsCommentVOMapperTest {
     EcoNewsCommentVOMapper mapper;
 
     @Test
-    void convert() {
-        EcoNewsCommentVO expected = ModelUtils.getEcoNewsCommentVOWithData();
+    void convertWithoutParent() {
+        EcoNewsCommentVO expected = ModelUtils.getEcoNewsCommentVOWithoutParentWithData();
+
+        EcoNewsComment ecoNewsComment = EcoNewsComment.builder()
+            .id(expected.getId())
+            .user(User.builder()
+                .id(expected.getUser().getId())
+                .role(expected.getUser().getRole())
+                .name(expected.getUser().getName())
+                .build())
+            .modifiedDate(expected.getModifiedDate())
+            .parentComment(null)
+            .text(expected.getText())
+            .deleted(expected.isDeleted())
+            .currentUserLiked(expected.isCurrentUserLiked())
+            .createdDate(expected.getCreatedDate())
+            .usersLiked(expected.getUsersLiked().stream().map(user -> User.builder()
+                .id(user.getId())
+                .build()).collect(Collectors.toSet()))
+            .ecoNews(EcoNews.builder()
+                .id(expected.getEcoNews().getId())
+                .build())
+            .build();
+
+        EcoNewsCommentVO actual = mapper.convert(ecoNewsComment);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void convertWithParent() {
+        EcoNewsCommentVO expected = ModelUtils.getEcoNewsCommentVOWithParentWithData();
+        EcoNewsCommentVO expectedParent = expected.getParentComment();
 
         EcoNewsComment ecoNewsComment = EcoNewsComment.builder()
             .id(expected.getId())
@@ -30,6 +61,26 @@ class EcoNewsCommentVOMapperTest {
                 .build())
             .modifiedDate(expected.getModifiedDate())
             .text(expected.getText())
+            .parentComment(EcoNewsComment.builder()
+                .id(expectedParent.getId())
+                .user(User.builder()
+                    .id(expectedParent.getUser().getId())
+                    .role(expectedParent.getUser().getRole())
+                    .name(expectedParent.getUser().getName())
+                    .build())
+                .modifiedDate(expectedParent.getModifiedDate())
+                .parentComment(null)
+                .text(expectedParent.getText())
+                .deleted(expectedParent.isDeleted())
+                .currentUserLiked(expectedParent.isCurrentUserLiked())
+                .createdDate(expectedParent.getCreatedDate())
+                .usersLiked(expectedParent.getUsersLiked().stream().map(user -> User.builder()
+                    .id(user.getId())
+                    .build()).collect(Collectors.toSet()))
+                .ecoNews(EcoNews.builder()
+                    .id(expectedParent.getEcoNews().getId())
+                    .build())
+                .build())
             .deleted(expected.isDeleted())
             .currentUserLiked(expected.isCurrentUserLiked())
             .createdDate(expected.getCreatedDate())


### PR DESCRIPTION
## Summary Of Issue :
When user likes a reply to comment reply becomes a comment, instead of remaining a reply

**Issue Link**
https://github.com/ita-social-projects/GreenCity/issues/5686

## Summary Of Changes :
1) Fixed parentId of reply becoming null after liking a reply
2) Changed EcoNewsCommentVOMapper to add parentComment to comment if parentComment is not null

## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] All files reviewed before sending to reviewers