### PR TITLE
[Create event] Authorized User is not able to create an online event #5746

### DIFF
--- a/dao/src/main/java/greencity/entity/event/Address.java
+++ b/dao/src/main/java/greencity/entity/event/Address.java
@@ -23,7 +23,7 @@ public final class Address {
     @Column
     private String streetEn;
 
-    @Column(nullable = false)
+    @Column
     private String streetUa;
 
     @Column
@@ -32,18 +32,18 @@ public final class Address {
     @Column
     private String cityEn;
 
-    @Column(nullable = false)
+    @Column
     private String cityUa;
 
     @Column
     private String regionEn;
 
-    @Column(nullable = false)
+    @Column
     private String regionUa;
 
     @Column
     private String countryEn;
 
-    @Column(nullable = false)
+    @Column
     private String countryUa;
 }

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -151,5 +151,6 @@
     <include file="db/changelog/logs/ch-update-fact-of-the-day-translations-Vatuliak.xml"/>
     <include file="db/changelog/logs/ch-update-habit-translation-Vatuliak.xml"/>
     <include file="db/changelog/logs/ch-update-habit-translations-Mokhnatska.xml"/>
+    <include file="db/changelog/logs/ch-change-table-events-dates-locations-dropNotNullConstraint-Seti.xml"/>
 </databaseChangeLog>
 

--- a/dao/src/main/resources/db/changelog/logs/ch-change-table-events-dates-locations-dropNotNullConstraint-Seti.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-change-table-events-dates-locations-dropNotNullConstraint-Seti.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="Julia Seti" id="Seti-1">
+        <dropNotNullConstraint tableName="events_dates_locations" columnName="street_ua"/>
+        <dropNotNullConstraint tableName="events_dates_locations" columnName="city_ua"/>
+        <dropNotNullConstraint tableName="events_dates_locations" columnName="region_ua"/>
+        <dropNotNullConstraint tableName="events_dates_locations" columnName="country_ua"/>
+    </changeSet>
+</databaseChangeLog>

--- a/service/src/main/java/greencity/mapping/events/AddEventDtoRequestMapper.java
+++ b/service/src/main/java/greencity/mapping/events/AddEventDtoRequestMapper.java
@@ -39,7 +39,7 @@ public class AddEventDtoRequestMapper extends AbstractConverter<AddEventDtoReque
         List<EventDateLocation> eventDateLocations = new ArrayList<>();
         for (var date : addEventDtoRequest.getDatesLocations()) {
             if (date.getCoordinates() == null && date.getOnlineLink() == null
-            || date.getCoordinates() != null && addressIsNotValid(date.getCoordinates())) {
+                || date.getCoordinates() != null && addressIsNotValid(date.getCoordinates())) {
                 throw new BadRequestException("Coordinates or link should be set!");
             }
             EventDateLocation eventDateLocation = new EventDateLocation();
@@ -60,6 +60,6 @@ public class AddEventDtoRequestMapper extends AbstractConverter<AddEventDtoReque
 
     private boolean addressIsNotValid(AddressDto dto) {
         return dto.getStreetUa() == null || dto.getCityUa() == null
-                || dto.getRegionUa() == null || dto.getCountryUa() == null;
+            || dto.getRegionUa() == null || dto.getCountryUa() == null;
     }
 }

--- a/service/src/main/java/greencity/mapping/events/AddEventDtoRequestMapper.java
+++ b/service/src/main/java/greencity/mapping/events/AddEventDtoRequestMapper.java
@@ -1,6 +1,7 @@
 package greencity.mapping.events;
 
 import greencity.dto.event.AddEventDtoRequest;
+import greencity.dto.event.AddressDto;
 import greencity.entity.event.Event;
 import greencity.entity.event.EventDateLocation;
 import greencity.exception.exceptions.BadRequestException;
@@ -37,7 +38,8 @@ public class AddEventDtoRequestMapper extends AbstractConverter<AddEventDtoReque
 
         List<EventDateLocation> eventDateLocations = new ArrayList<>();
         for (var date : addEventDtoRequest.getDatesLocations()) {
-            if (date.getCoordinates() == null && date.getOnlineLink() == null) {
+            if (date.getCoordinates() == null && date.getOnlineLink() == null
+            || date.getCoordinates() != null && addressIsNotValid(date.getCoordinates())) {
                 throw new BadRequestException("Coordinates or link should be set!");
             }
             EventDateLocation eventDateLocation = new EventDateLocation();
@@ -54,5 +56,10 @@ public class AddEventDtoRequestMapper extends AbstractConverter<AddEventDtoReque
         }
         event.setDates(eventDateLocations);
         return event;
+    }
+
+    private boolean addressIsNotValid(AddressDto dto) {
+        return dto.getStreetUa() == null || dto.getCityUa() == null
+                || dto.getRegionUa() == null || dto.getCountryUa() == null;
     }
 }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -1959,6 +1959,17 @@ public class ModelUtils {
         .tags(List.of("Social"))
         .build();
 
+    public static AddEventDtoRequest addEventDtoWithoutLinkRequest = AddEventDtoRequest.builder()
+        .datesLocations(List.of(new EventDateLocationDto(1L, null,
+            ZonedDateTime.of(2000, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+            ZonedDateTime.of(2000, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+            null,
+            getAddressDto())))
+        .description("Description")
+        .title("Title")
+        .tags(List.of("Social"))
+        .build();
+
     public static AddressDto getAddressDtoWithNullStreetUa() {
         return AddressDto.builder()
             .latitude(13.4567236)
@@ -2023,6 +2034,10 @@ public class ModelUtils {
             .build();
     }
 
+    public static AddressDto getAddressDtoWithoutData() {
+        return AddressDto.builder().build();
+    }
+
     public static AddEventDtoRequest addEventDtoRequestWithNullStreetUa = AddEventDtoRequest.builder()
         .datesLocations(List.of(new EventDateLocationDto(1L, null,
             ZonedDateTime.of(2000, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
@@ -2062,6 +2077,17 @@ public class ModelUtils {
             ZonedDateTime.of(2000, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
             null,
             getAddressDtoWithNullCountryUa())))
+        .description("Description")
+        .title("Title")
+        .tags(List.of("Social"))
+        .build();
+
+    public static AddEventDtoRequest addEventDtoRequestWithNullData = AddEventDtoRequest.builder()
+        .datesLocations(List.of(new EventDateLocationDto(1L, null,
+            ZonedDateTime.of(2000, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+            ZonedDateTime.of(2000, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+            null,
+            getAddressDtoWithoutData())))
         .description("Description")
         .title("Title")
         .tags(List.of("Social"))

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -1961,111 +1961,111 @@ public class ModelUtils {
 
     public static AddressDto getAddressDtoWithNullStreetUa() {
         return AddressDto.builder()
-                .latitude(13.4567236)
-                .longitude(98.2354469)
-                .streetUa(null)
-                .streetEn("Street")
-                .houseNumber("1B")
-                .cityUa("Місто")
-                .cityEn("City")
-                .regionUa("Область")
-                .regionEn("Oblast")
-                .countryUa("Країна")
-                .countryEn("Country")
-                .build();
+            .latitude(13.4567236)
+            .longitude(98.2354469)
+            .streetUa(null)
+            .streetEn("Street")
+            .houseNumber("1B")
+            .cityUa("Місто")
+            .cityEn("City")
+            .regionUa("Область")
+            .regionEn("Oblast")
+            .countryUa("Країна")
+            .countryEn("Country")
+            .build();
     }
 
     public static AddressDto getAddressDtoWithNullCityUa() {
         return AddressDto.builder()
-                .latitude(13.4567236)
-                .longitude(98.2354469)
-                .streetUa("Вулиця")
-                .streetEn("Street")
-                .houseNumber("1B")
-                .cityUa(null)
-                .cityEn("City")
-                .regionUa("Область")
-                .regionEn("Oblast")
-                .countryUa("Країна")
-                .countryEn("Country")
-                .build();
+            .latitude(13.4567236)
+            .longitude(98.2354469)
+            .streetUa("Вулиця")
+            .streetEn("Street")
+            .houseNumber("1B")
+            .cityUa(null)
+            .cityEn("City")
+            .regionUa("Область")
+            .regionEn("Oblast")
+            .countryUa("Країна")
+            .countryEn("Country")
+            .build();
     }
 
     public static AddressDto getAddressDtoWithNullRegionUa() {
         return AddressDto.builder()
-                .latitude(13.4567236)
-                .longitude(98.2354469)
-                .streetUa("Вулиця")
-                .streetEn("Street")
-                .houseNumber("1B")
-                .cityUa("Місто")
-                .cityEn("City")
-                .regionUa(null)
-                .regionEn("Oblast")
-                .countryUa("Країна")
-                .countryEn("Country")
-                .build();
+            .latitude(13.4567236)
+            .longitude(98.2354469)
+            .streetUa("Вулиця")
+            .streetEn("Street")
+            .houseNumber("1B")
+            .cityUa("Місто")
+            .cityEn("City")
+            .regionUa(null)
+            .regionEn("Oblast")
+            .countryUa("Країна")
+            .countryEn("Country")
+            .build();
     }
 
     public static AddressDto getAddressDtoWithNullCountryUa() {
         return AddressDto.builder()
-                .latitude(13.4567236)
-                .longitude(98.2354469)
-                .streetUa("Вулиця")
-                .streetEn("Street")
-                .houseNumber("1B")
-                .cityUa("Місто")
-                .cityEn("City")
-                .regionUa("Область")
-                .regionEn("Oblast")
-                .countryUa(null)
-                .countryEn("Country")
-                .build();
+            .latitude(13.4567236)
+            .longitude(98.2354469)
+            .streetUa("Вулиця")
+            .streetEn("Street")
+            .houseNumber("1B")
+            .cityUa("Місто")
+            .cityEn("City")
+            .regionUa("Область")
+            .regionEn("Oblast")
+            .countryUa(null)
+            .countryEn("Country")
+            .build();
     }
 
     public static AddEventDtoRequest addEventDtoRequestWithNullStreetUa = AddEventDtoRequest.builder()
-            .datesLocations(List.of(new EventDateLocationDto(1L, null,
-                    ZonedDateTime.of(2000, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
-                    ZonedDateTime.of(2000, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
-                    "/url",
-                    getAddressDtoWithNullStreetUa())))
-            .description("Description")
-            .title("Title")
-            .tags(List.of("Social"))
-            .build();
+        .datesLocations(List.of(new EventDateLocationDto(1L, null,
+            ZonedDateTime.of(2000, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+            ZonedDateTime.of(2000, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+            "/url",
+            getAddressDtoWithNullStreetUa())))
+        .description("Description")
+        .title("Title")
+        .tags(List.of("Social"))
+        .build();
 
     public static AddEventDtoRequest addEventDtoRequestWithNullCityUa = AddEventDtoRequest.builder()
-            .datesLocations(List.of(new EventDateLocationDto(1L, null,
-                    ZonedDateTime.of(2000, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
-                    ZonedDateTime.of(2000, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
-                    "/url",
-                    getAddressDtoWithNullCityUa())))
-            .description("Description")
-            .title("Title")
-            .tags(List.of("Social"))
-            .build();
+        .datesLocations(List.of(new EventDateLocationDto(1L, null,
+            ZonedDateTime.of(2000, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+            ZonedDateTime.of(2000, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+            "/url",
+            getAddressDtoWithNullCityUa())))
+        .description("Description")
+        .title("Title")
+        .tags(List.of("Social"))
+        .build();
 
     public static AddEventDtoRequest addEventDtoRequestWithNullRegionUa = AddEventDtoRequest.builder()
-            .datesLocations(List.of(new EventDateLocationDto(1L, null,
-                    ZonedDateTime.of(2000, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
-                    ZonedDateTime.of(2000, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
-                    null,
-                    getAddressDtoWithNullRegionUa())))
-            .description("Description")
-            .title("Title")
-            .tags(List.of("Social"))
-            .build();
+        .datesLocations(List.of(new EventDateLocationDto(1L, null,
+            ZonedDateTime.of(2000, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+            ZonedDateTime.of(2000, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+            null,
+            getAddressDtoWithNullRegionUa())))
+        .description("Description")
+        .title("Title")
+        .tags(List.of("Social"))
+        .build();
 
     public static AddEventDtoRequest addEventDtoRequestWithNullCountryUa = AddEventDtoRequest.builder()
-            .datesLocations(List.of(new EventDateLocationDto(1L, null,
-                    ZonedDateTime.of(2000, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
-                    ZonedDateTime.of(2000, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
-                    null,
-                    getAddressDtoWithNullCountryUa())))
-            .description("Description")
-            .title("Title")
-            .tags(List.of("Social"))
-            .build();
+        .datesLocations(List.of(new EventDateLocationDto(1L, null,
+            ZonedDateTime.of(2000, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+            ZonedDateTime.of(2000, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+            null,
+            getAddressDtoWithNullCountryUa())))
+        .description("Description")
+        .title("Title")
+        .tags(List.of("Social"))
+        .build();
 
     public static EventDto getEventDtoWithoutAddress() {
         return EventDto.builder()

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -1959,6 +1959,114 @@ public class ModelUtils {
         .tags(List.of("Social"))
         .build();
 
+    public static AddressDto getAddressDtoWithNullStreetUa() {
+        return AddressDto.builder()
+                .latitude(13.4567236)
+                .longitude(98.2354469)
+                .streetUa(null)
+                .streetEn("Street")
+                .houseNumber("1B")
+                .cityUa("Місто")
+                .cityEn("City")
+                .regionUa("Область")
+                .regionEn("Oblast")
+                .countryUa("Країна")
+                .countryEn("Country")
+                .build();
+    }
+
+    public static AddressDto getAddressDtoWithNullCityUa() {
+        return AddressDto.builder()
+                .latitude(13.4567236)
+                .longitude(98.2354469)
+                .streetUa("Вулиця")
+                .streetEn("Street")
+                .houseNumber("1B")
+                .cityUa(null)
+                .cityEn("City")
+                .regionUa("Область")
+                .regionEn("Oblast")
+                .countryUa("Країна")
+                .countryEn("Country")
+                .build();
+    }
+
+    public static AddressDto getAddressDtoWithNullRegionUa() {
+        return AddressDto.builder()
+                .latitude(13.4567236)
+                .longitude(98.2354469)
+                .streetUa("Вулиця")
+                .streetEn("Street")
+                .houseNumber("1B")
+                .cityUa("Місто")
+                .cityEn("City")
+                .regionUa(null)
+                .regionEn("Oblast")
+                .countryUa("Країна")
+                .countryEn("Country")
+                .build();
+    }
+
+    public static AddressDto getAddressDtoWithNullCountryUa() {
+        return AddressDto.builder()
+                .latitude(13.4567236)
+                .longitude(98.2354469)
+                .streetUa("Вулиця")
+                .streetEn("Street")
+                .houseNumber("1B")
+                .cityUa("Місто")
+                .cityEn("City")
+                .regionUa("Область")
+                .regionEn("Oblast")
+                .countryUa(null)
+                .countryEn("Country")
+                .build();
+    }
+
+    public static AddEventDtoRequest addEventDtoRequestWithNullStreetUa = AddEventDtoRequest.builder()
+            .datesLocations(List.of(new EventDateLocationDto(1L, null,
+                    ZonedDateTime.of(2000, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+                    ZonedDateTime.of(2000, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+                    "/url",
+                    getAddressDtoWithNullStreetUa())))
+            .description("Description")
+            .title("Title")
+            .tags(List.of("Social"))
+            .build();
+
+    public static AddEventDtoRequest addEventDtoRequestWithNullCityUa = AddEventDtoRequest.builder()
+            .datesLocations(List.of(new EventDateLocationDto(1L, null,
+                    ZonedDateTime.of(2000, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+                    ZonedDateTime.of(2000, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+                    "/url",
+                    getAddressDtoWithNullCityUa())))
+            .description("Description")
+            .title("Title")
+            .tags(List.of("Social"))
+            .build();
+
+    public static AddEventDtoRequest addEventDtoRequestWithNullRegionUa = AddEventDtoRequest.builder()
+            .datesLocations(List.of(new EventDateLocationDto(1L, null,
+                    ZonedDateTime.of(2000, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+                    ZonedDateTime.of(2000, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+                    null,
+                    getAddressDtoWithNullRegionUa())))
+            .description("Description")
+            .title("Title")
+            .tags(List.of("Social"))
+            .build();
+
+    public static AddEventDtoRequest addEventDtoRequestWithNullCountryUa = AddEventDtoRequest.builder()
+            .datesLocations(List.of(new EventDateLocationDto(1L, null,
+                    ZonedDateTime.of(2000, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+                    ZonedDateTime.of(2000, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+                    null,
+                    getAddressDtoWithNullCountryUa())))
+            .description("Description")
+            .title("Title")
+            .tags(List.of("Social"))
+            .build();
+
     public static EventDto getEventDtoWithoutAddress() {
         return EventDto.builder()
             .id(1L)

--- a/service/src/test/java/greencity/mapping/events/AddEventDtoRequestMapperTest.java
+++ b/service/src/test/java/greencity/mapping/events/AddEventDtoRequestMapperTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
@@ -32,12 +33,12 @@ class AddEventDtoRequestMapperTest {
         when(addressDtoMapper.convert(addressDto)).thenReturn(ModelUtils.getAddress());
         assertEquals(expected.getTitle(), mapper.convert(request).getTitle());
         verify(addressDtoMapper).convert(addressDto);
+        verifyNoMoreInteractions(addressDtoMapper);
     }
 
     @Test
     void convertTestWithoutAddress() {
         Event expected = ModelUtils.getEventWithoutAddress();
-
         AddEventDtoRequest request = ModelUtils.addEventDtoWithoutAddressRequest;
 
         assertEquals(expected.getTitle(), mapper.convert(request).getTitle());
@@ -47,11 +48,8 @@ class AddEventDtoRequestMapperTest {
     void convertTestWithoutOnlineLink() {
         Event expected = ModelUtils.getEvent();
         AddEventDtoRequest request = ModelUtils.addEventDtoWithoutLinkRequest;
-        AddressDto addressDto = ModelUtils.getAddressDto();
 
-        when(addressDtoMapper.convert(addressDto)).thenReturn(ModelUtils.getAddress());
         assertEquals(expected.getTitle(), mapper.convert(request).getTitle());
-        verify(addressDtoMapper).convert(addressDto);
     }
 
     @Test

--- a/service/src/test/java/greencity/mapping/events/AddEventDtoRequestMapperTest.java
+++ b/service/src/test/java/greencity/mapping/events/AddEventDtoRequestMapperTest.java
@@ -43,4 +43,28 @@ class AddEventDtoRequestMapperTest {
         AddEventDtoRequest request = ModelUtils.addEventDtoWithoutAddressAndLinkRequest;
         assertThrows(BadRequestException.class, () -> mapper.convert(request));
     }
+
+    @Test
+    void convertTestWithNullStreetUa() {
+        AddEventDtoRequest request = ModelUtils.addEventDtoRequestWithNullStreetUa;
+        assertThrows(BadRequestException.class, () -> mapper.convert(request));
+    }
+
+    @Test
+    void convertTestWithNullCityUa() {
+        AddEventDtoRequest request = ModelUtils.addEventDtoRequestWithNullCityUa;
+        assertThrows(BadRequestException.class, () -> mapper.convert(request));
+    }
+
+    @Test
+    void convertTestWithNullRegionUa() {
+        AddEventDtoRequest request = ModelUtils.addEventDtoRequestWithNullRegionUa;
+        assertThrows(BadRequestException.class, () -> mapper.convert(request));
+    }
+
+    @Test
+    void convertTestWithNullCountryUa() {
+        AddEventDtoRequest request = ModelUtils.addEventDtoRequestWithNullCountryUa;
+        assertThrows(BadRequestException.class, () -> mapper.convert(request));
+    }
 }

--- a/service/src/test/java/greencity/mapping/events/AddEventDtoRequestMapperTest.java
+++ b/service/src/test/java/greencity/mapping/events/AddEventDtoRequestMapperTest.java
@@ -2,6 +2,7 @@ package greencity.mapping.events;
 
 import greencity.ModelUtils;
 import greencity.dto.event.AddEventDtoRequest;
+import greencity.dto.event.AddressDto;
 import greencity.entity.event.Event;
 import greencity.exception.exceptions.BadRequestException;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 class AddEventDtoRequestMapperTest {
@@ -23,10 +26,12 @@ class AddEventDtoRequestMapperTest {
     @Test
     void convertTest() {
         Event expected = ModelUtils.getEvent();
-
         AddEventDtoRequest request = ModelUtils.addEventDtoRequest;
+        AddressDto addressDto = ModelUtils.getAddressDto();
 
+        when(addressDtoMapper.convert(addressDto)).thenReturn(ModelUtils.getAddress());
         assertEquals(expected.getTitle(), mapper.convert(request).getTitle());
+        verify(addressDtoMapper).convert(addressDto);
     }
 
     @Test
@@ -36,6 +41,17 @@ class AddEventDtoRequestMapperTest {
         AddEventDtoRequest request = ModelUtils.addEventDtoWithoutAddressRequest;
 
         assertEquals(expected.getTitle(), mapper.convert(request).getTitle());
+    }
+
+    @Test
+    void convertTestWithoutOnlineLink() {
+        Event expected = ModelUtils.getEvent();
+        AddEventDtoRequest request = ModelUtils.addEventDtoWithoutLinkRequest;
+        AddressDto addressDto = ModelUtils.getAddressDto();
+
+        when(addressDtoMapper.convert(addressDto)).thenReturn(ModelUtils.getAddress());
+        assertEquals(expected.getTitle(), mapper.convert(request).getTitle());
+        verify(addressDtoMapper).convert(addressDto);
     }
 
     @Test
@@ -65,6 +81,12 @@ class AddEventDtoRequestMapperTest {
     @Test
     void convertTestWithNullCountryUa() {
         AddEventDtoRequest request = ModelUtils.addEventDtoRequestWithNullCountryUa;
+        assertThrows(BadRequestException.class, () -> mapper.convert(request));
+    }
+
+    @Test
+    void convertTestWhenAddressDtoWithNullData() {
+        AddEventDtoRequest request = ModelUtils.addEventDtoRequestWithNullData;
         assertThrows(BadRequestException.class, () -> mapper.convert(request));
     }
 }

--- a/service/src/test/java/greencity/mapping/events/AddEventDtoRequestMapperTest.java
+++ b/service/src/test/java/greencity/mapping/events/AddEventDtoRequestMapperTest.java
@@ -2,7 +2,6 @@ package greencity.mapping.events;
 
 import greencity.ModelUtils;
 import greencity.dto.event.AddEventDtoRequest;
-import greencity.dto.event.AddressDto;
 import greencity.entity.event.Event;
 import greencity.exception.exceptions.BadRequestException;
 import org.junit.jupiter.api.Test;
@@ -13,9 +12,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 class AddEventDtoRequestMapperTest {
@@ -28,12 +24,8 @@ class AddEventDtoRequestMapperTest {
     void convertTest() {
         Event expected = ModelUtils.getEvent();
         AddEventDtoRequest request = ModelUtils.addEventDtoRequest;
-        AddressDto addressDto = ModelUtils.getAddressDto();
 
-        when(addressDtoMapper.convert(addressDto)).thenReturn(ModelUtils.getAddress());
         assertEquals(expected.getTitle(), mapper.convert(request).getTitle());
-        verify(addressDtoMapper).convert(addressDto);
-        verifyNoMoreInteractions(addressDtoMapper);
     }
 
     @Test


### PR DESCRIPTION
## Summary Of Issue :
Authorized User is not able to create an online event

**Issue Link:**
https://github.com/ita-social-projects/GreenCity/issues/5746

## Summary Of Changes :

- In the events_dates_locations table the street_ua, city_ua, region_ua and country_ua columns are set to nullable, as well as the streetUa, cityUa, regionUa, countryUa fields in dao/src/main/java/greencity/entity/event/Address.java.
- Changed convert() method in service/src/main/java/greencity/mapping/events/AddEventDtoRequestMapper.java.
- Added tests and test methods.

## Test:
Tested in swagger http://localhost:8080/swagger-ui.html#/  by  /events/create endpoint.