### PR TITLE
[API] [Eco-news-comment-controller] Status 200OK is displayed when entered the wrong {parentCommentId} #6041

### DIFF
--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -190,6 +190,8 @@ public final class ErrorMessage {
     public static final String USER_HAS_NO_FRIEND_WITH_ID = "User has no friend with this id: ";
     public static final String INVALID_DURATION = "The duration for such habit is lower than previously set";
 
+    public static final String REPLIES_NOT_FOUND = "Replies not found by this parent comment id: ";
+
     private ErrorMessage() {
     }
 }

--- a/service/src/main/java/greencity/service/EcoNewsCommentServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsCommentServiceImpl.java
@@ -323,8 +323,11 @@ public class EcoNewsCommentServiceImpl implements EcoNewsCommentService {
         UserVO user = userVO == null ? UserVO.builder().build() : userVO;
         List<EcoNewsCommentDto> ecoNewsCommentDtos = pages
             .stream()
-            .peek(comment -> comment.setCurrentUserLiked(comment.getUsersLiked().stream()
-                .anyMatch(u -> u.getId().equals(user.getId()))))
+            .map(comment -> {
+                comment.setCurrentUserLiked(comment.getUsersLiked().stream()
+                    .anyMatch(u -> u.getId().equals(user.getId())));
+                return comment;
+            })
             .map(ecoNewsComment -> modelMapper.map(ecoNewsComment, EcoNewsCommentDto.class))
             .collect(Collectors.toList());
 

--- a/service/src/main/java/greencity/service/EcoNewsCommentServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsCommentServiceImpl.java
@@ -3,6 +3,8 @@ package greencity.service;
 import greencity.achievement.AchievementCalculation;
 import greencity.annotations.RatingCalculationEnum;
 import static greencity.constant.AppConstant.AUTHORIZATION;
+import static greencity.constant.ErrorMessage.REPLIES_NOT_FOUND;
+
 import greencity.constant.ErrorMessage;
 import greencity.dto.PageableDto;
 import greencity.dto.econews.EcoNewsVO;
@@ -303,8 +305,8 @@ public class EcoNewsCommentServiceImpl implements EcoNewsCommentService {
     /**
      * Method returns all replies to certain comment specified by parentCommentId.
      *
-     * @param parentCommentId specifies {@link greencity.entity.EcoNewsComment} to
-     *                        which we search for replies
+     * @param parentCommentId specifies {@link EcoNewsComment} to which we search
+     *                        for replies
      * @param userVO          current {@link User}
      * @return all replies to certain comment specified by parentCommentId.
      * @author Taras Dovganyuk
@@ -313,14 +315,16 @@ public class EcoNewsCommentServiceImpl implements EcoNewsCommentService {
     public PageableDto<EcoNewsCommentDto> findAllActiveReplies(Pageable pageable, Long parentCommentId, UserVO userVO) {
         Page<EcoNewsComment> pages = ecoNewsCommentRepo
             .findAllByParentCommentIdAndDeletedFalseOrderByCreatedDateDesc(pageable, parentCommentId);
+
+        if (pages.isEmpty()) {
+            throw new NotFoundException(REPLIES_NOT_FOUND + parentCommentId);
+        }
+
         UserVO user = userVO == null ? UserVO.builder().build() : userVO;
         List<EcoNewsCommentDto> ecoNewsCommentDtos = pages
             .stream()
-            .map(comment -> {
-                comment.setCurrentUserLiked(comment.getUsersLiked().stream()
-                    .anyMatch(u -> u.getId().equals(user.getId())));
-                return comment;
-            })
+            .peek(comment -> comment.setCurrentUserLiked(comment.getUsersLiked().stream()
+                .anyMatch(u -> u.getId().equals(user.getId()))))
             .map(ecoNewsComment -> modelMapper.map(ecoNewsComment, EcoNewsCommentDto.class))
             .collect(Collectors.toList());
 

--- a/service/src/test/java/greencity/service/EcoNewsCommentServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EcoNewsCommentServiceImplTest.java
@@ -7,8 +7,14 @@ import greencity.exception.exceptions.UserHasNoPermissionToAccessException;
 import javax.servlet.http.HttpServletRequest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import greencity.ModelUtils;
 import greencity.constant.ErrorMessage;
@@ -47,7 +53,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.security.core.parameters.P;
 
 @ExtendWith(MockitoExtension.class)
 class EcoNewsCommentServiceImplTest {

--- a/service/src/test/java/greencity/service/EcoNewsCommentServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EcoNewsCommentServiceImplTest.java
@@ -47,6 +47,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.parameters.P;
 
 @ExtendWith(MockitoExtension.class)
 class EcoNewsCommentServiceImplTest {
@@ -492,5 +493,16 @@ class EcoNewsCommentServiceImplTest {
 
         PageableDto<EcoNewsCommentDto> actual = ecoNewsCommentService.findAllActiveReplies(pageRequest, 1L, userVO);
         assertEquals(pageableDto, actual);
+    }
+
+    @Test
+    void findAllActiveRepliesThrowsNotFoundExceptionTest() {
+        UserVO userVO = ModelUtils.getUserVO();
+        PageRequest pageRequest = PageRequest.of(0, 1);
+        when(ecoNewsCommentRepo.findAllByParentCommentIdAndDeletedFalseOrderByCreatedDateDesc(pageRequest, 1L))
+            .thenReturn(Page.empty());
+        assertThrows(NotFoundException.class,
+            () -> ecoNewsCommentService.findAllActiveReplies(pageRequest, 1L, userVO));
+        verify(ecoNewsCommentRepo).findAllByParentCommentIdAndDeletedFalseOrderByCreatedDateDesc(pageRequest, 1L);
     }
 }


### PR DESCRIPTION
# GreenCityUBS PR
https://github.com/ita-social-projects/GreenCity/issues/6041

## Summary Of Changes :fire:
404 status code occurs, if we get empty list of replies to certain comment specified by parentCommentId

## Added
* Validation of parent-comment-id
* Tests to cover all new lines of code

## How to test :clipboard:

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
