### PR TITLE
Commit with implementation of filtration of user events by event type and sorting

### DIFF
--- a/core/src/main/java/greencity/controller/EventsController.java
+++ b/core/src/main/java/greencity/controller/EventsController.java
@@ -21,15 +21,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.Nullable;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import springfox.documentation.annotations.ApiIgnore;
 
@@ -51,20 +43,20 @@ public class EventsController {
      */
     @ApiOperation(value = "Create new event")
     @ApiResponses(value = {
-        @ApiResponse(code = 201, message = HttpStatuses.CREATED),
-        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(code = 201, message = HttpStatuses.CREATED),
+            @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
     })
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping(value = "/create",
-        consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_UTF8_VALUE})
+            consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_UTF8_VALUE})
     public ResponseEntity<EventDto> save(
-        @ApiParam(value = SwaggerExampleModel.ADD_EVENT,
-            required = true) @ValidEventDtoRequest @RequestPart AddEventDtoRequest addEventDtoRequest,
-        @ApiIgnore Principal principal,
-        @RequestPart(required = false) @Nullable MultipartFile[] images) {
+            @ApiParam(value = SwaggerExampleModel.ADD_EVENT,
+                    required = true) @ValidEventDtoRequest @RequestPart AddEventDtoRequest addEventDtoRequest,
+            @ApiIgnore Principal principal,
+            @RequestPart(required = false) @Nullable MultipartFile[] images) {
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(eventService.save(addEventDtoRequest, principal.getName(), images));
+                .body(eventService.save(addEventDtoRequest, principal.getName(), images));
     }
 
     /**
@@ -74,11 +66,11 @@ public class EventsController {
      */
     @ApiOperation(value = "Delete event")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = HttpStatuses.OK),
-        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
-        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+            @ApiResponse(code = 200, message = HttpStatuses.OK),
+            @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
+            @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
     @DeleteMapping("/delete/{eventId}")
     public ResponseEntity<Object> delete(@PathVariable Long eventId, @ApiIgnore Principal principal) {
@@ -93,20 +85,20 @@ public class EventsController {
      */
     @ApiOperation(value = "Update event")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = HttpStatuses.OK, response = EventDto.class),
-        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
-        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+            @ApiResponse(code = 200, message = HttpStatuses.OK, response = EventDto.class),
+            @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
+            @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
     @PutMapping(value = "/update",
-        consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_UTF8_VALUE})
+            consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_UTF8_VALUE})
     public ResponseEntity<EventDto> update(
-        @ApiParam(required = true, value = SwaggerExampleModel.UPDATE_EVENT) @RequestPart UpdateEventDto eventDto,
-        @ApiIgnore Principal principal,
-        @RequestPart(required = false) @Nullable MultipartFile[] images) {
+            @ApiParam(required = true, value = SwaggerExampleModel.UPDATE_EVENT) @RequestPart UpdateEventDto eventDto,
+            @ApiIgnore Principal principal,
+            @RequestPart(required = false) @Nullable MultipartFile[] images) {
         return ResponseEntity.status(HttpStatus.OK).body(
-            eventService.update(eventDto, principal.getName(), images));
+                eventService.update(eventDto, principal.getName(), images));
     }
 
     /**
@@ -117,9 +109,9 @@ public class EventsController {
      */
     @ApiOperation(value = "Get the event")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = HttpStatuses.OK),
-        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+            @ApiResponse(code = 200, message = HttpStatuses.OK),
+            @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
     @GetMapping("/event/{eventId}")
     public ResponseEntity<EventDto> getEvent(@PathVariable Long eventId, @ApiIgnore Principal principal) {
@@ -134,33 +126,38 @@ public class EventsController {
      */
     @ApiOperation(value = "Get all events")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = HttpStatuses.OK),
-        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST)
+            @ApiResponse(code = 200, message = HttpStatuses.OK),
+            @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST)
     })
     @ApiPageableWithoutSort
     @GetMapping
     public ResponseEntity<PageableAdvancedDto<EventDto>> getEvent(@ApiIgnore Pageable pageable,
-        @ApiIgnore Principal principal) {
+                                                                  @ApiIgnore Principal principal) {
         return ResponseEntity.status(HttpStatus.OK).body(eventService.getAll(pageable, principal));
     }
 
     /**
-     * Method for getting pages of users events.
+     * Method for getting pages of users events sorted by dates if online and
+     * by closeness to coordinates of User if offline.
      *
      * @return a page of {@link EventDto} instance.
-     * @author Danylo Hlysnkyi.
+     * @author Danylo Hlysnkyi, Olena Sotnik.
      */
     @ApiOperation(value = "Get all users events")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = HttpStatuses.OK),
-        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED)
+            @ApiResponse(code = 200, message = HttpStatuses.OK),
+            @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED)
     })
     @ApiPageableWithoutSort
     @GetMapping("/myEvents")
-    public ResponseEntity<PageableAdvancedDto<EventDto>> getUserEvents(@ApiIgnore Pageable pageable,
-        @ApiIgnore Principal principal) {
-        return ResponseEntity.status(HttpStatus.OK).body(eventService.getAllUserEvents(pageable, principal.getName()));
+    public ResponseEntity<PageableAdvancedDto<EventDto>> getUserEvents(
+            @ApiIgnore Pageable pageable, @ApiIgnore Principal principal,
+            @RequestParam(required = false) String eventType,
+            @RequestParam(required = false) String userLatitude,
+            @RequestParam(required = false) String userLongitude) {
+        return ResponseEntity.status(HttpStatus.OK).body(eventService.getAllUserEvents(
+                pageable, principal.getName(), userLatitude, userLongitude, eventType));
     }
 
     /**
@@ -171,16 +168,16 @@ public class EventsController {
      */
     @ApiOperation(value = "Get events created by user")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = HttpStatuses.OK),
-        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED)
+            @ApiResponse(code = 200, message = HttpStatuses.OK),
+            @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED)
     })
     @ApiPageableWithoutSort
     @GetMapping("/myEvents/createdEvents")
     public ResponseEntity<PageableAdvancedDto<EventDto>> getEventsCreatedByUser(
-        @ApiIgnore Pageable pageable, @ApiIgnore Principal principal) {
+            @ApiIgnore Pageable pageable, @ApiIgnore Principal principal) {
         return ResponseEntity.status(HttpStatus.OK).body(eventService
-            .getEventsCreatedByUser(pageable, principal.getName()));
+                .getEventsCreatedByUser(pageable, principal.getName()));
     }
 
     /**
@@ -192,16 +189,16 @@ public class EventsController {
      */
     @ApiOperation(value = "Get all users events and events which were created by this user")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = HttpStatuses.OK),
-        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED)
+            @ApiResponse(code = 200, message = HttpStatuses.OK),
+            @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED)
     })
     @ApiPageableWithoutSort
     @GetMapping("/myEvents/relatedEvents")
     public ResponseEntity<PageableAdvancedDto<EventDto>> getRelatedToUserEvents(@ApiIgnore Pageable pageable,
-        @ApiIgnore Principal principal) {
+                                                                                @ApiIgnore Principal principal) {
         return ResponseEntity.status(HttpStatus.OK).body(eventService
-            .getRelatedToUserEvents(pageable, principal.getName()));
+                .getRelatedToUserEvents(pageable, principal.getName()));
     }
 
     /**
@@ -211,10 +208,10 @@ public class EventsController {
      */
     @ApiOperation(value = "Add an attender to the event")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = HttpStatuses.OK),
-        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+            @ApiResponse(code = 200, message = HttpStatuses.OK),
+            @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
     @PostMapping("/addAttender/{eventId}")
     public void addAttender(@PathVariable Long eventId, @ApiIgnore Principal principal) {
@@ -228,10 +225,10 @@ public class EventsController {
      */
     @ApiOperation(value = "Remove an attender from the event")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = HttpStatuses.OK),
-        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+            @ApiResponse(code = 200, message = HttpStatuses.OK),
+            @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
     @DeleteMapping("/removeAttender/{eventId}")
     public ResponseEntity<Object> removeAttender(@PathVariable Long eventId, @ApiIgnore Principal principal) {
@@ -246,10 +243,10 @@ public class EventsController {
      */
     @ApiOperation(value = "Add an event to favorites")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = HttpStatuses.OK),
-        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+            @ApiResponse(code = 200, message = HttpStatuses.OK),
+            @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
     @PostMapping("/addToFavorites/{eventId}")
     public ResponseEntity<Object> addToFavorites(@PathVariable Long eventId, @ApiIgnore Principal principal) {
@@ -264,10 +261,10 @@ public class EventsController {
      */
     @ApiOperation(value = "Remove an event from favorites")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = HttpStatuses.OK),
-        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+            @ApiResponse(code = 200, message = HttpStatuses.OK),
+            @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
     @DeleteMapping("/removeFromFavorites/{eventId}")
     public ResponseEntity<Object> removeFromFavorites(@PathVariable Long eventId, @ApiIgnore Principal principal) {
@@ -282,14 +279,14 @@ public class EventsController {
      */
     @ApiOperation(value = "Rate event")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = HttpStatuses.OK),
-        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+            @ApiResponse(code = 200, message = HttpStatuses.OK),
+            @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
     @PostMapping("/rateEvent/{eventId}/{grade}")
     public ResponseEntity<Object> rateEvent(@PathVariable Long eventId, @PathVariable int grade,
-        @ApiIgnore Principal principal) {
+                                            @ApiIgnore Principal principal) {
         eventService.rateEvent(eventId, principal.getName(), grade);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
@@ -302,9 +299,9 @@ public class EventsController {
      */
     @ApiOperation(value = "Get all event attenders")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = HttpStatuses.OK),
-        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+            @ApiResponse(code = 200, message = HttpStatuses.OK),
+            @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
     @GetMapping("/getAllSubscribers/{eventId}")
     public ResponseEntity<Set<EventAttenderDto>> getAllEventSubscribers(@PathVariable Long eventId) {

--- a/core/src/test/java/greencity/controller/EventsControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventsControllerTest.java
@@ -81,9 +81,9 @@ class EventsControllerTest {
     @BeforeEach
     void setup() {
         this.mockMvc = MockMvcBuilders.standaloneSetup(eventsController)
-            .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver(),
-                new UserArgumentResolver(userService, modelMapper))
-            .build();
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver(),
+                        new UserArgumentResolver(userService, modelMapper))
+                .build();
     }
 
     @Test
@@ -94,7 +94,7 @@ class EventsControllerTest {
 
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/myEvents/createdEvents").principal(principal))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
         verify(eventService).getEventsCreatedByUser(pageable, "test@gmail.com");
 
     }
@@ -116,11 +116,11 @@ class EventsControllerTest {
         when(eventService.getAll(pageable, principal)).thenReturn(pageableAdvancedDto);
 
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK)
-            .contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON)
-            .principal(principal))
-            .andExpect(status().isOk())
-            .andExpect(content().json(expectedJson));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .principal(principal))
+                .andExpect(status().isOk())
+                .andExpect(content().json(expectedJson));
 
         verify(eventService).getAll(pageable, principal);
     }
@@ -130,6 +130,7 @@ class EventsControllerTest {
     void getUserEventsTest() {
         int pageNumber = 0;
         int pageSize = 20;
+        String eventType = "";
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
 
         PageableAdvancedDto<EventDto> pageableAdvancedDto = getPageableAdvancedDtoEventDto();
@@ -139,16 +140,16 @@ class EventsControllerTest {
         ObjectWriter ow = objectMapper.writer();
         String expectedJson = ow.writeValueAsString(pageableAdvancedDto);
 
-        when(eventService.getAllUserEvents(pageable, principal.getName())).thenReturn(pageableAdvancedDto);
+        when(eventService.getAllUserEvents(pageable, principal.getName(), "", "", eventType)).thenReturn(pageableAdvancedDto);
 
-        mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/myEvents")
-            .contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON)
-            .principal(principal))
-            .andExpect(status().isOk())
-            .andExpect(content().json(expectedJson));
+        mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/myEvents?eventType=&userLatitude=&userLongitude=")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .principal(principal))
+                .andExpect(status().isOk())
+                .andExpect(content().json(expectedJson));
 
-        verify(eventService).getAllUserEvents(pageable, principal.getName());
+        verify(eventService).getAllUserEvents(pageable, principal.getName(),"","", eventType);
     }
 
     @Test
@@ -158,7 +159,7 @@ class EventsControllerTest {
         int pageSize = 20;
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/myEvents/relatedEvents").principal(principal))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
         verify(eventService).getRelatedToUserEvents(pageable, principal.getName());
     }
 
@@ -177,7 +178,7 @@ class EventsControllerTest {
     void addAttenderWithNotValidIdBadRequestTest() {
         String notValidId = "id";
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/addAttender/{eventId}", notValidId).principal(principal))
-            .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -186,13 +187,13 @@ class EventsControllerTest {
         Long eventId = 1L;
 
         doThrow(new NotFoundException("ErrorMessage"))
-            .when(eventService)
-            .addAttender(eventId, principal.getName());
+                .when(eventService)
+                .addAttender(eventId, principal.getName());
 
         Assertions.assertThatThrownBy(
-            () -> mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/addAttender/{eventId}", eventId).principal(principal))
-                .andExpect(status().isNotFound()))
-            .hasCause(new NotFoundException("ErrorMessage"));
+                        () -> mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/addAttender/{eventId}", eventId).principal(principal))
+                                .andExpect(status().isNotFound()))
+                .hasCause(new NotFoundException("ErrorMessage"));
     }
 
     @Test
@@ -201,13 +202,13 @@ class EventsControllerTest {
         Long eventId = 1L;
 
         doThrow(new BadRequestException("ErrorMessage"))
-            .when(eventService)
-            .addAttender(eventId, principal.getName());
+                .when(eventService)
+                .addAttender(eventId, principal.getName());
 
         Assertions.assertThatThrownBy(
-            () -> mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/addAttender/{eventId}", eventId).principal(principal))
-                .andExpect(status().isBadRequest()))
-            .hasCause(new BadRequestException("ErrorMessage"));
+                        () -> mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/addAttender/{eventId}", eventId).principal(principal))
+                                .andExpect(status().isBadRequest()))
+                .hasCause(new BadRequestException("ErrorMessage"));
     }
 
     @Test
@@ -215,8 +216,8 @@ class EventsControllerTest {
     void addToFavoritesTest() {
         Long eventId = 1L;
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/addToFavorites/{eventId}", eventId)
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
         verify(eventService).addToFavorites(eventId, principal.getName());
     }
 
@@ -225,8 +226,8 @@ class EventsControllerTest {
     void removeFromFavoritesTest() {
         Long eventId = 1L;
         mockMvc.perform(delete(EVENTS_CONTROLLER_LINK + "/removeFromFavorites/{eventId}", eventId)
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
         verify(eventService).removeFromFavorites(eventId, principal.getName());
     }
 
@@ -240,14 +241,14 @@ class EventsControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile jsonFile =
-            new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
+                new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
 
         mockMvc.perform(multipart(EVENTS_CONTROLLER_LINK + "/create")
-            .file(jsonFile)
-            .principal(principal)
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isCreated());
+                        .file(jsonFile)
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
 
         verify(eventService).save(addEventDtoRequest, principal.getName(), new MultipartFile[0]);
     }
@@ -257,13 +258,13 @@ class EventsControllerTest {
     void saveBadRequestTest() {
         String json = "{}";
         MockMultipartFile jsonFile =
-            new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
+                new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
         mockMvc.perform(multipart(EVENTS_CONTROLLER_LINK + "/create")
-            .file(jsonFile)
-            .principal(principal)
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isBadRequest());
+                        .file(jsonFile)
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -272,7 +273,7 @@ class EventsControllerTest {
         Long eventId = 1L;
 
         mockMvc.perform(delete(EVENTS_CONTROLLER_LINK + "/removeAttender/{eventId}", eventId).principal(principal))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
 
         verify(eventService).removeAttender(eventId, principal.getName());
     }
@@ -282,8 +283,8 @@ class EventsControllerTest {
     void removeAttenderBadRequestTest() {
         String notValidId = "id";
         mockMvc.perform(delete(EVENTS_CONTROLLER_LINK + "/removeAttender/{eventId}", notValidId)
-            .principal(principal))
-            .andExpect(status().isBadRequest());
+                        .principal(principal))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -291,12 +292,12 @@ class EventsControllerTest {
     void removeAttenderNotFoundTest() {
         Long eventId = 1L;
         doThrow(new NotFoundException("ErrorMessage"))
-            .when(eventService)
-            .removeAttender(eventId, principal.getName());
+                .when(eventService)
+                .removeAttender(eventId, principal.getName());
 
         Assertions.assertThatThrownBy(() -> mockMvc
-            .perform(delete(EVENTS_CONTROLLER_LINK + "/removeAttender/{eventId}", eventId).principal(principal))
-            .andExpect(status().isNotFound())).hasCause(new NotFoundException("ErrorMessage"));
+                .perform(delete(EVENTS_CONTROLLER_LINK + "/removeAttender/{eventId}", eventId).principal(principal))
+                .andExpect(status().isNotFound())).hasCause(new NotFoundException("ErrorMessage"));
     }
 
     @Test
@@ -304,8 +305,8 @@ class EventsControllerTest {
     void deleteTest() {
 
         mockMvc.perform(delete(EVENTS_CONTROLLER_LINK + "/delete/{eventId}", 1)
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
 
         verify(eventService).delete(1L, "test@gmail.com");
     }
@@ -314,8 +315,8 @@ class EventsControllerTest {
     @SneakyThrows
     void deleteFailedTest() {
         mockMvc.perform(delete(EVENTS_CONTROLLER_LINK + "/delete/{eventId}", "not_number")
-            .principal(principal))
-            .andExpect(status().isBadRequest());
+                        .principal(principal))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -328,21 +329,21 @@ class EventsControllerTest {
         String json = objectMapper.writeValueAsString(updateEventDto);
 
         MockMultipartFile jsonFile =
-            new MockMultipartFile("eventDto", "", "application/json", json.getBytes());
+                new MockMultipartFile("eventDto", "", "application/json", json.getBytes());
 
         MockMultipartHttpServletRequestBuilder builder =
-            MockMvcRequestBuilders.multipart(EVENTS_CONTROLLER_LINK + "/update");
+                MockMvcRequestBuilders.multipart(EVENTS_CONTROLLER_LINK + "/update");
         builder.with(request -> {
             request.setMethod("PUT");
             return request;
         });
 
         mockMvc.perform(builder
-            .file(jsonFile)
-            .principal(principal)
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk());
+                        .file(jsonFile)
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
 
         verify(eventService).update(updateEventDto, principal.getName(), new MultipartFile[0]);
     }
@@ -354,8 +355,8 @@ class EventsControllerTest {
         int grade = 2;
 
         mockMvc
-            .perform(post(EVENTS_CONTROLLER_LINK + "/rateEvent/{eventId}/{grade}", eventId, grade).principal(principal))
-            .andExpect(status().isOk());
+                .perform(post(EVENTS_CONTROLLER_LINK + "/rateEvent/{eventId}/{grade}", eventId, grade).principal(principal))
+                .andExpect(status().isOk());
 
         verify(eventService).rateEvent(eventId, principal.getName(), grade);
     }
@@ -367,9 +368,9 @@ class EventsControllerTest {
         int grade = 2;
 
         mockMvc
-            .perform(
-                post(EVENTS_CONTROLLER_LINK + "/rateEvent/{eventId}/{grade}", notValidId, grade).principal(principal))
-            .andExpect(status().isBadRequest());
+                .perform(
+                        post(EVENTS_CONTROLLER_LINK + "/rateEvent/{eventId}/{grade}", notValidId, grade).principal(principal))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -379,9 +380,9 @@ class EventsControllerTest {
         String notValidGrade = "grade";
 
         mockMvc
-            .perform(post(EVENTS_CONTROLLER_LINK + "/rateEvent/{eventId}/{grade}", eventId, notValidGrade)
-                .principal(principal))
-            .andExpect(status().isBadRequest());
+                .perform(post(EVENTS_CONTROLLER_LINK + "/rateEvent/{eventId}/{grade}", eventId, notValidGrade)
+                        .principal(principal))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -391,12 +392,12 @@ class EventsControllerTest {
         int grade = 2;
 
         doThrow(new NotFoundException("ErrorMessage"))
-            .when(eventService)
-            .rateEvent(eventId, principal.getName(), grade);
+                .when(eventService)
+                .rateEvent(eventId, principal.getName(), grade);
 
         Assertions.assertThatThrownBy(() -> mockMvc
-            .perform(post(EVENTS_CONTROLLER_LINK + "/rateEvent/{eventId}/{grade}", eventId, grade).principal(principal))
-            .andExpect(status().isNotFound())).hasCause(new NotFoundException("ErrorMessage"));
+                .perform(post(EVENTS_CONTROLLER_LINK + "/rateEvent/{eventId}/{grade}", eventId, grade).principal(principal))
+                .andExpect(status().isNotFound())).hasCause(new NotFoundException("ErrorMessage"));
     }
 
     @Test
@@ -406,12 +407,12 @@ class EventsControllerTest {
         int grade = 2;
 
         doThrow(new BadRequestException("ErrorMessage"))
-            .when(eventService)
-            .rateEvent(eventId, principal.getName(), grade);
+                .when(eventService)
+                .rateEvent(eventId, principal.getName(), grade);
 
         Assertions.assertThatThrownBy(() -> mockMvc
-            .perform(post(EVENTS_CONTROLLER_LINK + "/rateEvent/{eventId}/{grade}", eventId, grade).principal(principal))
-            .andExpect(status().isBadRequest())).hasCause(new BadRequestException("ErrorMessage"));
+                .perform(post(EVENTS_CONTROLLER_LINK + "/rateEvent/{eventId}/{grade}", eventId, grade).principal(principal))
+                .andExpect(status().isBadRequest())).hasCause(new BadRequestException("ErrorMessage"));
     }
 
     @Test
@@ -420,41 +421,41 @@ class EventsControllerTest {
         String json = "";
 
         MockMultipartFile jsonFile =
-            new MockMultipartFile("eventDto", "", "application/json", json.getBytes());
+                new MockMultipartFile("eventDto", "", "application/json", json.getBytes());
 
         MockMultipartHttpServletRequestBuilder builder =
-            MockMvcRequestBuilders.multipart(EVENTS_CONTROLLER_LINK + "/update");
+                MockMvcRequestBuilders.multipart(EVENTS_CONTROLLER_LINK + "/update");
         builder.with(request -> {
             request.setMethod("PUT");
             return request;
         });
 
         mockMvc.perform(builder
-            .file(jsonFile)
-            .principal(principal)
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isBadRequest());
+                        .file(jsonFile)
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
     @SneakyThrows
     void getEventTest() {
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/event/{eventId}", 1L).principal(principal))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
 
         verify(eventService)
-            .getEvent(1L, principal);
+                .getEvent(1L, principal);
     }
 
     @Test
     @SneakyThrows
     void getEventFailedTest() {
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/event/{eventId}", "not_number").principal(principal))
-            .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest());
 
         verify(eventService, times(0))
-            .getEvent(1L, principal);
+                .getEvent(1L, principal);
     }
 
     @Test
@@ -465,10 +466,10 @@ class EventsControllerTest {
         when(eventService.getEvent(1L, principal)).thenReturn(eventDto);
 
         MvcResult result = mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/event/{eventId}", 1L)
-            .principal(principal)
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk()).andReturn();
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk()).andReturn();
 
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.findAndRegisterModules();
@@ -477,7 +478,7 @@ class EventsControllerTest {
         assertEquals(eventDto, responseEventDto);
 
         verify(eventService)
-            .getEvent(1L, principal);
+                .getEvent(1L, principal);
     }
 
     @Test
@@ -485,7 +486,7 @@ class EventsControllerTest {
     void getAllEventSubscribersTest() {
         Long eventId = 1L;
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/getAllSubscribers/{eventId}", eventId))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
 
         verify(eventService).getAllEventAttenders(eventId);
     }
@@ -495,7 +496,7 @@ class EventsControllerTest {
     void getAllEventSubscribersWithNotValidIdBadRequestTest() {
         String notValidId = "id";
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/getAllSubscribers/{eventId}", notValidId))
-            .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -504,83 +505,83 @@ class EventsControllerTest {
         Long eventId = 1L;
 
         doThrow(new NotFoundException("ErrorMessage"))
-            .when(eventService)
-            .getAllEventAttenders(eventId);
+                .when(eventService)
+                .getAllEventAttenders(eventId);
 
         Assertions.assertThatThrownBy(
-            () -> mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/getAllSubscribers/{eventId}", eventId))
-                .andExpect(status().isNotFound()))
-            .hasCause(new NotFoundException("ErrorMessage"));
+                        () -> mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/getAllSubscribers/{eventId}", eventId))
+                                .andExpect(status().isNotFound()))
+                .hasCause(new NotFoundException("ErrorMessage"));
     }
 
     private PageableAdvancedDto<EventDto> getPageableAdvancedDtoEventDto() {
         EventDto eventDto = EventDto.builder()
-            .id(11L)
-            .title("Test-Title")
-            .organizer(EventAuthorDto.builder()
-                .id(12L)
-                .name("Organizer-Name")
-                .organizerRating(1.1D)
-                .build())
-            .description("Event Description")
-            .dates(List.of(EventDateLocationDto.builder()
-                .id(13L)
-                .startDate(ZonedDateTime.of(2023, 6, 1, 1, 2, 3, 4, ZoneId.of("Europe/Kiev")))
-                .finishDate(ZonedDateTime.of(2023, 6, 1, 3, 2, 3, 4, ZoneId.of("Europe/Kiev")))
-                .onlineLink("some-link.com")
-                .coordinates(AddressDto.builder()
-                    .streetUa("Вулиця")
-                    .streetEn("Street")
-                    .houseNumber("1B")
-                    .cityUa("Місто")
-                    .cityEn("City")
-                    .regionUa("Область")
-                    .regionUa("Oblast")
-                    .countryUa("Країна")
-                    .countryEn("Country")
-                    .latitude(50.45594503475653d)
-                    .longitude(30.5058935778292d).build())
-                .build()))
-            .tags(List.of(TagUaEnDto.builder()
-                .id(20)
-                .nameEn("Name")
-                .nameUa("Назва").build()))
-            .titleImage("https://csb10032000a548f571.blob.core.windows.net/all/8f09887c.png")
-            .additionalImages(List.of("https://csb10032000a548f571.blob.core.windows.net/all/10005000.png"))
-            .isOpen(true)
-            .isSubscribed(true).build();
+                .id(11L)
+                .title("Test-Title")
+                .organizer(EventAuthorDto.builder()
+                        .id(12L)
+                        .name("Organizer-Name")
+                        .organizerRating(1.1D)
+                        .build())
+                .description("Event Description")
+                .dates(List.of(EventDateLocationDto.builder()
+                        .id(13L)
+                        .startDate(ZonedDateTime.of(2023, 6, 1, 1, 2, 3, 4, ZoneId.of("Europe/Kiev")))
+                        .finishDate(ZonedDateTime.of(2023, 6, 1, 3, 2, 3, 4, ZoneId.of("Europe/Kiev")))
+                        .onlineLink("some-link.com")
+                        .coordinates(AddressDto.builder()
+                                .streetUa("Вулиця")
+                                .streetEn("Street")
+                                .houseNumber("1B")
+                                .cityUa("Місто")
+                                .cityEn("City")
+                                .regionUa("Область")
+                                .regionUa("Oblast")
+                                .countryUa("Країна")
+                                .countryEn("Country")
+                                .latitude(50.45594503475653d)
+                                .longitude(30.5058935778292d).build())
+                        .build()))
+                .tags(List.of(TagUaEnDto.builder()
+                        .id(20)
+                        .nameEn("Name")
+                        .nameUa("Назва").build()))
+                .titleImage("https://csb10032000a548f571.blob.core.windows.net/all/8f09887c.png")
+                .additionalImages(List.of("https://csb10032000a548f571.blob.core.windows.net/all/10005000.png"))
+                .isOpen(true)
+                .isSubscribed(true).build();
 
         return new PageableAdvancedDto<>(
-            List.of(eventDto),
-            1,
-            0,
-            1,
-            0,
-            false,
-            false,
-            true,
-            true);
+                List.of(eventDto),
+                1,
+                0,
+                1,
+                0,
+                false,
+                false,
+                true,
+                true);
     }
 
     @SneakyThrows
     private AddEventDtoRequest getAddEventDtoRequest() {
         String json = "{\n" +
-            "    \"title\":\"string\",\n" +
-            "    \"description\":\"stringstringstringstringstringstringstringstring\",\n" +
-            "    \"open\":true,\n" +
-            "    \"datesLocations\":[\n" +
-            "        {\n" +
-            "            \"startDate\":\"2023-05-27T15:00:00Z\",\n" +
-            "            \"finishDate\":\"2023-05-27T17:00:00Z\",\n" +
-            "            \"coordinates\":{\n" +
-            "                \"latitude\":1,\n" +
-            "                \"longitude\":1\n" +
-            "            },\n" +
-            "            \"onlineLink\":\"http://localhost:8080/swagger-ui.html#/events-controller\"\n" +
-            "        }\n" +
-            "    ],\n" +
-            "    \"tags\":[\"Social\"]\n" +
-            "}   ";
+                "    \"title\":\"string\",\n" +
+                "    \"description\":\"stringstringstringstringstringstringstringstring\",\n" +
+                "    \"open\":true,\n" +
+                "    \"datesLocations\":[\n" +
+                "        {\n" +
+                "            \"startDate\":\"2023-05-27T15:00:00Z\",\n" +
+                "            \"finishDate\":\"2023-05-27T17:00:00Z\",\n" +
+                "            \"coordinates\":{\n" +
+                "                \"latitude\":1,\n" +
+                "                \"longitude\":1\n" +
+                "            },\n" +
+                "            \"onlineLink\":\"http://localhost:8080/swagger-ui.html#/events-controller\"\n" +
+                "        }\n" +
+                "    ],\n" +
+                "    \"tags\":[\"Social\"]\n" +
+                "}   ";
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.findAndRegisterModules();
         return objectMapper.readValue(json, AddEventDtoRequest.class);
@@ -589,23 +590,23 @@ class EventsControllerTest {
     @SneakyThrows
     private UpdateEventDto getUpdateEventDto() {
         String json = "{\n" +
-            "    \"id\":0,\n" +
-            "    \"title\":\"string\",\n" +
-            "    \"description\":\"stringstringstringstringstringstringstringstring\",\n" +
-            "    \"open\":true,\n" +
-            "    \"datesLocations\":[\n" +
-            "        {\n" +
-            "            \"startDate\":\"2023-05-27T15:00:00Z\",\n" +
-            "            \"finishDate\":\"2023-05-27T17:00:00Z\",\n" +
-            "            \"coordinates\":{\n" +
-            "                \"latitude\":1,\n" +
-            "                \"longitude\":1\n" +
-            "            },\n" +
-            "            \"onlineLink\":\"http://localhost:8080/swagger-ui.html#/events-controller\"\n" +
-            "        }\n" +
-            "    ],\n" +
-            "    \"tags\":[\"Social\"]\n" +
-            "}   ";
+                "    \"id\":0,\n" +
+                "    \"title\":\"string\",\n" +
+                "    \"description\":\"stringstringstringstringstringstringstringstring\",\n" +
+                "    \"open\":true,\n" +
+                "    \"datesLocations\":[\n" +
+                "        {\n" +
+                "            \"startDate\":\"2023-05-27T15:00:00Z\",\n" +
+                "            \"finishDate\":\"2023-05-27T17:00:00Z\",\n" +
+                "            \"coordinates\":{\n" +
+                "                \"latitude\":1,\n" +
+                "                \"longitude\":1\n" +
+                "            },\n" +
+                "            \"onlineLink\":\"http://localhost:8080/swagger-ui.html#/events-controller\"\n" +
+                "        }\n" +
+                "    ],\n" +
+                "    \"tags\":[\"Social\"]\n" +
+                "}   ";
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.findAndRegisterModules();
         return objectMapper.readValue(json, UpdateEventDto.class);
@@ -614,50 +615,50 @@ class EventsControllerTest {
     @SneakyThrows
     private EventDto getEventDto() {
         String json = "{\n" +
-            "  \"additionalImages\": [\n" +
-            "    \"string\"\n" +
-            "  ],\n" +
-            "  \"dates\": [\n" +
-            "    {\n" +
-            "        \"coordinates\": {\n" +
-            "        \"streetUa\": \"string\",\n" +
-            "        \"streetEn\": \"string\",\n" +
-            "        \"houseNumber\": \"string\",\n" +
-            "        \"cityUa\": \"string\",\n" +
-            "        \"cityEn\": \"string\",\n" +
-            "        \"regionUa\": \"string\",\n" +
-            "        \"regionEn\": \"string\",\n" +
-            "        \"countryUa\": \"string\",\n" +
-            "        \"countryEn\": \"string\",\n" +
-            "        \"latitude\": 0,\n" +
-            "        \"longitude\": 0\n" +
-            "      },\n" +
-            "      \"finishDate\": \"2022-12-08T15:13:27.538Z\",\n" +
-            "      \"id\": 0,\n" +
-            "      \"onlineLink\": \"string\",\n" +
-            "      \"startDate\": \"2022-12-08T15:13:27.538Z\"\n" +
-            "    }\n" +
-            "  ],\n" +
-            "  \"description\": \"stringstringstringstringstringstringstring\",\n" +
-            "  \"creationDate\": \"2022-12-08\",\n" +
-            "  \"id\": 0,\n" +
-            "  \"isSubscribed\": true,\n" +
-            "  \"open\": true,\n" +
-            "  \"organizer\": {\n" +
-            "    \"id\": 0,\n" +
-            "    \"name\": \"string\",\n" +
-            "    \"organizerRating\": 0\n" +
-            "  },\n" +
-            "  \"tags\": [\n" +
-            "    {\n" +
-            "      \"id\": 0,\n" +
-            "      \"nameEn\": \"string\",\n" +
-            "      \"nameUa\": \"string\"\n" +
-            "    }\n" +
-            "  ],\n" +
-            "  \"title\": \"string\",\n" +
-            "  \"titleImage\": \"string\"\n" +
-            "}";
+                "  \"additionalImages\": [\n" +
+                "    \"string\"\n" +
+                "  ],\n" +
+                "  \"dates\": [\n" +
+                "    {\n" +
+                "        \"coordinates\": {\n" +
+                "        \"streetUa\": \"string\",\n" +
+                "        \"streetEn\": \"string\",\n" +
+                "        \"houseNumber\": \"string\",\n" +
+                "        \"cityUa\": \"string\",\n" +
+                "        \"cityEn\": \"string\",\n" +
+                "        \"regionUa\": \"string\",\n" +
+                "        \"regionEn\": \"string\",\n" +
+                "        \"countryUa\": \"string\",\n" +
+                "        \"countryEn\": \"string\",\n" +
+                "        \"latitude\": 0,\n" +
+                "        \"longitude\": 0\n" +
+                "      },\n" +
+                "      \"finishDate\": \"2022-12-08T15:13:27.538Z\",\n" +
+                "      \"id\": 0,\n" +
+                "      \"onlineLink\": \"string\",\n" +
+                "      \"startDate\": \"2022-12-08T15:13:27.538Z\"\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"description\": \"stringstringstringstringstringstringstring\",\n" +
+                "  \"creationDate\": \"2022-12-08\",\n" +
+                "  \"id\": 0,\n" +
+                "  \"isSubscribed\": true,\n" +
+                "  \"open\": true,\n" +
+                "  \"organizer\": {\n" +
+                "    \"id\": 0,\n" +
+                "    \"name\": \"string\",\n" +
+                "    \"organizerRating\": 0\n" +
+                "  },\n" +
+                "  \"tags\": [\n" +
+                "    {\n" +
+                "      \"id\": 0,\n" +
+                "      \"nameEn\": \"string\",\n" +
+                "      \"nameUa\": \"string\"\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"title\": \"string\",\n" +
+                "  \"titleImage\": \"string\"\n" +
+                "}";
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.findAndRegisterModules();
         return objectMapper.readValue(json, EventDto.class);

--- a/dao/src/main/java/greencity/repository/EventRepo.java
+++ b/dao/src/main/java/greencity/repository/EventRepo.java
@@ -24,8 +24,8 @@ public interface EventRepo extends JpaRepository<Event, Long>, JpaSpecificationE
      *
      * @return list of {@link Event} instances.
      */
-    @Query(value = "SELECT e FROM Event e LEFT JOIN e.attenders AS att WHERE att.id = :userId ORDER BY e.id DESC")
-    Page<Event> findAllByAttender(Pageable page, Long userId);
+    @Query(value = "SELECT e FROM Event e LEFT JOIN e.attenders AS att WHERE att.id = :userId")
+    List<Event> findAllByAttender(Long userId);
 
     /**
      * Method for getting events created by User.

--- a/service-api/src/main/java/greencity/service/EventService.java
+++ b/service-api/src/main/java/greencity/service/EventService.java
@@ -49,7 +49,8 @@ public interface EventService {
      *
      * @return List of {@link EventDto} instance.
      */
-    PageableAdvancedDto<EventDto> getAllUserEvents(Pageable page, String email);
+    PageableAdvancedDto<EventDto> getAllUserEvents(Pageable page, String email, String latitude,
+                                                   String longitude, String eventType);
 
     /**
      * Method for getting page of events which were created user.
@@ -87,7 +88,6 @@ public interface EventService {
      *
      * @param eventId - event id.
      * @param email   - user email.
-     *
      * @author Anton Bondar.
      */
     void addToFavorites(Long eventId, String email);
@@ -97,7 +97,6 @@ public interface EventService {
      *
      * @param eventId - event id.
      * @param email   - user email.
-     *
      * @author Anton Bondar.
      */
     void removeFromFavorites(Long eventId, String email);
@@ -114,7 +113,6 @@ public interface EventService {
      * Update Event.
      *
      * @param email    - user that edits event
-     *
      * @param eventDto - new event information
      * @param images   - new images of event
      * @return EventDto

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -5,13 +5,7 @@ import greencity.client.RestClient;
 import greencity.constant.AppConstant;
 import greencity.constant.ErrorMessage;
 import greencity.dto.PageableAdvancedDto;
-import greencity.dto.event.AddEventDtoRequest;
-import greencity.dto.event.AddressDto;
-import greencity.dto.event.EventAttenderDto;
-import greencity.dto.event.EventDateLocationDto;
-import greencity.dto.event.EventDto;
-import greencity.dto.event.EventVO;
-import greencity.dto.event.UpdateEventDto;
+import greencity.dto.event.*;
 import greencity.dto.geocoding.AddressLatLngResponse;
 import greencity.dto.tag.TagVO;
 import greencity.entity.Tag;
@@ -32,6 +26,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,12 +35,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.security.Principal;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -63,7 +53,7 @@ public class EventServiceImpl implements EventService {
 
     @Override
     public EventDto save(AddEventDtoRequest addEventDtoRequest, String email,
-        MultipartFile[] images) {
+                         MultipartFile[] images) {
         addAddressToLocation(addEventDtoRequest.getDatesLocations());
         Event toSave = modelMapper.map(addEventDtoRequest, Event.class);
         toSave.setCreationDate(LocalDate.now());
@@ -83,11 +73,11 @@ public class EventServiceImpl implements EventService {
         }
 
         List<TagVO> tagVOs = tagService.findTagsWithAllTranslationsByNamesAndType(
-            addEventDtoRequest.getTags(), TagType.EVENT);
+                addEventDtoRequest.getTags(), TagType.EVENT);
 
         toSave.setTags(modelMapper.map(tagVOs,
-            new TypeToken<List<Tag>>() {
-            }.getType()));
+                new TypeToken<List<Tag>>() {
+                }.getType()));
 
         return modelMapper.map(eventRepo.save(toSave), EventDto.class);
     }
@@ -100,7 +90,7 @@ public class EventServiceImpl implements EventService {
         eventImages.add(toDelete.getTitleImage());
         if (toDelete.getAdditionalImages() != null) {
             eventImages
-                .addAll(toDelete.getAdditionalImages().stream().map(EventImages::getLink).collect(Collectors.toList()));
+                    .addAll(toDelete.getAdditionalImages().stream().map(EventImages::getLink).collect(Collectors.toList()));
         }
 
         if (toDelete.getOrganizer().getId().equals(user.getId()) || user.getRole() == Role.ROLE_ADMIN) {
@@ -114,12 +104,12 @@ public class EventServiceImpl implements EventService {
     @Override
     public EventDto getEvent(Long eventId, Principal principal) {
         Event event =
-            eventRepo.findById(eventId).orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND));
+                eventRepo.findById(eventId).orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND));
         EventDto eventDto = modelMapper.map(event, EventDto.class);
         if (principal != null) {
             User currentUser = modelMapper.map(restClient.findByEmail(principal.getName()), User.class);
             eventDto.setIsSubscribed(event.getAttenders().stream()
-                .anyMatch(attender -> attender.getId().equals(currentUser.getId())));
+                    .anyMatch(attender -> attender.getId().equals(currentUser.getId())));
         }
         return eventDto;
     }
@@ -137,12 +127,101 @@ public class EventServiceImpl implements EventService {
     }
 
     @Override
-    public PageableAdvancedDto<EventDto> getAllUserEvents(Pageable page, String email) {
+    public PageableAdvancedDto<EventDto> getAllUserEvents(
+            Pageable page, String email, String userLatitude, String userLongitude, String eventType) {
         User attender = modelMapper.map(restClient.findByEmail(email), User.class);
-        Page<Event> events = eventRepo.findAllByAttender(page, attender.getId());
-        PageableAdvancedDto<EventDto> eventDtos = buildPageableAdvancedDto(events);
-        setSubscribes(events, eventDtos, attender);
+        List<Event> events = sortUserEventsByEventType(eventType, attender, userLatitude, userLongitude);
+        Page<Event> eventPage = new PageImpl<>(events, page, events.size());
+        PageableAdvancedDto<EventDto> eventDtos = buildPageableAdvancedDto(eventPage);
+        setSubscribes(eventPage, eventDtos, attender);
         return eventDtos;
+    }
+
+    private List<Event> sortUserEventsByEventType(
+            String eventType, User attender, String userLatitude, String userLongitude) {
+        if (eventType.equalsIgnoreCase("ONLINE")) {
+            return getOnlineUserEventsSortedByDate(attender);
+        }
+
+        if (eventType.equalsIgnoreCase("OFFLINE")) {
+            if (!userLatitude.isBlank() && !userLongitude.isBlank()) {
+                return getOfflineUserEventsSortedCloserToUserLocation(attender, userLatitude, userLongitude);
+            } else {
+                return getOfflineUserEventsSortedByDate(attender);
+            }
+        }
+        return eventRepo.findAllByAttender(attender.getId()).stream().sorted(getComparatorByDates())
+                .collect(Collectors.toList());
+    }
+
+    private List<Event> getOnlineUserEventsSortedByDate(User attender) {
+        return eventRepo.findAllByAttender(attender.getId()).stream()
+                .filter(event -> event.getDates().get(event.getDates().size() - 1).getOnlineLink() != null)
+                .sorted(getComparatorByDates())
+                .collect(Collectors.toList());
+    }
+
+    private List<Event> getOfflineUserEventsSortedByDate(User attender) {
+        return eventRepo.findAllByAttender(attender.getId()).stream()
+                .filter(event -> event.getDates().get(event.getDates().size() - 1).getAddress() != null)
+                .filter(event -> event.getDates().get(event.getDates().size() - 1).getAddress().getLatitude() != 0
+                        && event.getDates().get(event.getDates().size() - 1).getAddress().getLongitude() != 0)
+                .sorted(getComparatorByDates())
+                .collect(Collectors.toList());
+    }
+
+    private List<Event> getOfflineUserEventsSortedCloserToUserLocation(
+            User attender, String userLatitude, String userLongitude) {
+        List<Event> eventsFurtherSorted = getOfflineUserEventsSortedByDate(attender).stream()
+                .filter(event -> LocalDate.now().isBefore(event.getDates().get(event.getDates().size() - 1)
+                        .getFinishDate().toLocalDate())
+                        || LocalDate.now().isEqual(event.getDates().get(event.getDates().size() - 1)
+                        .getFinishDate().toLocalDate()))
+                .sorted(getComparatorByDistance(Double.parseDouble(userLatitude), Double.parseDouble(userLongitude)))
+                .collect(Collectors.toList());
+        List<Event> eventsPassed = getOfflineUserEventsSortedByDate(attender).stream()
+                .filter(event -> LocalDate.now().isAfter(event.getDates().get(event.getDates().size() - 1)
+                        .getFinishDate().toLocalDate()))
+                .collect(Collectors.toList());
+        eventsFurtherSorted.addAll(eventsPassed);
+        return eventsFurtherSorted;
+    }
+
+    private Comparator<Event> getComparatorByDistance(final double userLatitude, final double userLongitude) {
+        return new Comparator<Event>() {
+            @Override
+            public int compare(Event e1, Event e2) {
+                double distance1 = calculateDistance(userLatitude, userLongitude,
+                        e1.getDates().get(e1.getDates().size() - 1).getAddress().getLatitude(),
+                        e1.getDates().get(e1.getDates().size() - 1).getAddress().getLongitude());
+                double distance2 = calculateDistance(userLatitude, userLongitude,
+                        e2.getDates().get(e2.getDates().size() - 1).getAddress().getLatitude(),
+                        e2.getDates().get(e2.getDates().size() - 1).getAddress().getLongitude());
+                return Double.compare(distance1, distance2);
+            }
+        };
+    }
+
+    private static Comparator<Event> getComparatorByDates() {
+        return (e1, e2) -> e2.getDates().get(e2.getDates().size() - 1).getStartDate()
+                .compareTo(e1.getDates().get(e1.getDates().size() - 1).getStartDate());
+    }
+
+
+    private static double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        double earthRadius = 6371.0;
+
+        double lat1Rad = Math.toRadians(lat1);
+        double lon1Rad = Math.toRadians(lon1);
+        double lat2Rad = Math.toRadians(lat2);
+        double lon2Rad = Math.toRadians(lon2);
+        double dLat = lat2Rad - lat1Rad;
+        double dLon = lon2Rad - lon1Rad;
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(lat1Rad) * Math.cos(lat2Rad) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return earthRadius * c;
     }
 
     @Override
@@ -165,43 +244,43 @@ public class EventServiceImpl implements EventService {
 
     private void setSubscribes(Page<Event> events, PageableAdvancedDto<EventDto> eventDtos, User user) {
         List<Long> eventIds = events.stream()
-            .filter(event -> event.getAttenders().stream().map(User::getId).collect(Collectors.toList())
-                .contains(user.getId()))
-            .map(Event::getId)
-            .collect(Collectors.toList());
+                .filter(event -> event.getAttenders().stream().map(User::getId).collect(Collectors.toList())
+                        .contains(user.getId()))
+                .map(Event::getId)
+                .collect(Collectors.toList());
         eventDtos.getPage().forEach(eventDto -> eventDto.setIsSubscribed(eventIds.contains(eventDto.getId())));
     }
 
     private void setFollowers(Page<Event> events, PageableAdvancedDto<EventDto> eventDtos, User user) {
         List<Long> eventIds = events.stream()
-            .filter(event -> event.getFollowers().stream().map(User::getId).collect(Collectors.toList())
-                .contains(user.getId()))
-            .map(Event::getId)
-            .collect(Collectors.toList());
+                .filter(event -> event.getFollowers().stream().map(User::getId).collect(Collectors.toList())
+                        .contains(user.getId()))
+                .map(Event::getId)
+                .collect(Collectors.toList());
         eventDtos.getPage().forEach(eventDto -> eventDto.setIsFavorite(eventIds.contains(eventDto.getId())));
     }
 
     private PageableAdvancedDto<EventDto> buildPageableAdvancedDto(Page<Event> eventsPage) {
         List<EventDto> eventDtos = eventsPage.stream()
-            .map(event -> modelMapper.map(event, EventDto.class))
-            .collect(Collectors.toList());
+                .map(event -> modelMapper.map(event, EventDto.class))
+                .collect(Collectors.toList());
 
         return new PageableAdvancedDto<>(
-            eventDtos,
-            eventsPage.getTotalElements(),
-            eventsPage.getPageable().getPageNumber(),
-            eventsPage.getTotalPages(),
-            eventsPage.getNumber(),
-            eventsPage.hasPrevious(),
-            eventsPage.hasNext(),
-            eventsPage.isFirst(),
-            eventsPage.isLast());
+                eventDtos,
+                eventsPage.getTotalElements(),
+                eventsPage.getPageable().getPageNumber(),
+                eventsPage.getTotalPages(),
+                eventsPage.getNumber(),
+                eventsPage.hasPrevious(),
+                eventsPage.hasNext(),
+                eventsPage.isFirst(),
+                eventsPage.isLast());
     }
 
     @Override
     public void addAttender(Long eventId, String email) {
         Event event =
-            eventRepo.findById(eventId).orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND));
+                eventRepo.findById(eventId).orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND));
         User currentUser = modelMapper.map(restClient.findByEmail(email), User.class);
         checkAttenderToJoinTheEvent(event, currentUser);
         event.getAttenders().add(currentUser);
@@ -212,7 +291,7 @@ public class EventServiceImpl implements EventService {
         if (Objects.equals(event.getOrganizer().getId(), user.getId())) {
             throw new BadRequestException(ErrorMessage.YOU_ARE_EVENT_ORGANIZER);
         } else if (!event.isOpen()
-            && userRepo.findUserByIdAndByFriendId(user.getId(), event.getOrganizer().getId()).isEmpty()) {
+                && userRepo.findUserByIdAndByFriendId(user.getId(), event.getOrganizer().getId()).isEmpty()) {
             throw new BadRequestException(ErrorMessage.YOU_CANNOT_SUBSCRIBE_TO_CLOSE_EVENT);
         } else if (event.getAttenders().stream().anyMatch(a -> a.getId().equals(user.getId()))) {
             throw new BadRequestException(ErrorMessage.HAVE_ALREADY_SUBSCRIBED_ON_EVENT);
@@ -222,11 +301,11 @@ public class EventServiceImpl implements EventService {
     @Override
     public void removeAttender(Long eventId, String email) {
         Event event =
-            eventRepo.findById(eventId).orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND));
+                eventRepo.findById(eventId).orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND));
         User currentUser = modelMapper.map(restClient.findByEmail(email), User.class);
 
         event.setAttenders(event.getAttenders().stream().filter(user -> !user.getId().equals(currentUser.getId()))
-            .collect(Collectors.toSet()));
+                .collect(Collectors.toSet()));
 
         eventRepo.save(event);
     }
@@ -234,10 +313,10 @@ public class EventServiceImpl implements EventService {
     @Override
     public void addToFavorites(Long eventId, String email) {
         Event event = eventRepo.findById(eventId)
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + eventId));
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + eventId));
 
         User currentUser = userRepo.findByEmail(email)
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_EMAIL + email));
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_EMAIL + email));
 
         if (event.getFollowers().contains(currentUser)) {
             throw new BadRequestException(ErrorMessage.USER_HAS_ALREADY_ADDED_EVENT_TO_FAVORITES);
@@ -250,19 +329,19 @@ public class EventServiceImpl implements EventService {
     @Override
     public void removeFromFavorites(Long eventId, String email) {
         Event event = eventRepo.findById(eventId)
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + eventId));
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + eventId));
 
         User currentUser = userRepo.findByEmail(email)
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_EMAIL + email));
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_EMAIL + email));
 
         if (!event.getFollowers().contains(currentUser)) {
             throw new BadRequestException(ErrorMessage.EVENT_IS_NOT_IN_FAVORITES);
         }
 
         event.setFollowers(event.getAttenders()
-            .stream()
-            .filter(user -> !user.getId().equals(currentUser.getId()))
-            .collect(Collectors.toSet()));
+                .stream()
+                .filter(user -> !user.getId().equals(currentUser.getId()))
+                .collect(Collectors.toSet()));
         eventRepo.save(event);
     }
 
@@ -281,11 +360,11 @@ public class EventServiceImpl implements EventService {
     @Transactional
     public EventDto update(UpdateEventDto eventDto, String email, MultipartFile[] images) {
         Event toUpdate =
-            eventRepo.findById(eventDto.getId()).orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND));
+                eventRepo.findById(eventDto.getId()).orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND));
         User organizer = modelMapper.map(restClient.findByEmail(email), User.class);
 
         if (organizer.getRole() != Role.ROLE_ADMIN && organizer.getRole() != Role.ROLE_MODERATOR
-            && !organizer.getId().equals(toUpdate.getOrganizer().getId())) {
+                && !organizer.getId().equals(toUpdate.getOrganizer().getId())) {
             throw new UserHasNoPermissionToAccessException(ErrorMessage.USER_HAS_NO_PERMISSION);
         }
 
@@ -303,18 +382,18 @@ public class EventServiceImpl implements EventService {
     @Override
     public void rateEvent(Long eventId, String email, int grade) {
         Event event =
-            eventRepo.findById(eventId).orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND));
+                eventRepo.findById(eventId).orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND));
         User currentUser = modelMapper.map(restClient.findByEmail(email), User.class);
 
         if (findLastEventDateTime(event).isAfter(ZonedDateTime.now())) {
             throw new BadRequestException(ErrorMessage.EVENT_IS_NOT_FINISHED);
         }
         if (!event.getAttenders().stream().map(User::getId).collect(Collectors.toList())
-            .contains(currentUser.getId())) {
+                .contains(currentUser.getId())) {
             throw new BadRequestException(ErrorMessage.YOU_ARE_NOT_EVENT_SUBSCRIBER);
         }
         if (event.getEventGrades().stream().map(eventGrade -> eventGrade.getUser().getId()).collect(Collectors.toList())
-            .contains(currentUser.getId())) {
+                .contains(currentUser.getId())) {
             throw new BadRequestException(ErrorMessage.HAVE_ALREADY_RATED);
         }
 
@@ -322,21 +401,21 @@ public class EventServiceImpl implements EventService {
         eventRepo.save(event);
 
         userService.updateEventOrganizerRating(event.getOrganizer().getId(),
-            calculateUserEventOrganizerRating(event.getOrganizer()));
+                calculateUserEventOrganizerRating(event.getOrganizer()));
     }
 
     @Override
     public Set<EventAttenderDto> getAllEventAttenders(Long eventId) {
         Event event =
-            eventRepo.findById(eventId).orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND));
+                eventRepo.findById(eventId).orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND));
         return event.getAttenders().stream().map(attender -> modelMapper.map(attender, EventAttenderDto.class))
-            .collect(Collectors.toSet());
+                .collect(Collectors.toSet());
     }
 
     @Override
     public EventVO findById(Long eventId) {
         Event event = eventRepo.findById(eventId)
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.ECO_NEWS_NOT_FOUND_BY_ID + eventId));
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.ECO_NEWS_NOT_FOUND_BY_ID + eventId));
         return modelMapper.map(event, EventVO.class);
     }
 
@@ -370,9 +449,9 @@ public class EventServiceImpl implements EventService {
 
         if (updateEventDto.getTags() != null) {
             toUpdate.setTags(modelMapper.map(tagService
-                .findTagsWithAllTranslationsByNamesAndType(updateEventDto.getTags(), TagType.EVENT),
-                new TypeToken<List<Tag>>() {
-                }.getType()));
+                            .findTagsWithAllTranslationsByNamesAndType(updateEventDto.getTags(), TagType.EVENT),
+                    new TypeToken<List<Tag>>() {
+                    }.getType()));
         }
 
         updateImages(toUpdate, updateEventDto, images);
@@ -381,12 +460,12 @@ public class EventServiceImpl implements EventService {
             addAddressToLocation(updateEventDto.getDatesLocations());
             eventRepo.deleteEventDateLocationsByEventId(toUpdate.getId());
             toUpdate.setDates(updateEventDto.getDatesLocations().stream()
-                .map(d -> modelMapper.map(d, EventDateLocation.class))
-                .map(d -> {
-                    d.setEvent(toUpdate);
-                    return d;
-                })
-                .collect(Collectors.toList()));
+                    .map(d -> modelMapper.map(d, EventDateLocation.class))
+                    .map(d -> {
+                        d.setEvent(toUpdate);
+                        return d;
+                    })
+                    .collect(Collectors.toList()));
         }
     }
 
@@ -412,7 +491,7 @@ public class EventServiceImpl implements EventService {
         }
         if (updateEventDto.getAdditionalImages() != null) {
             updateEventDto.getAdditionalImages().forEach(img -> toUpdate
-                .setAdditionalImages(List.of(EventImages.builder().link(img).event(toUpdate).build())));
+                    .setAdditionalImages(List.of(EventImages.builder().link(img).event(toUpdate).build())));
         } else {
             toUpdate.setAdditionalImages(null);
         }
@@ -424,8 +503,8 @@ public class EventServiceImpl implements EventService {
             toUpdate.setTitleImage(updateEventDto.getTitleImage());
             if (updateEventDto.getAdditionalImages() != null) {
                 toUpdate.setAdditionalImages(updateEventDto.getAdditionalImages().stream()
-                    .map(url -> EventImages.builder().event(toUpdate).link(url).build())
-                    .collect(Collectors.toList()));
+                        .map(url -> EventImages.builder().event(toUpdate).link(url).build())
+                        .collect(Collectors.toList()));
             } else {
                 toUpdate.setAdditionalImages(null);
             }
@@ -454,7 +533,7 @@ public class EventServiceImpl implements EventService {
         }
         if (!additionalImagesStr.isEmpty()) {
             toUpdate.setAdditionalImages(additionalImagesStr.stream().map(url -> EventImages.builder()
-                .event(toUpdate).link(url).build()).collect(Collectors.toList()));
+                    .event(toUpdate).link(url).build()).collect(Collectors.toList()));
         } else {
             toUpdate.setAdditionalImages(null);
         }
@@ -462,18 +541,18 @@ public class EventServiceImpl implements EventService {
 
     private void addAddressToLocation(List<EventDateLocationDto> eventDateLocationDtos) {
         eventDateLocationDtos
-            .stream()
-            .filter(eventDateLocationDto -> Objects.nonNull(eventDateLocationDto.getCoordinates()))
-            .forEach(eventDateLocationDto -> {
-                AddressDto addressDto = eventDateLocationDto.getCoordinates();
-                AddressLatLngResponse response = googleApiService.getResultFromGeoCodeByCoordinates(
-                    new LatLng(addressDto.getLatitude(), addressDto.getLongitude()));
-                eventDateLocationDto.setCoordinates(modelMapper.map(response, AddressDto.class));
-            });
+                .stream()
+                .filter(eventDateLocationDto -> Objects.nonNull(eventDateLocationDto.getCoordinates()))
+                .forEach(eventDateLocationDto -> {
+                    AddressDto addressDto = eventDateLocationDto.getCoordinates();
+                    AddressLatLngResponse response = googleApiService.getResultFromGeoCodeByCoordinates(
+                            new LatLng(addressDto.getLatitude(), addressDto.getLongitude()));
+                    eventDateLocationDto.setCoordinates(modelMapper.map(response, AddressDto.class));
+                });
     }
 
     private ZonedDateTime findLastEventDateTime(Event event) {
         return Collections
-            .max(event.getDates().stream().map(EventDateLocation::getFinishDate).collect(Collectors.toList()));
+                .max(event.getDates().stream().map(EventDateLocation::getFinishDate).collect(Collectors.toList()));
     }
 }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -1907,7 +1907,41 @@ public class ModelUtils {
         dates.add(new EventDateLocation(2L, event,
             ZonedDateTime.of(2002, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
             ZonedDateTime.of(2002, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
-            null, null));
+            null, "url/"));
+        event.setDates(dates);
+        event.setTags(List.of(getEventTag()));
+        return event;
+    }
+
+    public static Event getOnlineEvent() {
+        Event event = new Event();
+
+        event.setDescription("Description");
+        event.setId(1L);
+        event.setOrganizer(getUser());
+        event.setTitle("Title");
+        List<EventDateLocation> dates = new ArrayList<>();
+        dates.add(new EventDateLocation(1L, event,
+                ZonedDateTime.of(2000, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+                ZonedDateTime.of(2000, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+                getAddress(), "url/"));
+        event.setDates(dates);
+        event.setTags(List.of(getEventTag()));
+        return event;
+    }
+
+    public static Event getOfflineOnlineEventIfEventFinalDateToday() {
+        Event event = new Event();
+
+        event.setDescription("Description");
+        event.setId(1L);
+        event.setOrganizer(getUser());
+        event.setTitle("Title");
+        List<EventDateLocation> dates = new ArrayList<>();
+        dates.add(new EventDateLocation(1L, event,
+                ZonedDateTime.of(2023, 7, 11, 1, 1, 1, 1, ZoneId.systemDefault()),
+                ZonedDateTime.now(),
+                getAddress(), "url/"));
         event.setDates(dates);
         event.setTags(List.of(getEventTag()));
         return event;
@@ -2118,8 +2152,8 @@ public class ModelUtils {
                 .build())
             .title("Title")
             .dates(List.of(new EventDateLocationDto(1L, null,
-                ZonedDateTime.of(2000, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
-                ZonedDateTime.of(2000, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+                ZonedDateTime.of(2023, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+                ZonedDateTime.of(2023, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
                 "/url",
                 AddressDto.builder().build())))
             .tags(List.of(TagUaEnDto.builder().id(1L).nameEn("Social")

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -37,6 +37,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.ui.Model;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.lang.reflect.Method;
@@ -48,12 +49,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyList;
@@ -112,21 +109,21 @@ class EventServiceImplTest {
         }.getType())).thenReturn(tags);
 
         when(googleApiService.getResultFromGeoCodeByCoordinates(any()))
-            .thenReturn(ModelUtils.getAddressLatLngResponse());
+                .thenReturn(ModelUtils.getAddressLatLngResponse());
 
         assertEquals(eventDto, eventService.save(addEventDtoRequest, ModelUtils.getUser().getEmail(), null));
 
         MultipartFile multipartFile = ModelUtils.getMultipartFile();
         when(fileService.upload(multipartFile)).thenReturn("/url1");
         assertEquals(eventDto,
-            eventService.save(addEventDtoRequest, ModelUtils.getUser().getEmail(),
-                new MultipartFile[] {multipartFile}));
+                eventService.save(addEventDtoRequest, ModelUtils.getUser().getEmail(),
+                        new MultipartFile[]{multipartFile}));
 
         MultipartFile[] multipartFiles = ModelUtils.getMultipartFiles();
         when(fileService.upload(multipartFiles[0])).thenReturn("/url1");
         when(fileService.upload(multipartFiles[1])).thenReturn("/url2");
         assertEquals(eventDto,
-            eventService.save(addEventDtoRequest, ModelUtils.getUser().getEmail(), multipartFiles));
+                eventService.save(addEventDtoRequest, ModelUtils.getUser().getEmail(), multipartFiles));
     }
 
     @Test
@@ -143,16 +140,16 @@ class EventServiceImplTest {
         when(modelMapper.map(eventWithoutCoordinates, EventDto.class)).thenReturn(eventDtoWithoutCoordinatesDto);
         List<TagVO> tagVOList = Collections.singletonList(ModelUtils.getTagVO());
         when(tagService.findTagsWithAllTranslationsByNamesAndType(addEventDtoWithoutCoordinates.getTags(),
-            TagType.EVENT)).thenReturn(tagVOList);
+                TagType.EVENT)).thenReturn(tagVOList);
         when(modelMapper.map(tagVOList, new TypeToken<List<Tag>>() {
         }.getType())).thenReturn(tags);
 
         assertEquals(eventDtoWithoutCoordinatesDto,
-            eventService.save(addEventDtoWithoutCoordinates, user.getEmail(), null));
+                eventService.save(addEventDtoWithoutCoordinates, user.getEmail(), null));
         verify(restClient, times(1)).findByEmail(user.getEmail());
         verify(eventRepo, times(1)).save(eventWithoutCoordinates);
         verify(tagService, times(1)).findTagsWithAllTranslationsByNamesAndType(addEventDtoWithoutCoordinates.getTags(),
-            TagType.EVENT);
+                TagType.EVENT);
     }
 
     @Test
@@ -183,7 +180,7 @@ class EventServiceImplTest {
         when(restClient.findByEmail(anyString())).thenReturn(userVO);
 
         assertThrows(UserHasNoPermissionToAccessException.class,
-            () -> eventService.update(eventToUpdateDto, userVoEmail, null));
+                () -> eventService.update(eventToUpdateDto, userVoEmail, null));
         verify(eventRepo).findById(1L);
         verify(restClient).findByEmail("user@email.com");
         verify(modelMapper).map(userVO, User.class);
@@ -200,14 +197,14 @@ class EventServiceImplTest {
         when(restClient.findByEmail(anyString())).thenReturn(ModelUtils.TEST_USER_VO);
 
         assertThrows(BadRequestException.class,
-            () -> eventService.update(eventToUpdateDto, userEmail, null));
+                () -> eventService.update(eventToUpdateDto, userEmail, null));
     }
 
     @Test
     @SneakyThrows
     void enhanceWithNewData() {
         Method method = EventServiceImpl.class.getDeclaredMethod("enhanceWithNewData", Event.class,
-            UpdateEventDto.class, MultipartFile[].class);
+                UpdateEventDto.class, MultipartFile[].class);
         method.setAccessible(true);
         Event event = ModelUtils.getEvent();
         Event expectedEvent = ModelUtils.getExpectedEvent();
@@ -229,15 +226,15 @@ class EventServiceImplTest {
 
         List updatedTagVO = List.of(ModelUtils.getTagVO());
         when(tagService.findTagsWithAllTranslationsByNamesAndType(eventToUpdateDto.getTags(), TagType.EVENT))
-            .thenReturn(updatedTagVO);
+                .thenReturn(updatedTagVO);
         when(modelMapper.map(updatedTagVO, new TypeToken<List<Tag>>() {
         }.getType())).thenReturn(ModelUtils.getEventTags());
         doNothing().when(eventRepo).deleteEventDateLocationsByEventId(1L);
         when(modelMapper.map(eventToUpdateDto.getDatesLocations().get(0), EventDateLocation.class))
-            .thenReturn(ModelUtils.getUpdatedEventDateLocation());
+                .thenReturn(ModelUtils.getUpdatedEventDateLocation());
 
         when(googleApiService.getResultFromGeoCodeByCoordinates(any()))
-            .thenReturn(ModelUtils.getAddressLatLngResponse());
+                .thenReturn(ModelUtils.getAddressLatLngResponse());
 
         method.invoke(eventService, event, eventToUpdateDto, null);
         assertEquals(event.getTitleImage(), expectedEvent.getTitleImage());
@@ -251,7 +248,7 @@ class EventServiceImplTest {
 
         method.invoke(eventService, event, eventToUpdateDto, null);
         assertEquals(expectedEvent.getAdditionalImages().get(0).getLink(),
-            event.getAdditionalImages().get(0).getLink());
+                event.getAdditionalImages().get(0).getLink());
         assertEquals(event.getTitleImage(), expectedEvent.getTitleImage());
 
         eventToUpdateDto.setImagesToDelete(List.of("New addition image"));
@@ -260,7 +257,7 @@ class EventServiceImplTest {
         method.invoke(eventService, event, eventToUpdateDto, null);
         assertEquals(expectedEvent.getTitleImage(), event.getTitleImage());
         assertEquals(expectedEvent.getAdditionalImages().get(0).getLink(),
-            event.getAdditionalImages().get(0).getLink());
+                event.getAdditionalImages().get(0).getLink());
 
         eventToUpdateDto.setAdditionalImages(null);
         method.invoke(eventService, event, eventToUpdateDto, null);
@@ -283,18 +280,18 @@ class EventServiceImplTest {
         method.invoke(eventService, event, eventToUpdateDto, multipartFiles);
         assertEquals(expectedEvent.getTitleImage(), event.getTitleImage());
         assertEquals(expectedEvent.getAdditionalImages().get(0).getLink(),
-            event.getAdditionalImages().get(0).getLink());
+                event.getAdditionalImages().get(0).getLink());
 
         eventToUpdateDto.setImagesToDelete(null);
         eventToUpdateDto.setTitleImage("url");
         eventToUpdateDto.setAdditionalImages(List.of("Add img 1", "Add img 2"));
         expectedEvent.setTitleImage("url");
         expectedEvent.setAdditionalImages(List.of(EventImages.builder().event(expectedEvent).link("Add img 1").build(),
-            EventImages.builder().event(expectedEvent).link("Add img 2").build()));
+                EventImages.builder().event(expectedEvent).link("Add img 2").build()));
         method.invoke(eventService, event, eventToUpdateDto, multipartFiles);
         assertEquals(expectedEvent.getTitleImage(), event.getTitleImage());
         assertEquals(expectedEvent.getAdditionalImages().get(0).getLink(),
-            event.getAdditionalImages().get(0).getLink());
+                event.getAdditionalImages().get(0).getLink());
         assertEquals("url2", event.getAdditionalImages().get(3).getLink());
 
         eventToUpdateDto.setAdditionalImages(null);
@@ -304,7 +301,7 @@ class EventServiceImplTest {
         MultipartFile multipartFile = ModelUtils.getMultipartFile();
         when(fileService.upload(multipartFile)).thenReturn("title url");
 
-        method.invoke(eventService, event, eventToUpdateDto, new MultipartFile[] {multipartFile});
+        method.invoke(eventService, event, eventToUpdateDto, new MultipartFile[]{multipartFile});
         assertEquals(expectedEvent.getTitleImage(), event.getTitleImage());
         assertNull(event.getAdditionalImages());
     }
@@ -340,15 +337,15 @@ class EventServiceImplTest {
         List updatedTagVO = List.of(ModelUtils.getTagVO());
 
         when(tagService.findTagsWithAllTranslationsByNamesAndType(eventToUpdateDto.getTags(), TagType.EVENT))
-            .thenReturn(updatedTagVO);
+                .thenReturn(updatedTagVO);
         when(modelMapper.map(updatedTagVO, new TypeToken<List<Tag>>() {
         }.getType())).thenReturn(ModelUtils.getEventTags());
         doNothing().when(eventRepo).deleteEventDateLocationsByEventId(1L);
         when(modelMapper.map(eventToUpdateDto.getDatesLocations().get(0), EventDateLocation.class))
-            .thenReturn(ModelUtils.getUpdatedEventDateLocation());
+                .thenReturn(ModelUtils.getUpdatedEventDateLocation());
 
         when(googleApiService.getResultFromGeoCodeByCoordinates(any()))
-            .thenReturn(ModelUtils.getAddressLatLngResponse());
+                .thenReturn(ModelUtils.getAddressLatLngResponse());
 
         updatedEventDto = eventService.update(eventToUpdateDto, ModelUtils.getUser().getEmail(), null);
 
@@ -360,7 +357,7 @@ class EventServiceImplTest {
     void delete(UserVO userVO, User user) {
         Event event = ModelUtils.getEvent();
         when(modelMapper.map(restClient.findByEmail(userVO.getEmail()), User.class))
-            .thenReturn(user);
+                .thenReturn(user);
         when(eventRepo.getOne(any())).thenReturn(event);
         doNothing().when(fileService).delete(any());
 
@@ -371,9 +368,9 @@ class EventServiceImplTest {
 
     private static Stream<Arguments> provideUserVOForDeleteEventTest() {
         return Stream.of(
-            Arguments.of(ModelUtils.getUserVO(), ModelUtils.getUser()),
-            Arguments.of(ModelUtils.getUserVO().setRole(Role.ROLE_ADMIN).setId(999L),
-                ModelUtils.getUser().setRole(Role.ROLE_ADMIN).setId(999L)));
+                Arguments.of(ModelUtils.getUserVO(), ModelUtils.getUser()),
+                Arguments.of(ModelUtils.getUserVO().setRole(Role.ROLE_ADMIN).setId(999L),
+                        ModelUtils.getUser().setRole(Role.ROLE_ADMIN).setId(999L)));
     }
 
     @Test
@@ -424,16 +421,166 @@ class EventServiceImplTest {
         when(restClient.findByEmail(principal.getName())).thenReturn(ModelUtils.TEST_USER_VO);
         when(modelMapper.map(ModelUtils.TEST_USER_VO, User.class)).thenReturn(ModelUtils.getUser());
 
-        when(eventRepo.findAllByAttender(pageRequest, ModelUtils.TEST_USER_VO.getId()))
-            .thenReturn(new PageImpl<>(events, pageRequest, events.size()));
+        when(eventRepo.findAllByAttender(ModelUtils.TEST_USER_VO.getId()))
+                .thenReturn(new ArrayList<>(events));
 
         when(modelMapper.map(events.get(0), EventDto.class)).thenReturn(expected);
 
+        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto1 =
+                eventService.getAllUserEvents(
+                        pageRequest, principal.getName(), "", "", "");
+        EventDto actual = eventDtoPageableAdvancedDto1.getPage().get(0);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void getAllUserOfflineEventsWithoutUserGeoPosition() {
+        String eventType = "OFFLINE";
+        List<Event> eventsOffline = List.of(ModelUtils.getEvent());
+        EventDto expected = ModelUtils.getEventDto();
+        Principal principal = ModelUtils.getPrincipal();
+        PageRequest pageRequest = PageRequest.of(0, 1);
+
+        when(restClient.findByEmail(principal.getName())).thenReturn(ModelUtils.TEST_USER_VO);
+        when(modelMapper.map(ModelUtils.TEST_USER_VO, User.class)).thenReturn(ModelUtils.getUser());
+
+        when(eventRepo.findAllByAttender(ModelUtils.TEST_USER_VO.getId()))
+                .thenReturn(new ArrayList<>(eventsOffline));
+        when(modelMapper.map(eventsOffline.get(0), EventDto.class)).thenReturn(expected);
+
         PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto =
-            eventService.getAllUserEvents(pageRequest, principal.getName());
+                eventService.getAllUserEvents(
+                        pageRequest, principal.getName(), "", "", eventType);
         EventDto actual = eventDtoPageableAdvancedDto.getPage().get(0);
 
         assertEquals(expected, actual);
+    }
+
+    @Test
+    void getAllUserOfflineEventsWithUserGeoPosition() {
+        String eventType = "OFFLINE";
+        String userLatitude = "50.42929";
+        String userLongitude = "30.53806";
+        List<Event> eventsOffline = List.of(ModelUtils.getEvent());
+        EventDto expected = ModelUtils.getEventDto();
+        Principal principal = ModelUtils.getPrincipal();
+        PageRequest pageRequest = PageRequest.of(0, 1);
+
+        when(restClient.findByEmail(principal.getName())).thenReturn(ModelUtils.TEST_USER_VO);
+        when(modelMapper.map(ModelUtils.TEST_USER_VO, User.class)).thenReturn(ModelUtils.getUser());
+
+        when(eventRepo.findAllByAttender(ModelUtils.TEST_USER_VO.getId()))
+                .thenReturn(new ArrayList<>(eventsOffline));
+        when(modelMapper.map(eventsOffline.get(0), EventDto.class)).thenReturn(expected);
+
+        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto =
+                eventService.getAllUserEvents(
+                        pageRequest, principal.getName(), userLatitude, userLongitude, eventType);
+        EventDto actual = eventDtoPageableAdvancedDto.getPage().get(0);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void getAllUserOfflineEventsWithUserGeoPositionIfEventFinishesToday() {
+        String eventType = "OFFLINE";
+        String userLatitude = "50.42929";
+        String userLongitude = "30.53806";
+        List<Event> eventsOffline = List.of(ModelUtils.getOfflineOnlineEventIfEventFinalDateToday());
+        EventDto expected = ModelUtils.getEventDto();
+        Principal principal = ModelUtils.getPrincipal();
+        PageRequest pageRequest = PageRequest.of(0, 1);
+
+        when(restClient.findByEmail(principal.getName())).thenReturn(ModelUtils.TEST_USER_VO);
+        when(modelMapper.map(ModelUtils.TEST_USER_VO, User.class)).thenReturn(ModelUtils.getUser());
+
+        when(eventRepo.findAllByAttender(ModelUtils.TEST_USER_VO.getId()))
+                .thenReturn(new ArrayList<>(eventsOffline));
+        when(modelMapper.map(eventsOffline.get(0), EventDto.class)).thenReturn(expected);
+
+        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto =
+                eventService.getAllUserEvents(
+                        pageRequest, principal.getName(), userLatitude, userLongitude, eventType);
+        EventDto actual = eventDtoPageableAdvancedDto.getPage().get(0);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void getAllUserOnlineEvents() {
+        String eventType = "ONLINE";
+        List<Event> eventsOnline = List.of(ModelUtils.getOnlineEvent());
+        EventDto expected = ModelUtils.getEventDto();
+        Principal principal = ModelUtils.getPrincipal();
+        PageRequest pageRequest = PageRequest.of(0, 1);
+
+        when(restClient.findByEmail(principal.getName())).thenReturn(ModelUtils.TEST_USER_VO);
+        when(modelMapper.map(ModelUtils.TEST_USER_VO, User.class)).thenReturn(ModelUtils.getUser());
+
+        when(eventRepo.findAllByAttender(ModelUtils.TEST_USER_VO.getId()))
+                .thenReturn(new ArrayList<>(eventsOnline));
+        when(modelMapper.map(eventsOnline.get(0), EventDto.class)).thenReturn(expected);
+
+        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto =
+                eventService.getAllUserEvents(
+                        pageRequest, principal.getName(), "", "", eventType);
+        EventDto actual = eventDtoPageableAdvancedDto.getPage().get(0);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void getAllUserOnlineEventsSortedByDate() {
+        String eventType = "OFFLINE";
+        String userLatitude = "50.42929";
+        String userLongitude = "30.53806";
+        List<Event> events = List.of(ModelUtils.getEvent(), ModelUtils.getOfflineOnlineEventIfEventFinalDateToday());
+        List<EventDto> expected = List.of(ModelUtils.getEventDto(), ModelUtils.getSecondEventDto());
+        Principal principal = ModelUtils.getPrincipal();
+        PageRequest pageRequest = PageRequest.of(0, 2);
+
+        when(restClient.findByEmail(principal.getName())).thenReturn(ModelUtils.TEST_USER_VO);
+        when(modelMapper.map(ModelUtils.TEST_USER_VO, User.class)).thenReturn(ModelUtils.getUser());
+        when(eventRepo.findAllByAttender(ModelUtils.TEST_USER_VO.getId()))
+                .thenReturn(new ArrayList<>(events));
+
+        for (int i = 0; i < events.size(); i++) {
+            when(modelMapper.map(events.get(i), EventDto.class)).thenReturn(expected.get(i));
+        }
+
+        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto =
+                eventService.getAllUserEvents(
+                        pageRequest, principal.getName(), userLatitude, userLongitude, eventType);
+        List<EventDto> actual = eventDtoPageableAdvancedDto.getPage();
+
+        assertEquals(expected.size(), actual.size());
+    }
+
+    @Test
+    void getAllUserOfflineEventsSortedByCoordinates() {
+        String eventType = "OFFLINE";
+        List<Event> events = List.of(ModelUtils.getOnlineEvent(), ModelUtils.getCloseEvent());
+        List<EventDto> expected = List.of(ModelUtils.getEventDto(), ModelUtils.getSecondEventDto());
+        Principal principal = ModelUtils.getPrincipal();
+        PageRequest pageRequest = PageRequest.of(0, 2);
+
+        when(restClient.findByEmail(principal.getName())).thenReturn(ModelUtils.TEST_USER_VO);
+        when(modelMapper.map(ModelUtils.TEST_USER_VO, User.class)).thenReturn(ModelUtils.getUser());
+        when(eventRepo.findAllByAttender(ModelUtils.TEST_USER_VO.getId()))
+                .thenReturn(new ArrayList<>(events));
+
+        for (int i = 0; i < events.size(); i++) {
+            when(modelMapper.map(events.get(i), EventDto.class)).thenReturn(expected.get(i));
+        }
+
+        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto =
+                eventService.getAllUserEvents(
+                        pageRequest, principal.getName(), "", "", eventType);
+        List<EventDto> actual = eventDtoPageableAdvancedDto.getPage();
+
+        assertEquals(expected.contains(ModelUtils.getEventDto()), actual.contains(ModelUtils.getEventDto()));
+        assertEquals(expected.contains(ModelUtils.getSecondEventDto()), actual.contains(ModelUtils.getEventDto()));
     }
 
     @Test
@@ -447,13 +594,13 @@ class EventServiceImplTest {
         when(modelMapper.map(ModelUtils.TEST_USER_VO, User.class)).thenReturn(ModelUtils.getUser());
 
         when(eventRepo.findEventsByOrganizer(pageRequest, ModelUtils.TEST_USER_VO.getId()))
-            .thenReturn(new PageImpl<>(events, pageRequest, events.size()));
+                .thenReturn(new PageImpl<>(events, pageRequest, events.size()));
 
         when(modelMapper.map(events.get(0), EventDto.class)).thenReturn(expected);
         when(modelMapper.map(events.get(1), EventDto.class)).thenReturn(ModelUtils.getSecondEventDto());
 
         PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto =
-            eventService.getEventsCreatedByUser(pageRequest, principal.getName());
+                eventService.getEventsCreatedByUser(pageRequest, principal.getName());
         EventDto actual = eventDtoPageableAdvancedDto.getPage().get(0);
         assertEquals(expected, actual);
     }
@@ -471,14 +618,14 @@ class EventServiceImplTest {
         when(modelMapper.map(userVO, User.class)).thenReturn(user);
 
         when(eventRepo.findRelatedEventsByUser(pageRequest, userVO.getId()))
-            .thenReturn(new PageImpl<>(events, pageRequest, events.size()));
+                .thenReturn(new PageImpl<>(events, pageRequest, events.size()));
 
         for (int i = 0; i < events.size(); i++) {
             when(modelMapper.map(events.get(i), EventDto.class)).thenReturn(expected.get(i));
         }
 
         PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto =
-            eventService.getRelatedToUserEvents(pageRequest, principal.getName());
+                eventService.getRelatedToUserEvents(pageRequest, principal.getName());
         List<EventDto> actual = eventDtoPageableAdvancedDto.getPage();
 
         assertArrayEquals(expected.toArray(), actual.toArray());
@@ -503,14 +650,14 @@ class EventServiceImplTest {
         when(modelMapper.map(userVO, User.class)).thenReturn(user);
 
         when(eventRepo.findRelatedEventsByUser(pageRequest, userVO.getId()))
-            .thenReturn(new PageImpl<>(events, pageRequest, events.size()));
+                .thenReturn(new PageImpl<>(events, pageRequest, events.size()));
 
         for (int i = 0; i < events.size(); i++) {
             when(modelMapper.map(events.get(i), EventDto.class)).thenReturn(eventDtos.get(i));
         }
 
         PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto =
-            eventService.getRelatedToUserEvents(pageRequest, principal.getName());
+                eventService.getRelatedToUserEvents(pageRequest, principal.getName());
         List<EventDto> result = eventDtoPageableAdvancedDto.getPage();
 
         result.forEach(eventDto -> assertFalse(eventDto.getIsSubscribed()));
@@ -531,14 +678,14 @@ class EventServiceImplTest {
         when(modelMapper.map(userVO, User.class)).thenReturn(user);
 
         when(eventRepo.findRelatedEventsByUser(pageRequest, userVO.getId()))
-            .thenReturn(new PageImpl<>(events, pageRequest, events.size()));
+                .thenReturn(new PageImpl<>(events, pageRequest, events.size()));
 
         for (int i = 0; i < events.size(); i++) {
             when(modelMapper.map(events.get(i), EventDto.class)).thenReturn(eventDtos.get(i));
         }
 
         PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto =
-            eventService.getRelatedToUserEvents(pageRequest, principal.getName());
+                eventService.getRelatedToUserEvents(pageRequest, principal.getName());
         List<EventDto> result = eventDtoPageableAdvancedDto.getPage();
 
         result.forEach(eventDto -> assertTrue(eventDto.getIsSubscribed()));
@@ -557,10 +704,10 @@ class EventServiceImplTest {
         when(modelMapper.map(userVO, User.class)).thenReturn(user);
 
         when(eventRepo.findRelatedEventsByUser(pageRequest, userVO.getId()))
-            .thenReturn(new PageImpl<>(events, pageRequest, eventSize));
+                .thenReturn(new PageImpl<>(events, pageRequest, eventSize));
 
         PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto =
-            eventService.getRelatedToUserEvents(pageRequest, principal.getName());
+                eventService.getRelatedToUserEvents(pageRequest, principal.getName());
         int actual = eventDtoPageableAdvancedDto.getPage().size();
         assertEquals(eventSize, actual);
     }
@@ -572,7 +719,7 @@ class EventServiceImplTest {
 
         when(eventRepo.findById(any())).thenReturn(Optional.of(event));
         when(modelMapper.map(restClient.findByEmail(ModelUtils.getUserVO().getEmail()), User.class))
-            .thenReturn(user);
+                .thenReturn(user);
         when(eventRepo.save(event)).thenReturn(event);
 
         eventService.addAttender(1L, "danylo@gmail.com");
@@ -589,7 +736,7 @@ class EventServiceImplTest {
 
         when(eventRepo.findById(any())).thenReturn(Optional.of(event));
         when(modelMapper.map(restClient.findByEmail(ModelUtils.getUserVO().getEmail()), User.class))
-            .thenReturn(user);
+                .thenReturn(user);
 
         assertThrows(BadRequestException.class, () -> eventService.addAttender(1L, TestConst.EMAIL));
 
@@ -608,7 +755,7 @@ class EventServiceImplTest {
 
         when(eventRepo.findById(any())).thenReturn(Optional.of(event));
         when(modelMapper.map(restClient.findByEmail(ModelUtils.getUserVO().getEmail()), User.class))
-            .thenReturn(user);
+                .thenReturn(user);
 
         assertThrows(BadRequestException.class, () -> eventService.addAttender(1L, "danylo@gmail.com"));
 
@@ -624,7 +771,7 @@ class EventServiceImplTest {
 
         when(eventRepo.findById(any())).thenReturn(Optional.of(event));
         when(modelMapper.map(restClient.findByEmail(ModelUtils.getUserVO().getEmail()), User.class))
-            .thenReturn(user);
+                .thenReturn(user);
         when(userRepo.findUserByIdAndByFriendId(2L, 1L)).thenReturn(Optional.of(user));
         when(eventRepo.save(event)).thenReturn(event);
 
@@ -643,7 +790,7 @@ class EventServiceImplTest {
 
         when(eventRepo.findById(any())).thenReturn(Optional.of(event));
         when(modelMapper.map(restClient.findByEmail(ModelUtils.getUserVO().getEmail()), User.class))
-            .thenReturn(user);
+                .thenReturn(user);
 
         assertThrows(BadRequestException.class, () -> eventService.addAttender(1L, TestConst.EMAIL));
 
@@ -662,7 +809,7 @@ class EventServiceImplTest {
 
         when(eventRepo.findById(any())).thenReturn(Optional.of(event));
         when(modelMapper.map(restClient.findByEmail(ModelUtils.getUserVO().getEmail()), User.class))
-            .thenReturn(user);
+                .thenReturn(user);
 
         assertThrows(BadRequestException.class, () -> eventService.addAttender(1L, "danylo@gmail.com"));
 
@@ -678,7 +825,7 @@ class EventServiceImplTest {
 
         when(eventRepo.findById(any())).thenReturn(Optional.of(event));
         when(modelMapper.map(restClient.findByEmail(ModelUtils.getUserVO().getEmail()), User.class))
-            .thenReturn(user);
+                .thenReturn(user);
         when(userRepo.findUserByIdAndByFriendId(2L, 1L)).thenReturn(Optional.empty());
 
         assertThrows(BadRequestException.class, () -> eventService.addAttender(1L, "danylo@gmail.com"));
@@ -810,7 +957,7 @@ class EventServiceImplTest {
         PageRequest pageRequest = PageRequest.of(0, 1);
 
         when(eventRepo.findAllByOrderByIdDesc(pageRequest))
-            .thenReturn(new PageImpl<>(events, pageRequest, events.size()));
+                .thenReturn(new PageImpl<>(events, pageRequest, events.size()));
         when(modelMapper.map(events.get(0), EventDto.class)).thenReturn(expected);
 
         PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getAll(pageRequest, null);
@@ -828,7 +975,7 @@ class EventServiceImplTest {
         PageRequest pageRequest = PageRequest.of(0, 1);
 
         when(eventRepo.findAllByOrderByIdDesc(pageRequest))
-            .thenReturn(new PageImpl<>(events, pageRequest, events.size()));
+                .thenReturn(new PageImpl<>(events, pageRequest, events.size()));
         when(modelMapper.map(events.get(0), EventDto.class)).thenReturn(expected);
         when(modelMapper.map(ModelUtils.TEST_USER_VO, User.class)).thenReturn(ModelUtils.getUser());
         when(restClient.findByEmail(principal.getName())).thenReturn(ModelUtils.TEST_USER_VO);
@@ -849,7 +996,7 @@ class EventServiceImplTest {
         Page<Event> page = new PageImpl<>(events, pageRequest, events.size());
         when(eventRepo.searchEventsBy(pageRequest, "query")).thenReturn(page);
         PageableAdvancedDto<EventDto> expected = new PageableAdvancedDto<>(eventDtos, eventDtos.size(), 0, 1,
-            0, false, false, true, true);
+                0, false, false, true, true);
         assertEquals(expected.getTotalPages(), eventService.searchEventsBy(pageRequest, "query").getTotalPages());
     }
 


### PR DESCRIPTION
 [[View my events] The upcoming events are displayed in random order on My events page #5148](url)

Sorting online events by date and offline by closeness to user geoposition if user shows his location, otherwise, by date. If no eventType is chosen all user events are sorted by date.
Added methods in EventServiceImpl : 
- getComparatorByDistance
- getComparatorByDates
- calculateDistance (to calculate distance between event attender and event location)
- getOfflineUserEventsSortedCloserToUserLocation (if filtration choice is online and event attender share his location)
- getOfflineUserEventsSortedByDate (if  filtration choice is online and even tattender share his location)
- getOnlineUserEventsSortedByDate (if filtration choice is online)
- sortUserEventsByEventType (method accept eventType and gives sorted List<Event> list)

Modified methods in EventServiceImpl: 
- getAllUserEvents

Created test for all new methods.
Test with local database are made in Postman with different scenarios, show correct endpoint data. 
Necessary to add 3 Params to succeed in testing:
eventType( may be: online,offline, or empty string)
userLatitude(may be: any string representing number for example 50.42929, or empty string)
userLongitude(may be: any string representing number,for example 30.53806 or empty string)


