### PR TITLE
Event creation notification implementation

### DIFF
--- a/service-api/src/main/java/greencity/client/RestClient.java
+++ b/service-api/src/main/java/greencity/client/RestClient.java
@@ -11,6 +11,7 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 
 import greencity.dto.eventcomment.EventCommentForSendEmailDto;
+import greencity.message.SendEventCreationNotification;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.data.domain.Pageable;
@@ -550,5 +551,19 @@ public class RestClient {
             .findFirst()
             .map(Cookie::getValue).orElse(null);
         return token == null ? null : "Bearer " + token;
+    }
+
+    /**
+     * Method to send email notification about event creation to GreenCityUser.
+     *
+     * @param notification {@link SendEventCreationNotification} has message for
+     *                     sending email to user about event creation status.
+     * @author Olena Sotnik.
+     */
+    public void sendEventCreationNotification(SendEventCreationNotification notification) {
+        HttpEntity<SendEventCreationNotification> entity = new HttpEntity<>(notification, new HttpHeaders());
+        restTemplate.exchange(greenCityUserServerAddress
+            + RestTemplateLinks.SEND_EVENT_CREATION_NOTIFICATION, HttpMethod.POST, entity, Object.class)
+            .getBody();
     }
 }

--- a/service-api/src/main/java/greencity/constant/RestTemplateLinks.java
+++ b/service-api/src/main/java/greencity/constant/RestTemplateLinks.java
@@ -18,6 +18,7 @@ public class RestTemplateLinks {
     public static final String SEND_REPORT = "/email/sendReport";
     public static final String CHANGE_PLACE_STATUS = "/email/changePlaceStatus";
     public static final String SEND_HABIT_NOTIFICATION = "/email/sendHabitNotification";
+    public static final String SEND_EVENT_CREATION_NOTIFICATION = "/email/sendEventNotification";
     public static final String USER = "/user";
     public static final String USER_FIND_ALL = "user/findAll";
     public static final String FRIENDS = "/friends";

--- a/service-api/src/main/java/greencity/message/SendEventCreationNotification.java
+++ b/service-api/src/main/java/greencity/message/SendEventCreationNotification.java
@@ -1,0 +1,23 @@
+package greencity.message;
+
+import java.io.Serializable;
+
+import lombok.Getter;
+import lombok.ToString;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+/**
+ * Message, that is used for sending notification about event creation status on
+ * user email.
+ */
+@Getter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SendEventCreationNotification implements Serializable {
+    private String email;
+    private String messageBody;
+}

--- a/service-api/src/test/java/greencity/ModelUtils.java
+++ b/service-api/src/test/java/greencity/ModelUtils.java
@@ -21,10 +21,12 @@ import greencity.dto.user.UserVO;
 import greencity.dto.verifyemail.VerifyEmailVO;
 import greencity.enums.Role;
 import greencity.enums.ShoppingListItemStatus;
-import greencity.message.AddEcoNewsMessage;
 import greencity.message.SendChangePlaceStatusEmailMessage;
-import greencity.message.SendHabitNotification;
+import greencity.message.SendEventCreationNotification;
 import greencity.message.SendReportEmailMessage;
+import greencity.message.SendHabitNotification;
+import greencity.message.AddEcoNewsMessage;
+
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
@@ -209,6 +211,13 @@ public class ModelUtils {
             .image("")
             .defaultDuration(14)
             .tagIds(Set.of(20L))
+            .build();
+    }
+
+    public static SendEventCreationNotification getSendEventCreationNotification() {
+        return SendEventCreationNotification.builder()
+            .email("test@gmail.com")
+            .messageBody("You have successfully created event")
             .build();
     }
 }

--- a/service-api/src/test/java/greencity/client/RestClientTest.java
+++ b/service-api/src/test/java/greencity/client/RestClientTest.java
@@ -14,6 +14,7 @@ import greencity.dto.econews.EcoNewsForSendEmailDto;
 import greencity.dto.eventcomment.EventCommentForSendEmailDto;
 import greencity.enums.EmailNotification;
 import greencity.message.SendChangePlaceStatusEmailMessage;
+import greencity.message.SendEventCreationNotification;
 import greencity.message.SendHabitNotification;
 import greencity.message.SendReportEmailMessage;
 
@@ -560,5 +561,18 @@ class RestClientTest {
             }))
                 .thenReturn(ResponseEntity.status(HttpStatus.OK).body(expected));
         assertEquals(expected, restClient.findAllUsersCities());
+    }
+
+    @Test
+    void sendEventCreationNotificationTest() {
+        SendEventCreationNotification notification = ModelUtils.getSendEventCreationNotification();
+        HttpEntity<SendEventCreationNotification> entity = new HttpEntity<>(notification, new HttpHeaders());
+        when(restTemplate.exchange(greenCityUserServerAddress
+            + RestTemplateLinks.SEND_EVENT_CREATION_NOTIFICATION, HttpMethod.POST, entity, Object.class))
+                .thenReturn(ResponseEntity.ok(Object));
+        restClient.sendEventCreationNotification(notification);
+
+        verify(restTemplate).exchange(greenCityUserServerAddress
+            + RestTemplateLinks.SEND_EVENT_CREATION_NOTIFICATION, HttpMethod.POST, entity, Object.class);
     }
 }

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -103,7 +103,7 @@ public class EventServiceImpl implements EventService {
             }.getType()));
 
         Event savedEvent = eventRepo.save(toSave);
-        sendEmailNotification(savedEvent, organizer);
+        sendEmailNotification(savedEvent.getTitle(), organizer.getFirstName(), organizer.getEmail());
         return buildEventDto(savedEvent, organizer.getId());
     }
 
@@ -787,11 +787,11 @@ public class EventServiceImpl implements EventService {
      *
      * @author Olena Sotnik.
      */
-    public void sendEmailNotification(Event event, User user) {
-        String message = "Dear, " + user.getFirstName() + "!"
-            + "\nYou have successfully created an event: " + event.getTitle();
+    public void sendEmailNotification(String eventTitle, String userName, String email) {
+        String message = "Dear, " + userName + "!"
+            + "\nYou have successfully created an event: " + eventTitle;
         SendEventCreationNotification notification = SendEventCreationNotification.builder()
-            .email(user.getEmail())
+            .email(email)
             .messageBody(message)
             .build();
         restClient.sendEventCreationNotification(notification);

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -28,6 +28,7 @@ import greencity.enums.TagType;
 import greencity.exception.exceptions.BadRequestException;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.exception.exceptions.UserHasNoPermissionToAccessException;
+import greencity.message.SendEventCreationNotification;
 import greencity.repository.EventRepo;
 import greencity.repository.UserRepo;
 import lombok.RequiredArgsConstructor;
@@ -102,7 +103,7 @@ public class EventServiceImpl implements EventService {
             }.getType()));
 
         Event savedEvent = eventRepo.save(toSave);
-
+        sendEmailNotification(savedEvent, organizer);
         return buildEventDto(savedEvent, organizer.getId());
     }
 
@@ -779,5 +780,20 @@ public class EventServiceImpl implements EventService {
 
     private EventDto buildEventDto(Event event) {
         return modelMapper.map(event, EventDto.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @author Olena Sotnik.
+     */
+    public void sendEmailNotification(Event event, User user) {
+        String message = "Dear, " + user.getFirstName() + "!"
+            + "\nYou have successfully created an event: " + event.getTitle();
+        SendEventCreationNotification notification = SendEventCreationNotification.builder()
+            .email(user.getEmail())
+            .messageBody(message)
+            .build();
+        restClient.sendEventCreationNotification(notification);
     }
 }


### PR DESCRIPTION
# GreenCity PR
## Issue link :clipboard:
[[Add event] User is not received a notification on email upon status of event creation #5874](https://github.com/ita-social-projects/GreenCity/issues/5874)

Notification via email about status of event creation has not been implemented. 
## Summary Of Changes :fire:
- created class SendEventCreationNotification in service-api
- added method sendEventCreationNotification in RestClient class
- code covered by tests
- changed method save in EventServiceImpl
- added method sendEmailNotification() in EventServiceImpl

