### PR TITLE
[GreenCity] Remove duplicated dependency #6060

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -257,12 +257,6 @@
             <version>${test.containers.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <version>2.6.2</version>
-            <scope>test</scope>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/net.java.dev.jna/jna -->
         <dependency>
             <groupId>net.java.dev.jna</groupId>


### PR DESCRIPTION
## Summary Of Issue :
In core module, pom.xml file contains two duplicated dependency. Remove last one.
![image](https://github.com/ita-social-projects/GreenCity/assets/74297669/9c097482-ae75-4be1-a450-dac572f2e48a)
![image](https://github.com/ita-social-projects/GreenCity/assets/74297669/b6e9d7d1-58d4-47d6-8cab-517197ee74e9)



**Issue Link:**
https://github.com/ita-social-projects/GreenCity/issues/6039

## Summary Of Changes :
- Remove duplicated dependency

