### PR TITLE
#5855 [GreenCity] Add formatted address field to EventDateLocation Address

### DIFF
--- a/dao/src/main/java/greencity/entity/event/Address.java
+++ b/dao/src/main/java/greencity/entity/event/Address.java
@@ -46,4 +46,10 @@ public final class Address {
 
     @Column
     private String countryUa;
+
+    @Column
+    private String formattedAddressEn;
+
+    @Column
+    private String formattedAddressUa;
 }

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -154,5 +154,6 @@
     <include file="/db/changelog/logs/ch-add-table-employee-positions-mapping-Bondar.xml"/>
     <include file="db/changelog/logs/ch-change-table-events-dates-locations-dropNotNullConstraint-Seti.xml"/>
     <include file="db/changelog/logs/ch-update-employee_authorities-table-name-value-Bondar.xml"/>
+    <include file="db/changelog/logs/ch-add-formatted_address-to-event_dates_locations-Lenets.xml"/>
 </databaseChangeLog>
 

--- a/dao/src/main/resources/db/changelog/logs/ch-add-formatted_address-to-event_dates_locations-Lenets.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-add-formatted_address-to-event_dates_locations-Lenets.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet id="Lenets-3" author="Maksym Lenets">
+        <addColumn tableName="events_dates_locations">
+            <column name="formatted_address_en"  type="varchar(255)">
+            <constraints nullable="true"/>
+            </column>
+        </addColumn>
+
+        <addColumn tableName="events_dates_locations">
+            <column name="formatted_address_ua"  type="varchar(255)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service-api/src/main/java/greencity/dto/event/AddressDto.java
+++ b/service-api/src/main/java/greencity/dto/event/AddressDto.java
@@ -21,4 +21,6 @@ public class AddressDto {
     private String regionUa;
     private String countryEn;
     private String countryUa;
+    private String formattedAddressEn;
+    private String formattedAddressUa;
 }

--- a/service-api/src/main/java/greencity/dto/geocoding/AddressResponse.java
+++ b/service-api/src/main/java/greencity/dto/geocoding/AddressResponse.java
@@ -19,4 +19,5 @@ public class AddressResponse {
     private String city;
     private String region;
     private String country;
+    private String formattedAddress;
 }

--- a/service/src/main/java/greencity/mapping/AddressLatLngResponseMapper.java
+++ b/service/src/main/java/greencity/mapping/AddressLatLngResponseMapper.java
@@ -20,12 +20,14 @@ public class AddressLatLngResponseMapper extends AbstractConverter<AddressLatLng
             addressDto.setCityUa(addressLatLngResponse.getAddressUa().getCity());
             addressDto.setRegionUa(addressLatLngResponse.getAddressUa().getRegion());
             addressDto.setCountryUa(addressLatLngResponse.getAddressUa().getCountry());
+            addressDto.setFormattedAddressUa(addressLatLngResponse.getAddressUa().getFormattedAddress());
         }
         if (addressLatLngResponse.getAddressEn() != null) {
             addressDto.setStreetEn(addressLatLngResponse.getAddressEn().getStreet());
             addressDto.setCityEn(addressLatLngResponse.getAddressEn().getCity());
             addressDto.setRegionEn(addressLatLngResponse.getAddressEn().getRegion());
             addressDto.setCountryEn(addressLatLngResponse.getAddressEn().getCountry());
+            addressDto.setFormattedAddressEn(addressLatLngResponse.getAddressEn().getFormattedAddress());
         }
         return addressDto;
     }

--- a/service/src/main/java/greencity/mapping/events/AddEventDtoRequestMapper.java
+++ b/service/src/main/java/greencity/mapping/events/AddEventDtoRequestMapper.java
@@ -59,7 +59,6 @@ public class AddEventDtoRequestMapper extends AbstractConverter<AddEventDtoReque
     }
 
     private boolean addressIsNotValid(AddressDto dto) {
-        return dto.getStreetUa() == null || dto.getCityUa() == null
-            || dto.getRegionUa() == null || dto.getCountryUa() == null;
+        return dto.getRegionUa() == null || dto.getCountryUa() == null;
     }
 }

--- a/service/src/main/java/greencity/mapping/events/AddressDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/events/AddressDtoMapper.java
@@ -21,6 +21,8 @@ public class AddressDtoMapper extends AbstractConverter<AddressDto, Address> {
             .regionUa(addressDto.getRegionUa())
             .countryEn(addressDto.getCountryEn())
             .countryUa(addressDto.getCountryUa())
+            .formattedAddressEn(addressDto.getFormattedAddressEn())
+            .formattedAddressUa(addressDto.getFormattedAddressUa())
             .build();
     }
 }

--- a/service/src/main/java/greencity/mapping/events/EventDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/events/EventDtoMapper.java
@@ -83,7 +83,10 @@ public class EventDtoMapper extends AbstractConverter<Event, EventDto> {
                 .regionEn(address.getRegionEn())
                 .regionUa(address.getRegionUa())
                 .countryEn(address.getCountryEn())
-                .countryUa(address.getCountryUa()).build();
+                .countryUa(address.getCountryUa())
+                .formattedAddressEn(address.getFormattedAddressEn())
+                .formattedAddressUa(address.getFormattedAddressUa())
+                .build();
             eventDateLocationDto.setCoordinates(addressDto);
         }
         return eventDateLocationDto;

--- a/service/src/main/java/greencity/mapping/events/EventDtoToEventMapper.java
+++ b/service/src/main/java/greencity/mapping/events/EventDtoToEventMapper.java
@@ -50,17 +50,17 @@ public class EventDtoToEventMapper extends AbstractConverter<EventDto, Event> {
             event.setAdditionalImages(eventImages);
         }
 
-        List<EventDateLocation> eventDateLocationsDto = new ArrayList<>();
+        List<EventDateLocation> eventDateLocations = new ArrayList<>();
         for (var date : eventDto.getDates()) {
             AddressDto addressDto = date.getCoordinates();
-            eventDateLocationsDto.add(EventDateLocation.builder()
+            eventDateLocations.add(EventDateLocation.builder()
                 .startDate(date.getStartDate())
                 .finishDate(date.getFinishDate())
                 .address(mapper.convert(addressDto))
                 .onlineLink(date.getOnlineLink())
                 .event(event).build());
         }
-        event.setDates(eventDateLocationsDto);
+        event.setDates(eventDateLocations);
 
         return event;
     }

--- a/service/src/main/java/greencity/service/GoogleApiService.java
+++ b/service/src/main/java/greencity/service/GoogleApiService.java
@@ -80,7 +80,7 @@ public class GoogleApiService {
         try {
             GeocodingResult[] results = GeocodingApi.newRequest(context)
                 .latlng(latLng).language(locale.getLanguage()).await();
-            return getAddressResponse(results[0].addressComponents);
+            return getAddressResponse(results[0]);
         } catch (IOException | InterruptedException | ApiException e) {
             log.error("Occurred error during the call on google API, reason: {}", e.getMessage());
             Thread.currentThread().interrupt();
@@ -88,8 +88,10 @@ public class GoogleApiService {
         }
     }
 
-    private AddressResponse getAddressResponse(AddressComponent[] addressComponents) {
+    private AddressResponse getAddressResponse(GeocodingResult geocodingResult) {
+        AddressComponent[] addressComponents = geocodingResult.addressComponents;
         AddressResponse addressResponse = new AddressResponse();
+        addressResponse.setFormattedAddress(geocodingResult.formattedAddress);
         for (AddressComponent component : addressComponents) {
             List<AddressComponentType> componentTypes = Arrays.asList(component.types);
             if (componentTypes.contains(AddressComponentType.STREET_NUMBER)) {

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -2333,6 +2333,8 @@ public class ModelUtils {
     public static GeocodingResult[] getGeocodingResultUk() {
         GeocodingResult geocodingResult = new GeocodingResult();
 
+        geocodingResult.formattedAddress = "Повна відформатована адреса";
+
         AddressComponent route = new AddressComponent();
         route.longName = "вулиця";
         route.types = new AddressComponentType[] {AddressComponentType.ROUTE};
@@ -2366,6 +2368,8 @@ public class ModelUtils {
 
     public static GeocodingResult[] getGeocodingResultEn() {
         GeocodingResult geocodingResult = new GeocodingResult();
+
+        geocodingResult.formattedAddress = "Full formatted address";
 
         AddressComponent route = new AddressComponent();
         route.longName = "fake street name";

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -2410,6 +2410,7 @@ public class ModelUtils {
                 .city("fake city")
                 .region("fake region")
                 .country("fake country")
+                .formattedAddress("Full formatted address")
                 .build())
             .addressUa(AddressResponse
                 .builder()
@@ -2418,6 +2419,7 @@ public class ModelUtils {
                 .city("місто")
                 .region("область")
                 .country("країна")
+                .formattedAddress("Повна відформатована адреса")
                 .build())
             .build();
     }
@@ -2511,6 +2513,8 @@ public class ModelUtils {
             .regionEn("Oblast")
             .countryUa("Країна")
             .countryEn("Country")
+            .formattedAddressEn("Full formatted address")
+            .formattedAddressUa("Повна відформатована адреса")
             .build();
     }
 
@@ -2536,6 +2540,9 @@ public class ModelUtils {
             .regionUa("Область")
             .regionEn("Oblast")
             .countryUa("Країна")
+            .countryEn("Country")
+            .formattedAddressEn("Full formatted address")
+            .formattedAddressUa("Повна відформатована адреса")
             .countryEn("Country")
             .build();
     }

--- a/service/src/test/java/greencity/mapping/AddressLatLngResponseMapperTest.java
+++ b/service/src/test/java/greencity/mapping/AddressLatLngResponseMapperTest.java
@@ -29,6 +29,7 @@ class AddressLatLngResponseMapperTest {
                 .city(expected.getCityUa())
                 .region(expected.getRegionUa())
                 .country(expected.getCountryUa())
+                .formattedAddress(expected.getFormattedAddressUa())
                 .build())
             .addressEn(AddressResponse
                 .builder()
@@ -37,6 +38,7 @@ class AddressLatLngResponseMapperTest {
                 .city(expected.getCityEn())
                 .region(expected.getRegionEn())
                 .country(expected.getCountryEn())
+                .formattedAddress(expected.getFormattedAddressEn())
                 .build())
             .build();
         Assertions.assertEquals(expected, mapper.convert(response));

--- a/service/src/test/java/greencity/mapping/events/AddEventDtoRequestMapperTest.java
+++ b/service/src/test/java/greencity/mapping/events/AddEventDtoRequestMapperTest.java
@@ -51,18 +51,6 @@ class AddEventDtoRequestMapperTest {
     }
 
     @Test
-    void convertTestWithNullStreetUa() {
-        AddEventDtoRequest request = ModelUtils.addEventDtoRequestWithNullStreetUa;
-        assertThrows(BadRequestException.class, () -> mapper.convert(request));
-    }
-
-    @Test
-    void convertTestWithNullCityUa() {
-        AddEventDtoRequest request = ModelUtils.addEventDtoRequestWithNullCityUa;
-        assertThrows(BadRequestException.class, () -> mapper.convert(request));
-    }
-
-    @Test
     void convertTestWithNullRegionUa() {
         AddEventDtoRequest request = ModelUtils.addEventDtoRequestWithNullRegionUa;
         assertThrows(BadRequestException.class, () -> mapper.convert(request));


### PR DESCRIPTION
## Summary Of Issue :
Some of the addresses returned by Google Api may not contain the "root" (street) name attribute, in this case we can use the formatted address that contains the most complete information about the address.

**Issue Link**
https://github.com/ita-social-projects/GreenCity/issues/5855

## Summary Of Changes :
1) Added formattedAddress field to Address entity and all associated DTOs.
2) Updated mappers.
3) Updated existing tests.
4) Updated liqubase changelog with new fields for events_dates_locations table.

## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] All files reviewed before sending to reviewers