### PR TITLE
[Green City] - Enabling the ability to add or remove events from favorites and retrieve all favorites events. #5856

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -233,7 +233,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 "/events/comments/{eventId}",
                 "/events/comments/like",
                 EVENTS + "/addAttender/{eventId}",
-                EVENTS + "/save/{eventId}",
+                EVENTS + "/addToFavorites/{eventId}",
                 EVENTS + "/create",
                 EVENTS + "/rateEvent/{eventId}/{rate}",
                 CUSTOM_SHOPPING_LIST_ITEMS,
@@ -296,7 +296,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 USER_SHOPPING_LIST,
                 EVENTS + "/delete/{eventId}",
                 EVENTS + "/removeAttender/{eventId}",
-                EVENTS + "/undoSave/{eventId}",
+                EVENTS + "/removeFromFavorites/{eventId}",
                 "/user/{userId}/userFriend/{friendId}",
                 "/habit/assign/delete/{habitAssignId}")
             .hasAnyRole(USER, ADMIN, MODERATOR, UBS_EMPLOYEE)

--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -233,6 +233,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 "/events/comments/{eventId}",
                 "/events/comments/like",
                 EVENTS + "/addAttender/{eventId}",
+                EVENTS + "/save/{eventId}",
                 EVENTS + "/create",
                 EVENTS + "/rateEvent/{eventId}/{rate}",
                 CUSTOM_SHOPPING_LIST_ITEMS,
@@ -295,6 +296,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 USER_SHOPPING_LIST,
                 EVENTS + "/delete/{eventId}",
                 EVENTS + "/removeAttender/{eventId}",
+                EVENTS + "/undoSave/{eventId}",
                 "/user/{userId}/userFriend/{friendId}",
                 "/habit/assign/delete/{habitAssignId}")
             .hasAnyRole(USER, ADMIN, MODERATOR, UBS_EMPLOYEE)

--- a/core/src/main/java/greencity/controller/EventsController.java
+++ b/core/src/main/java/greencity/controller/EventsController.java
@@ -238,38 +238,38 @@ public class EventsController {
     }
 
     /**
-     * Method for saving an Event by ID.
+     * Method for adding an event to favorites by event id.
      *
      * @author Anton Bondar.
      */
-    @ApiOperation(value = "Saving of an event")
+    @ApiOperation(value = "Add an event to favorites")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = HttpStatuses.OK),
         @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
         @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
         @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
-    @PostMapping("/save/{eventId}")
-    public ResponseEntity<Object> saveEvent(@PathVariable Long eventId, @ApiIgnore Principal principal) {
-        eventService.saveEvent(eventId, principal.getName());
+    @PostMapping("/addToFavorites/{eventId}")
+    public ResponseEntity<Object> addToFavorites(@PathVariable Long eventId, @ApiIgnore Principal principal) {
+        eventService.addToFavorites(eventId, principal.getName());
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     /**
-     * Method for undoing the saving of an Event by ID.
+     * Method for removing an event from favorites by event id.
      *
      * @author Anton Bondar.
      */
-    @ApiOperation(value = "Undo the saving of an event")
+    @ApiOperation(value = "Remove an event from favorites")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = HttpStatuses.OK),
         @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
         @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
         @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
-    @DeleteMapping("/undoSave/{eventId}")
-    public ResponseEntity<Object> undoSaveEvent(@PathVariable Long eventId, @ApiIgnore Principal principal) {
-        eventService.undoSaveEvent(eventId, principal.getName());
+    @DeleteMapping("/removeFromFavorites/{eventId}")
+    public ResponseEntity<Object> removeFromFavorites(@PathVariable Long eventId, @ApiIgnore Principal principal) {
+        eventService.removeFromFavorites(eventId, principal.getName());
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 

--- a/core/src/main/java/greencity/controller/EventsController.java
+++ b/core/src/main/java/greencity/controller/EventsController.java
@@ -21,7 +21,14 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.Nullable;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import springfox.documentation.annotations.ApiIgnore;
 
@@ -227,6 +234,42 @@ public class EventsController {
     @DeleteMapping("/removeAttender/{eventId}")
     public ResponseEntity<Object> removeAttender(@PathVariable Long eventId, @ApiIgnore Principal principal) {
         eventService.removeAttender(eventId, principal.getName());
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    /**
+     * Method for saving an Event by ID.
+     *
+     * @author Anton Bondar.
+     */
+    @ApiOperation(value = "Saving of an event")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = HttpStatuses.OK),
+        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+    })
+    @PostMapping("/save/{eventId}")
+    public ResponseEntity<Object> saveEvent(@PathVariable Long eventId, @ApiIgnore Principal principal) {
+        eventService.saveEvent(eventId, principal.getName());
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    /**
+     * Method for undoing the saving of an Event by ID.
+     *
+     * @author Anton Bondar.
+     */
+    @ApiOperation(value = "Undo the saving of an event")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = HttpStatuses.OK),
+        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+    })
+    @DeleteMapping("/undoSave/{eventId}")
+    public ResponseEntity<Object> undoSaveEvent(@PathVariable Long eventId, @ApiIgnore Principal principal) {
+        eventService.undoSaveEvent(eventId, principal.getName());
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 

--- a/core/src/test/java/greencity/controller/EventsControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventsControllerTest.java
@@ -59,16 +59,23 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class EventsControllerTest {
+
     private static final String EVENTS_CONTROLLER_LINK = "/events";
+
     private MockMvc mockMvc;
+
     @InjectMocks
     private EventsController eventsController;
+
     @Mock
     private EventService eventService;
+
     @Mock
     private UserService userService;
+
     @Mock
     private ModelMapper modelMapper;
+
     private final Principal principal = getPrincipal();
 
     @BeforeEach

--- a/core/src/test/java/greencity/controller/EventsControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventsControllerTest.java
@@ -205,22 +205,22 @@ class EventsControllerTest {
 
     @Test
     @SneakyThrows
-    void saveEventTest() {
+    void addToFavoritesTest() {
         Long eventId = 1L;
-        mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/save/{eventId}", eventId)
+        mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/addToFavorites/{eventId}", eventId)
             .principal(principal))
             .andExpect(status().isOk());
-        verify(eventService).saveEvent(eventId, principal.getName());
+        verify(eventService).addToFavorites(eventId, principal.getName());
     }
 
     @Test
     @SneakyThrows
-    void undoSaveEventTest() {
+    void removeFromFavoritesTest() {
         Long eventId = 1L;
-        mockMvc.perform(delete(EVENTS_CONTROLLER_LINK + "/undoSave/{eventId}", eventId)
+        mockMvc.perform(delete(EVENTS_CONTROLLER_LINK + "/removeFromFavorites/{eventId}", eventId)
             .principal(principal))
             .andExpect(status().isOk());
-        verify(eventService).undoSaveEvent(eventId, principal.getName());
+        verify(eventService).removeFromFavorites(eventId, principal.getName());
     }
 
     @Test

--- a/dao/src/main/java/greencity/entity/event/Event.java
+++ b/dao/src/main/java/greencity/entity/event/Event.java
@@ -2,9 +2,25 @@ package greencity.entity.event;
 
 import greencity.entity.Tag;
 import greencity.entity.User;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -46,6 +62,13 @@ public class Event {
         joinColumns = @JoinColumn(name = "event_id"),
         inverseJoinColumns = @JoinColumn(name = "user_id"))
     private Set<User> attenders = new HashSet<>();
+
+    @ManyToMany
+    @JoinTable(
+        name = "events_followers",
+        joinColumns = @JoinColumn(name = "event_id"),
+        inverseJoinColumns = @JoinColumn(name = "user_id"))
+    private Set<User> followers;
 
     @NonNull
     @OneToMany(mappedBy = "event", cascade = CascadeType.ALL)

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -154,5 +154,6 @@
     <include file="/db/changelog/logs/ch-add-table-employee-positions-mapping-Bondar.xml"/>
     <include file="db/changelog/logs/ch-change-table-events-dates-locations-dropNotNullConstraint-Seti.xml"/>
     <include file="db/changelog/logs/ch-update-employee_authorities-table-name-value-Bondar.xml"/>
+    <include file="db/changelog/logs/ch-add-table-events-followers-Bondar.xml"/>
 </databaseChangeLog>
 

--- a/dao/src/main/resources/db/changelog/logs/ch-add-table-events-followers-Bondar.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-add-table-events-followers-Bondar.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="Bondar-3" author="Anton Bondar">
+        <createTable tableName="events_followers">
+            <column name="event_id" type="BIGINT" >
+                <constraints nullable="false"/>
+            </column>
+            <column name="user_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addPrimaryKey tableName="events_followers"
+                       columnNames="event_id, user_id"/>
+        <addForeignKeyConstraint baseTableName="events_followers"
+                                 baseColumnNames="event_id"
+                                 constraintName="fk_events_followers_event_id"
+                                 referencedTableName="events"
+                                 referencedColumnNames="id"/>
+        <addForeignKeyConstraint baseTableName="events_followers"
+                                 baseColumnNames="user_id"
+                                 constraintName="fk_events_followers_user_id"
+                                 referencedTableName="users"
+                                 referencedColumnNames="id"/>
+    </changeSet>
+</databaseChangeLog>

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -178,6 +178,9 @@ public final class ErrorMessage {
     public static final String HAVE_ALREADY_RATED = "You have already rated this event";
     public static final String EVENT_IS_NOT_FINISHED = "Event is not finished yet";
     public static final String EVENT_NOT_FOUND_BY_ID = "Event doesn't exist by this id: ";
+    public static final String USER_HAS_ALREADY_ADDED_EVENT_TO_FAVORITES =
+        "User has already added this event to favorites.";
+    public static final String EVENT_IS_NOT_IN_FAVORITES = "This event is not in favorites.";
     public static final String EVENT_COMMENT_NOT_FOUND_BY_ID = "Event comment doesn't exist by this id: ";
     public static final String EVENT_IS_FINISHED = "Finished event cannot be modified";
 

--- a/service-api/src/main/java/greencity/dto/event/EventDto.java
+++ b/service-api/src/main/java/greencity/dto/event/EventDto.java
@@ -44,7 +44,7 @@ public class EventDto {
 
     private Boolean isSubscribed;
 
-    private Boolean isSaved;
+    private Boolean isFavorite;
 
     /**
      * Return String of event tags in English.

--- a/service-api/src/main/java/greencity/dto/event/EventDto.java
+++ b/service-api/src/main/java/greencity/dto/event/EventDto.java
@@ -44,6 +44,8 @@ public class EventDto {
 
     private Boolean isSubscribed;
 
+    private Boolean isSaved;
+
     /**
      * Return String of event tags in English.
      *

--- a/service-api/src/main/java/greencity/service/EventService.java
+++ b/service-api/src/main/java/greencity/service/EventService.java
@@ -83,6 +83,26 @@ public interface EventService {
     void removeAttender(Long eventId, String email);
 
     /**
+     * Method for saving an Event by ID.
+     *
+     * @param eventId - event id.
+     * @param email   - user email.
+     *
+     * @author Anton Bondar.
+     */
+    void saveEvent(Long eventId, String email);
+
+    /**
+     * Method for undoing the saving of an Event by ID.
+     *
+     * @param eventId - event id.
+     * @param email   - user email.
+     *
+     * @author Anton Bondar.
+     */
+    void undoSaveEvent(Long eventId, String email);
+
+    /**
      * Return Events searched by some query.
      *
      * @param paging - pagination params.

--- a/service-api/src/main/java/greencity/service/EventService.java
+++ b/service-api/src/main/java/greencity/service/EventService.java
@@ -83,24 +83,24 @@ public interface EventService {
     void removeAttender(Long eventId, String email);
 
     /**
-     * Method for saving an Event by ID.
+     * Method for adding an event to favorites by event id.
      *
      * @param eventId - event id.
      * @param email   - user email.
      *
      * @author Anton Bondar.
      */
-    void saveEvent(Long eventId, String email);
+    void addToFavorites(Long eventId, String email);
 
     /**
-     * Method for undoing the saving of an Event by ID.
+     * Method for removing an event from favorites by event id.
      *
      * @param eventId - event id.
      * @param email   - user email.
      *
      * @author Anton Bondar.
      */
-    void undoSaveEvent(Long eventId, String email);
+    void removeFromFavorites(Long eventId, String email);
 
     /**
      * Return Events searched by some query.

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -5,7 +5,13 @@ import greencity.client.RestClient;
 import greencity.constant.AppConstant;
 import greencity.constant.ErrorMessage;
 import greencity.dto.PageableAdvancedDto;
-import greencity.dto.event.*;
+import greencity.dto.event.AddEventDtoRequest;
+import greencity.dto.event.AddressDto;
+import greencity.dto.event.EventAttenderDto;
+import greencity.dto.event.EventDateLocationDto;
+import greencity.dto.event.EventDto;
+import greencity.dto.event.EventVO;
+import greencity.dto.event.UpdateEventDto;
 import greencity.dto.geocoding.AddressLatLngResponse;
 import greencity.dto.tag.TagVO;
 import greencity.entity.Tag;
@@ -33,7 +39,12 @@ import org.springframework.web.multipart.MultipartFile;
 import java.security.Principal;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
-import java.util.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -119,6 +130,7 @@ public class EventServiceImpl implements EventService {
         if (principal != null) {
             User user = modelMapper.map(restClient.findByEmail(principal.getName()), User.class);
             setSubscribes(events, eventDtos, user);
+            setFollowers(events, eventDtos, user);
         }
         return eventDtos;
     }
@@ -159,6 +171,15 @@ public class EventServiceImpl implements EventService {
         eventDtos.getPage().forEach(eventDto -> eventDto.setIsSubscribed(eventIds.contains(eventDto.getId())));
     }
 
+    private void setFollowers(Page<Event> events, PageableAdvancedDto<EventDto> eventDtos, User user) {
+        List<Long> eventIds = events.stream()
+            .filter(event -> event.getFollowers().stream().map(User::getId).collect(Collectors.toList())
+                .contains(user.getId()))
+            .map(Event::getId)
+            .collect(Collectors.toList());
+        eventDtos.getPage().forEach(eventDto -> eventDto.setIsSaved(eventIds.contains(eventDto.getId())));
+    }
+
     private PageableAdvancedDto<EventDto> buildPageableAdvancedDto(Page<Event> eventsPage) {
         List<EventDto> eventDtos = eventsPage.stream()
             .map(event -> modelMapper.map(event, EventDto.class))
@@ -186,17 +207,6 @@ public class EventServiceImpl implements EventService {
         eventRepo.save(event);
     }
 
-    private void checkAttenderToJoinTheEvent(Event event, User user) {
-        if (Objects.equals(event.getOrganizer().getId(), user.getId())) {
-            throw new BadRequestException(ErrorMessage.YOU_ARE_EVENT_ORGANIZER);
-        } else if (!event.isOpen()
-            && userRepo.findUserByIdAndByFriendId(user.getId(), event.getOrganizer().getId()).isEmpty()) {
-            throw new BadRequestException(ErrorMessage.YOU_CANNOT_SUBSCRIBE_TO_CLOSE_EVENT);
-        } else if (event.getAttenders().stream().anyMatch(a -> a.getId().equals(user.getId()))) {
-            throw new BadRequestException(ErrorMessage.HAVE_ALREADY_SUBSCRIBED_ON_EVENT);
-        }
-    }
-
     @Override
     public void removeAttender(Long eventId, String email) {
         Event event =
@@ -207,6 +217,40 @@ public class EventServiceImpl implements EventService {
             .collect(Collectors.toSet()));
 
         eventRepo.save(event);
+    }
+
+    @Override
+    public void saveEvent(Long eventId, String email) {
+        Event event = eventRepo.findById(eventId)
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND));
+        User currentUser = modelMapper.map(restClient.findByEmail(email), User.class);
+
+        event.getFollowers().add(currentUser);
+        eventRepo.save(event);
+    }
+
+    @Override
+    public void undoSaveEvent(Long eventId, String email) {
+        Event event = eventRepo.findById(eventId)
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND));
+        User currentUser = modelMapper.map(restClient.findByEmail(email), User.class);
+
+        event.setFollowers(event.getAttenders()
+            .stream()
+            .filter(user -> !user.getId().equals(currentUser.getId()))
+            .collect(Collectors.toSet()));
+        eventRepo.save(event);
+    }
+
+    private void checkAttenderToJoinTheEvent(Event event, User user) {
+        if (Objects.equals(event.getOrganizer().getId(), user.getId())) {
+            throw new BadRequestException(ErrorMessage.YOU_ARE_EVENT_ORGANIZER);
+        } else if (!event.isOpen()
+            && userRepo.findUserByIdAndByFriendId(user.getId(), event.getOrganizer().getId()).isEmpty()) {
+            throw new BadRequestException(ErrorMessage.YOU_CANNOT_SUBSCRIBE_TO_CLOSE_EVENT);
+        } else if (event.getAttenders().stream().anyMatch(a -> a.getId().equals(user.getId()))) {
+            throw new BadRequestException(ErrorMessage.HAVE_ALREADY_SUBSCRIBED_ON_EVENT);
+        }
     }
 
     @Override

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -207,6 +207,17 @@ public class EventServiceImpl implements EventService {
         eventRepo.save(event);
     }
 
+    private void checkAttenderToJoinTheEvent(Event event, User user) {
+        if (Objects.equals(event.getOrganizer().getId(), user.getId())) {
+            throw new BadRequestException(ErrorMessage.YOU_ARE_EVENT_ORGANIZER);
+        } else if (!event.isOpen()
+                && userRepo.findUserByIdAndByFriendId(user.getId(), event.getOrganizer().getId()).isEmpty()) {
+            throw new BadRequestException(ErrorMessage.YOU_CANNOT_SUBSCRIBE_TO_CLOSE_EVENT);
+        } else if (event.getAttenders().stream().anyMatch(a -> a.getId().equals(user.getId()))) {
+            throw new BadRequestException(ErrorMessage.HAVE_ALREADY_SUBSCRIBED_ON_EVENT);
+        }
+    }
+
     @Override
     public void removeAttender(Long eventId, String email) {
         Event event =
@@ -252,17 +263,6 @@ public class EventServiceImpl implements EventService {
             .filter(user -> !user.getId().equals(currentUser.getId()))
             .collect(Collectors.toSet()));
         eventRepo.save(event);
-    }
-
-    private void checkAttenderToJoinTheEvent(Event event, User user) {
-        if (Objects.equals(event.getOrganizer().getId(), user.getId())) {
-            throw new BadRequestException(ErrorMessage.YOU_ARE_EVENT_ORGANIZER);
-        } else if (!event.isOpen()
-            && userRepo.findUserByIdAndByFriendId(user.getId(), event.getOrganizer().getId()).isEmpty()) {
-            throw new BadRequestException(ErrorMessage.YOU_CANNOT_SUBSCRIBE_TO_CLOSE_EVENT);
-        } else if (event.getAttenders().stream().anyMatch(a -> a.getId().equals(user.getId()))) {
-            throw new BadRequestException(ErrorMessage.HAVE_ALREADY_SUBSCRIBED_ON_EVENT);
-        }
     }
 
     @Override

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -177,7 +177,7 @@ public class EventServiceImpl implements EventService {
                 .contains(user.getId()))
             .map(Event::getId)
             .collect(Collectors.toList());
-        eventDtos.getPage().forEach(eventDto -> eventDto.setIsSaved(eventIds.contains(eventDto.getId())));
+        eventDtos.getPage().forEach(eventDto -> eventDto.setIsFavorite(eventIds.contains(eventDto.getId())));
     }
 
     private PageableAdvancedDto<EventDto> buildPageableAdvancedDto(Page<Event> eventsPage) {
@@ -220,7 +220,7 @@ public class EventServiceImpl implements EventService {
     }
 
     @Override
-    public void saveEvent(Long eventId, String email) {
+    public void addToFavorites(Long eventId, String email) {
         Event event = eventRepo.findById(eventId)
             .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND));
         User currentUser = modelMapper.map(restClient.findByEmail(email), User.class);
@@ -230,7 +230,7 @@ public class EventServiceImpl implements EventService {
     }
 
     @Override
-    public void undoSaveEvent(Long eventId, String email) {
+    public void removeFromFavorites(Long eventId, String email) {
         Event event = eventRepo.findById(eventId)
             .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND));
         User currentUser = modelMapper.map(restClient.findByEmail(email), User.class);

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -211,7 +211,7 @@ public class EventServiceImpl implements EventService {
         if (Objects.equals(event.getOrganizer().getId(), user.getId())) {
             throw new BadRequestException(ErrorMessage.YOU_ARE_EVENT_ORGANIZER);
         } else if (!event.isOpen()
-                && userRepo.findUserByIdAndByFriendId(user.getId(), event.getOrganizer().getId()).isEmpty()) {
+            && userRepo.findUserByIdAndByFriendId(user.getId(), event.getOrganizer().getId()).isEmpty()) {
             throw new BadRequestException(ErrorMessage.YOU_CANNOT_SUBSCRIBE_TO_CLOSE_EVENT);
         } else if (event.getAttenders().stream().anyMatch(a -> a.getId().equals(user.getId()))) {
             throw new BadRequestException(ErrorMessage.HAVE_ALREADY_SUBSCRIBED_ON_EVENT);

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -222,8 +222,14 @@ public class EventServiceImpl implements EventService {
     @Override
     public void addToFavorites(Long eventId, String email) {
         Event event = eventRepo.findById(eventId)
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND));
-        User currentUser = modelMapper.map(restClient.findByEmail(email), User.class);
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + eventId));
+
+        User currentUser = userRepo.findByEmail(email)
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_EMAIL + email));
+
+        if (event.getFollowers().contains(currentUser)) {
+            throw new BadRequestException(ErrorMessage.USER_HAS_ALREADY_ADDED_EVENT_TO_FAVORITES);
+        }
 
         event.getFollowers().add(currentUser);
         eventRepo.save(event);
@@ -232,8 +238,14 @@ public class EventServiceImpl implements EventService {
     @Override
     public void removeFromFavorites(Long eventId, String email) {
         Event event = eventRepo.findById(eventId)
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND));
-        User currentUser = modelMapper.map(restClient.findByEmail(email), User.class);
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + eventId));
+
+        User currentUser = userRepo.findByEmail(email)
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_EMAIL + email));
+
+        if (!event.getFollowers().contains(currentUser)) {
+            throw new BadRequestException(ErrorMessage.EVENT_IS_NOT_IN_FAVORITES);
+        }
 
         event.setFollowers(event.getAttenders()
             .stream()

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -15,7 +15,6 @@ import greencity.dto.achievement.UserAchievementVO;
 import greencity.dto.achievement.UserVOAchievement;
 import greencity.dto.achievementcategory.AchievementCategoryDto;
 import greencity.dto.achievementcategory.AchievementCategoryVO;
-import greencity.dto.advice.AdviceDto;
 import greencity.dto.advice.AdvicePostDto;
 import greencity.dto.advice.AdviceTranslationVO;
 import greencity.dto.advice.AdviceVO;
@@ -39,7 +38,6 @@ import greencity.dto.econewscomment.EcoNewsCommentAuthorDto;
 import greencity.dto.econewscomment.EcoNewsCommentDto;
 import greencity.dto.econewscomment.EcoNewsCommentVO;
 import greencity.dto.event.AddEventDtoRequest;
-import greencity.dto.event.AddEventDtoResponse;
 import greencity.dto.event.AddressDto;
 import greencity.dto.event.EventAttenderDto;
 import greencity.dto.event.EventAuthorDto;
@@ -51,8 +49,6 @@ import greencity.dto.eventcomment.AddEventCommentDtoRequest;
 import greencity.dto.eventcomment.AddEventCommentDtoResponse;
 import greencity.dto.eventcomment.EventCommentAuthorDto;
 import greencity.dto.eventcomment.EventCommentDto;
-import greencity.dto.eventcomment.EventCommentForSendEmailDto;
-import greencity.dto.eventcomment.EventCommentVO;
 import greencity.dto.factoftheday.FactOfTheDayDTO;
 import greencity.dto.factoftheday.FactOfTheDayPostDTO;
 import greencity.dto.factoftheday.FactOfTheDayTranslationDTO;
@@ -113,14 +109,11 @@ import greencity.dto.tag.TagTranslationVO;
 import greencity.dto.tag.TagUaEnDto;
 import greencity.dto.tag.TagVO;
 import greencity.dto.tag.TagViewDto;
-import greencity.dto.user.AuthorDto;
 import greencity.dto.user.EcoNewsAuthorDto;
 import greencity.dto.user.HabitIdRequestDto;
-import greencity.dto.user.RecommendedFriendDto;
 import greencity.dto.user.UserFilterDtoRequest;
 import greencity.dto.user.UserFilterDtoResponse;
 import greencity.dto.user.UserManagementVO;
-import greencity.dto.user.UserProfilePictureDto;
 import greencity.dto.user.UserShoppingListItemAdvanceDto;
 import greencity.dto.user.UserShoppingListItemResponseDto;
 import greencity.dto.user.UserShoppingListItemVO;
@@ -221,7 +214,6 @@ public class ModelUtils {
     public static LocalDateTime localDateTime = LocalDateTime.now();
     public static String HABIT_TRANSLATION_NAME = "use shopper";
     public static String HABIT_TRANSLATION_DESCRIPTION = "Description";
-    public static String TAG_TRANSLATION_NAME = "Reusable";
     public static String SHOPPING_LIST_TEXT = "buy a shopper";
     public static String HABIT_ITEM = "Item";
 
@@ -291,10 +283,6 @@ public class ModelUtils {
             .verifyEmail(new VerifyEmail())
             .dateOfRegistration(localDateTime)
             .build();
-    }
-
-    public static RecommendedFriendDto getRecommendedFriendDto() {
-        return new RecommendedFriendDto(1L, TestConst.NAME, "profile");
     }
 
     public static List<User> getFriendsList() {
@@ -641,12 +629,6 @@ public class ModelUtils {
             .build();
     }
 
-    public static List<String> getTagsForTestingString() {
-        List<String> tags = new ArrayList<>();
-        tags.add("News");
-        return tags;
-    }
-
     public static List<UserShoppingListItem> getUserShoppingListItemList() {
         List<UserShoppingListItem> getUserShoppingListItemList = new ArrayList();
         getUserShoppingListItemList.add(getFullUserShoppingListItem());
@@ -908,10 +890,6 @@ public class ModelUtils {
         return new EcoNewsAuthorDto(1L, TestConst.NAME);
     }
 
-    public static UserProfilePictureDto getUserProfilePictureDto() {
-        return new UserProfilePictureDto(1L, "name", "image");
-    }
-
     public static FactOfTheDayTranslationDTO getFactOfTheDayTranslationDTO() {
         return new FactOfTheDayTranslationDTO(1L, "content");
     }
@@ -962,26 +940,12 @@ public class ModelUtils {
                 .build());
     }
 
-    public static List<TagTranslationVO> getEventTagTranslationsVO() {
-        return Arrays.asList(TagTranslationVO.builder().id(1L).name("Соціальний")
-            .languageVO(LanguageVO.builder().id(1L).code("ua").build()).build(),
-            TagTranslationVO.builder().id(2L).name("Social").languageVO(LanguageVO.builder().id(2L).code("en").build())
-                .build(),
-            TagTranslationVO.builder().id(3L).name("Соціальний")
-                .languageVO(LanguageVO.builder().id(3L).code("ru").build())
-                .build());
-    }
-
     public static LanguageVO getLanguageVO() {
         return new LanguageVO(1L, AppConstant.DEFAULT_LANGUAGE_CODE);
     }
 
     public static TagVO getTagVO() {
         return new TagVO(1L, TagType.ECO_NEWS, getTagTranslationsVO(), null, null, null);
-    }
-
-    public static TagVO getEventTagVO() {
-        return new TagVO(1L, TagType.EVENT, getEventTagTranslationsVO(), null, null, null);
     }
 
     public static TagPostDto getTagPostDto() {
@@ -1089,7 +1053,7 @@ public class ModelUtils {
             .deleted(false)
             .currentUserLiked(true)
             .createdDate(LocalDateTime.of(2020, 11, 7, 12, 42))
-            .usersLiked(new HashSet<UserVO>(Arrays.asList(
+            .usersLiked(new HashSet<>(Arrays.asList(
                 UserVO.builder()
                     .id(76L)
                     .build(),
@@ -1128,7 +1092,7 @@ public class ModelUtils {
                 .currentUserLiked(true)
                 .parentComment(null)
                 .createdDate(LocalDateTime.of(2020, 11, 7, 12, 42))
-                .usersLiked(new HashSet<UserVO>(Arrays.asList(
+                .usersLiked(new HashSet<>(Arrays.asList(
                     UserVO.builder()
                         .id(76L)
                         .build(),
@@ -1145,7 +1109,7 @@ public class ModelUtils {
             .deleted(false)
             .currentUserLiked(true)
             .createdDate(LocalDateTime.of(2020, 11, 7, 12, 42))
-            .usersLiked(new HashSet<UserVO>(Arrays.asList(
+            .usersLiked(new HashSet<>(Arrays.asList(
                 UserVO.builder()
                     .id(76L)
                     .build(),
@@ -1183,13 +1147,6 @@ public class ModelUtils {
             .likes(0)
             .currentUserLiked(false)
             .status(CommentStatus.ORIGINAL)
-            .build();
-    }
-
-    private static AuthorDto getAuthorDto() {
-        return AuthorDto.builder()
-            .id(1L)
-            .name("author")
             .build();
     }
 
@@ -1270,14 +1227,6 @@ public class ModelUtils {
             .build();
     }
 
-    public static AdviceDto getAdviceDto() {
-        return AdviceDto.builder()
-            .id(1L)
-            .content("name")
-            .habit(getHabitDto())
-            .build();
-    }
-
     public static List<HabitFactTranslationUpdateDto> getHabitFactTranslationUpdateDtos() {
         return new ArrayList<>(Arrays.asList(
             HabitFactTranslationUpdateDto.builder().content("ua").factOfDayStatus(FactOfDayStatus.POTENTIAL)
@@ -1318,14 +1267,6 @@ public class ModelUtils {
                 .translations(adviceTranslations).build(),
             Advice.builder().id(2L).habit(Habit.builder().id(1L).build()).translations(adviceTranslations).build(),
             Advice.builder().id(3L).habit(Habit.builder().id(1L).build()).translations(adviceTranslations).build()));
-    }
-
-    public static List<AdviceVO> getAdviceVOs() {
-        List<AdviceTranslationVO> adviceTranslationVOs = getAdviceTranslationVOs();
-        return new ArrayList<>(Arrays.asList(
-            AdviceVO.builder().id(1L).habit(new HabitIdRequestDto(1L)).translations(adviceTranslationVOs).build(),
-            AdviceVO.builder().id(2L).habit(new HabitIdRequestDto(1L)).translations(adviceTranslationVOs).build(),
-            AdviceVO.builder().id(3L).habit(new HabitIdRequestDto(1L)).translations(adviceTranslationVOs).build()));
     }
 
     public static Habit getHabit() {
@@ -1729,8 +1670,6 @@ public class ModelUtils {
                     .build())
                 .expiryDate(LocalDateTime.of(2021, 7, 7, 7, 7))
                 .token("toooookkkeeeeen42324532542")
-//                        .rating(13.4)
-//                        .em
                 .build())
             .userFriends(Collections.singletonList(
                 UserVO.builder()
@@ -1800,19 +1739,6 @@ public class ModelUtils {
             .build();
     }
 
-    public static HabitAssign buildHabitAssign() {
-        return HabitAssign.builder()
-            .habit(getHabit())
-            .status(HabitAssignStatus.INPROGRESS)
-            .createDate(ZonedDateTime.now())
-            .user(getUser())
-            .duration(1)
-            .habitStreak(0)
-            .workingDays(0)
-            .lastEnrollmentDate(ZonedDateTime.now())
-            .build();
-    }
-
     public static CustomShoppingListItemResponseDto getCustomShoppingListItemResponseDto() {
         return CustomShoppingListItemResponseDto.builder()
             .id(1L)
@@ -1831,10 +1757,13 @@ public class ModelUtils {
 
     public static Event getEvent() {
         Event event = new Event();
+        Set<User> followers = new HashSet<>();
+        followers.add(getUser());
         event.setOpen(true);
         event.setDescription("Description");
         event.setId(1L);
         event.setOrganizer(getUser());
+        event.setFollowers(followers);
         event.setTitle("Title");
         List<EventDateLocation> dates = new ArrayList<>();
         dates.add(new EventDateLocation(1L, event,
@@ -1911,23 +1840,6 @@ public class ModelUtils {
         return event;
     }
 
-    public static Event getUnfinishedEvent() {
-        Event event = new Event();
-        event.setDescription("Description");
-        event.setId(1L);
-        event.setOrganizer(getUser());
-        event.setTitle("Title");
-        List<EventDateLocation> dates = new ArrayList<>();
-        dates.add(new EventDateLocation(1L, event,
-            ZonedDateTime.now().plusDays(1),
-            ZonedDateTime.now().plusDays(1).plusSeconds(1),
-            getAddress(), null));
-        event.setDates(dates);
-        event.setTags(List.of(getEventTag()));
-        event.setTitleImage(AppConstant.DEFAULT_HABIT_IMAGE);
-        return event;
-    }
-
     public static Event getEventWithoutAddress() {
         Event event = new Event();
 
@@ -1947,19 +1859,6 @@ public class ModelUtils {
         event.setDates(dates);
         event.setTags(List.of(getEventTag()));
         return event;
-    }
-
-    public static AddEventDtoResponse getAddEventDtoResponse() {
-        return AddEventDtoResponse.builder()
-            .id(1L)
-            .dates(new ArrayList<>())
-            .title("Title")
-            .description("Description")
-            .organizer(EventAuthorDto.builder()
-                .id(1L)
-                .name("User")
-                .build())
-            .build();
     }
 
     public static MultipartFile getMultipartFile() {
@@ -2609,23 +2508,6 @@ public class ModelUtils {
             .build();
     }
 
-    public static EventCommentVO getEventCommentVO() {
-        return EventCommentVO.builder()
-            .id(278L)
-            .user(UserVO.builder()
-                .id(13L)
-                .role(Role.ROLE_ADMIN)
-                .name("name")
-                .build())
-            .text("I find this topic very useful!")
-            .createdDate(LocalDateTime.of(2020, 11, 7, 12, 42))
-            .usersLiked(new HashSet<>())
-            .event(EventVO.builder()
-                .id(32L)
-                .build())
-            .build();
-    }
-
     public static EventCommentAuthorDto getEventCommentAuthorDto() {
         return EventCommentAuthorDto.builder()
             .id(getUser().getId())
@@ -2656,16 +2538,6 @@ public class ModelUtils {
             .organizer(getUserVO())
             .title("title")
             .titleImage("title image")
-            .build();
-    }
-
-    public static EventCommentForSendEmailDto getEventCommentForSendEmailDto() {
-        return EventCommentForSendEmailDto.builder()
-            .id(1L)
-            .organizer(ModelUtils.getEventAuthorDto())
-            .createdDate(LocalDateTime.now())
-            .author(ModelUtils.getEventCommentAuthorDto())
-            .text("text")
             .build();
     }
 

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -68,20 +68,28 @@ import static org.mockito.Mockito.when;
 class EventServiceImplTest {
     @Mock
     ModelMapper modelMapper;
+
     @Mock
     EventRepo eventRepo;
+
     @Mock
     RestClient restClient;
+
     @Mock
+
     TagsService tagService;
     @Mock
     UserService userService;
+
     @Mock
     FileService fileService;
+
     @Mock
     GoogleApiService googleApiService;
+
     @Mock
     UserRepo userRepo;
+
     @InjectMocks
     EventServiceImpl eventService;
 
@@ -672,49 +680,90 @@ class EventServiceImplTest {
     void addToFavoritesTest() {
         Event event = ModelUtils.getEvent();
         User user = ModelUtils.getUser();
+        user.setId(2L);
 
         when(eventRepo.findById(any())).thenReturn(Optional.of(event));
-        when(modelMapper.map(restClient.findByEmail(ModelUtils.getUserVO().getEmail()), User.class))
-            .thenReturn(user);
+        when(userRepo.findByEmail(TestConst.EMAIL)).thenReturn(Optional.of(user));
         when(eventRepo.save(event)).thenReturn(event);
 
         eventService.addToFavorites(1L, TestConst.EMAIL);
 
         verify(eventRepo).findById(any());
-        verify(modelMapper).map(restClient.findByEmail(ModelUtils.getUserVO().getEmail()), User.class);
+        verify(userRepo).findByEmail(TestConst.EMAIL);
         verify(eventRepo).save(event);
     }
 
     @Test
-    void addToFavoritesThrowNotFoundExceptionTest() {
+    void addToFavoritesThrowsExceptionWhenEventNotFoundTest() {
         when(eventRepo.findById(any())).thenThrow(NotFoundException.class);
         assertThrows(NotFoundException.class, () -> eventService.addToFavorites(1L, TestConst.EMAIL));
         verify(eventRepo).findById(any());
     }
 
     @Test
-    void removeFromFavoritesTest() {
-        Event event = ModelUtils.getEvent();
-        Set<User> userSet = new HashSet<>();
-        User user = ModelUtils.getUser();
-        user.setId(22L);
-        userSet.add(user);
-        event.setFollowers(userSet);
-        when(eventRepo.findById(any())).thenReturn(Optional.of(event));
-        when(modelMapper.map(restClient.findByEmail(ModelUtils.getUserVO().getEmail()), User.class)).thenReturn(user);
-
-        eventService.removeFromFavorites(event.getId(), user.getEmail());
-
-        verify(eventRepo).save(event);
+    void addToFavoritesThrowsExceptionWhenUserNotFoundTest() {
+        when(userRepo.findById(any())).thenThrow(NotFoundException.class);
+        assertThrows(NotFoundException.class, () -> eventService.addToFavorites(1L, TestConst.EMAIL));
         verify(eventRepo).findById(any());
-        verify(modelMapper).map(restClient.findByEmail(ModelUtils.getUserVO().getEmail()), User.class);
     }
 
     @Test
-    void removeFromFavoritesThrowNotFoundExceptionTest() {
+    void addToFavoritesThrowsExceptionWhenUserHasAlreadyAddedEventToFavoritesTest() {
+        Event event = ModelUtils.getEvent();
+        User user = ModelUtils.getUser();
+
+        when(eventRepo.findById(any())).thenReturn(Optional.of(event));
+        when(userRepo.findByEmail(TestConst.EMAIL)).thenReturn(Optional.of(user));
+
+        assertThrows(BadRequestException.class, () -> eventService.addToFavorites(1L, TestConst.EMAIL));
+
+        verify(eventRepo).findById(any());
+        verify(userRepo).findByEmail(TestConst.EMAIL);
+    }
+
+    @Test
+    void removeFromFavoritesTest() {
+        Event event = ModelUtils.getEvent();
+        User user = ModelUtils.getUser();
+
+        when(eventRepo.findById(any())).thenReturn(Optional.of(event));
+        when(userRepo.findByEmail(TestConst.EMAIL)).thenReturn(Optional.of(user));
+        when(eventRepo.save(event)).thenReturn(event);
+
+        eventService.removeFromFavorites(1L, TestConst.EMAIL);
+
+        verify(eventRepo).findById(any());
+        verify(userRepo).findByEmail(TestConst.EMAIL);
+        verify(eventRepo).save(event);
+    }
+
+    @Test
+    void removeFromFavoritesThrowsExceptionWhenEventNotFoundTest() {
         when(eventRepo.findById(any())).thenThrow(NotFoundException.class);
         assertThrows(NotFoundException.class, () -> eventService.removeFromFavorites(1L, TestConst.EMAIL));
         verify(eventRepo).findById(any());
+    }
+
+    @Test
+    void removeFromFavoritesThrowsExceptionWhenUserNotFoundTest() {
+        when(userRepo.findById(any())).thenThrow(NotFoundException.class);
+        assertThrows(NotFoundException.class, () -> eventService.removeFromFavorites(1L, TestConst.EMAIL));
+        verify(eventRepo).findById(any());
+    }
+
+    @Test
+    void removeFromFavoritesThrowsExceptionWhenEventIsNotInFavoritesTest() {
+        Event event = ModelUtils.getEvent();
+        User user = ModelUtils.getUser();
+        user.setId(2L);
+
+        when(eventRepo.findById(any())).thenReturn(Optional.of(event));
+        when(userRepo.findByEmail(TestConst.EMAIL)).thenReturn(Optional.of(user));
+
+        assertThrows(BadRequestException.class, () -> eventService.removeFromFavorites(1L, TestConst.EMAIL));
+
+        verify(eventRepo).findById(any());
+        verify(userRepo).findByEmail(TestConst.EMAIL);
     }
 
     @Test

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -669,7 +669,7 @@ class EventServiceImplTest {
     }
 
     @Test
-    void saveEventTest() {
+    void addToFavoritesTest() {
         Event event = ModelUtils.getEvent();
         User user = ModelUtils.getUser();
 
@@ -678,7 +678,7 @@ class EventServiceImplTest {
             .thenReturn(user);
         when(eventRepo.save(event)).thenReturn(event);
 
-        eventService.saveEvent(1L, TestConst.EMAIL);
+        eventService.addToFavorites(1L, TestConst.EMAIL);
 
         verify(eventRepo).findById(any());
         verify(modelMapper).map(restClient.findByEmail(ModelUtils.getUserVO().getEmail()), User.class);
@@ -686,14 +686,14 @@ class EventServiceImplTest {
     }
 
     @Test
-    void saveEventThrowNotFoundExceptionTest() {
+    void addToFavoritesThrowNotFoundExceptionTest() {
         when(eventRepo.findById(any())).thenThrow(NotFoundException.class);
-        assertThrows(NotFoundException.class, () -> eventService.saveEvent(1L, TestConst.EMAIL));
+        assertThrows(NotFoundException.class, () -> eventService.addToFavorites(1L, TestConst.EMAIL));
         verify(eventRepo).findById(any());
     }
 
     @Test
-    void undoSaveEventTest() {
+    void removeFromFavoritesTest() {
         Event event = ModelUtils.getEvent();
         Set<User> userSet = new HashSet<>();
         User user = ModelUtils.getUser();
@@ -703,7 +703,7 @@ class EventServiceImplTest {
         when(eventRepo.findById(any())).thenReturn(Optional.of(event));
         when(modelMapper.map(restClient.findByEmail(ModelUtils.getUserVO().getEmail()), User.class)).thenReturn(user);
 
-        eventService.undoSaveEvent(event.getId(), user.getEmail());
+        eventService.removeFromFavorites(event.getId(), user.getEmail());
 
         verify(eventRepo).save(event);
         verify(eventRepo).findById(any());
@@ -711,9 +711,9 @@ class EventServiceImplTest {
     }
 
     @Test
-    void undoSaveEventThrowNotFoundExceptionTest() {
+    void removeFromFavoritesThrowNotFoundExceptionTest() {
         when(eventRepo.findById(any())).thenThrow(NotFoundException.class);
-        assertThrows(NotFoundException.class, () -> eventService.undoSaveEvent(1L, TestConst.EMAIL));
+        assertThrows(NotFoundException.class, () -> eventService.removeFromFavorites(1L, TestConst.EMAIL));
         verify(eventRepo).findById(any());
     }
 

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -76,8 +76,8 @@ class EventServiceImplTest {
     RestClient restClient;
 
     @Mock
-
     TagsService tagService;
+
     @Mock
     UserService userService;
 


### PR DESCRIPTION
# GreenCity PR
https://github.com/ita-social-projects/GreenCity/issues/5856

## Summary Of Changes :fire:
Enabled the ability to add or remove events from favorites and retrieve all favorites events.
## Issue Link :clipboard:
_&lt;Link to the issue&gt;_

## Added
* Added new endpoints for adding or removing events from favorites.
* Added tests to cover all new lines of code.

## Changed
* _&lt;detail item of what was changed&gt;_

## Deleted
* _&lt;detail item of what was removed&gt;_

## How to test :clipboard:
In can be test via swagger in [events-controller]:
[/events/addToFavorites/{eventId}]
[/events/removeFromFavorites/{eventId}]
[/events]

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
