### PR TITLE
Addition getEventsForCurrentPage method to EventServiceImpl

### DIFF
--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -184,11 +184,11 @@ public class EventServiceImpl implements EventService {
 
     private List<Event> sortUserEventsByEventType(
         String eventType, User attender, String userLatitude, String userLongitude) {
-        if (eventType.equalsIgnoreCase("ONLINE")) {
+        if (StringUtils.isNotBlank(eventType) && eventType.equalsIgnoreCase("ONLINE")) {
             return getOnlineUserEventsSortedByDate(attender);
         }
 
-        if (eventType.equalsIgnoreCase("OFFLINE")) {
+        if (StringUtils.isNotBlank(eventType) && eventType.equalsIgnoreCase("OFFLINE")) {
             return (StringUtils.isNotBlank(userLatitude) && StringUtils.isNotBlank(userLongitude))
                 ? getOfflineUserEventsSortedByUserLocation(attender, userLatitude, userLongitude)
                 : getOfflineUserEventsSortedByDate(attender);

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -156,7 +156,7 @@ public class EventServiceImpl implements EventService {
         User user = modelMapper.map(restClient.findByEmail(principal.getName()), User.class);
         List<Event> allEvents = getAllFilteredEventsAndSortedByIdDesc(
             eventRepo.findAll(), user.getId(), filterEventDto);
-        Page<Event> eventPage = new PageImpl<>(allEvents, page, allEvents.size());
+        Page<Event> eventPage = new PageImpl<>(getEventsForCurrentPage(page, allEvents), page, allEvents.size());
         return buildPageableAdvancedDto(eventPage);
     }
 
@@ -165,7 +165,7 @@ public class EventServiceImpl implements EventService {
         Pageable page, String email, String userLatitude, String userLongitude, String eventType) {
         User attender = modelMapper.map(restClient.findByEmail(email), User.class);
         List<Event> events = sortUserEventsByEventType(eventType, attender, userLatitude, userLongitude);
-        Page<Event> eventPage = new PageImpl<>(events, page, events.size());
+        Page<Event> eventPage = new PageImpl<>(getEventsForCurrentPage(page, events), page, events.size());
         return buildPageableAdvancedDto(eventPage, attender.getId());
     }
 
@@ -174,6 +174,12 @@ public class EventServiceImpl implements EventService {
         User user = modelMapper.map(restClient.findByEmail(email), User.class);
         Page<Event> events = eventRepo.findAllFavoritesByUser(user.getId(), page);
         return buildPageableAdvancedDto(events, user.getId());
+    }
+
+    private List<Event> getEventsForCurrentPage(Pageable page, List<Event> allEvents) {
+        int startIndex = page.getPageNumber() * page.getPageSize();
+        int endIndex = Math.min(startIndex + page.getPageSize(), allEvents.size());
+        return allEvents.subList(startIndex, endIndex);
     }
 
     private List<Event> sortUserEventsByEventType(


### PR DESCRIPTION
# GreenCity PR
[[GreenCity] Pagination for all events does not work correctly]](https://github.com/ita-social-projects/GreenCity/issues/6341)

## Issue :clipboard:
Pagination in EventServiceImpl getAllFilteredEvents() and getAllUserEvents() methods doesn't work correctly.
Instead of page with few events , page with all events is returned.

## Summary Of Changes :fire:
Method getEventsForCurrentPage() added to EventServiceImpl, that return list of events accordingly to Peageable request. 
Additionally has been added check StringUtils.isNotBlank() for input param EventType in method getAllUserEvents().

## Changed
Methods getAllFilteredEvents() and getAllUserEvents(). 