### PR TITLE
Added permission for the administrator to delete events #5140

### DIFF
--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -164,7 +164,6 @@ public final class ErrorMessage {
         "Habit assign status is not INPROGRESS or user has not any assigned habits";
     public static final String INVALID_SORTING_VALUE = "Supported sort is: asc|desc";
 
-    public static final String NOT_EVENT_ORGANIZER = "You're not the organizer of this event";
     public static final String YOU_ARE_EVENT_ORGANIZER = "You're the organizer of this event";
     public static final String WRONG_COUNT_OF_EVENT_DATES =
         "Count of dates should be at least one but not more seven";

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -89,11 +89,11 @@ public class EventServiceImpl implements EventService {
                 .addAll(toDelete.getAdditionalImages().stream().map(EventImages::getLink).collect(Collectors.toList()));
         }
 
-        if (toDelete.getOrganizer().getId().equals(user.getId())) {
+        if (toDelete.getOrganizer().getId().equals(user.getId()) || user.getRole() == Role.ROLE_ADMIN) {
             deleteImagesFromServer(eventImages);
             eventRepo.delete(toDelete);
         } else {
-            throw new BadRequestException(ErrorMessage.NOT_EVENT_ORGANIZER);
+            throw new BadRequestException(ErrorMessage.USER_HAS_NO_PERMISSION);
         }
     }
 


### PR DESCRIPTION
# GreenCityUBS PR
_&lt;Added permission for the administrator to delete events #5140&gt;_

## Summary Of Changes :fire:
_&lt;Added permission for the administrator to delete events&gt;_

## Issue Link :clipboard:
_&lt;[Link to the issue](https://github.com/ita-social-projects/GreenCity/issues/5140)&gt;_

## Changed
* _&lt;Checking for the right to delete an event&gt;_
* _&lt;Existed tests&gt;_

## Deleted
* _&lt;Unused error message&gt;_

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
