### PR TITLE
Deleted values from employee_authorities-mapping

### DIFF
--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -173,5 +173,6 @@
     <include file="db/changelog/logs/ch-delete-from-tag_translations-Spodaryk.xml"/>
     <include file="db/changelog/logs/ch-delete-from-languages-Spodaryk.xml"/>
     <include file="db/changelog/logs/ch-delete-values-employee_authorities-mapping-Spodaryk.xml"/>
+    <include file="db/changelog/logs/ch-delete-values-positions_authorities-mapping-Spodaryk.xml"/>
 </databaseChangeLog>
 

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -172,5 +172,6 @@
     <include file="db/changelog/logs/ch-delete-from-fact_of_the_day_translations-Spodaryk.xml"/>
     <include file="db/changelog/logs/ch-delete-from-tag_translations-Spodaryk.xml"/>
     <include file="db/changelog/logs/ch-delete-from-languages-Spodaryk.xml"/>
+    <include file="db/changelog/logs/ch-delete-values-employee_authorities-mapping-Spodaryk.xml"/>
 </databaseChangeLog>
 

--- a/dao/src/main/resources/db/changelog/logs/ch-delete-values-employee_authorities-mapping-Spodaryk.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-delete-values-employee_authorities-mapping-Spodaryk.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="Spodaryk-25" author="Oksana Spodaryk">
+        <sqlFile path="db/functions/delete-values-positions_authorities.sql"/>
+    </changeSet>
+    <changeSet id="Spodaryk-26" author="Oksana Spodaryk">
+        <sqlFile path="db/functions/delete-values-positions_authorities.sql"/>
+    </changeSet>
+</databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-delete-values-positions_authorities-mapping-Spodaryk.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-delete-values-positions_authorities-mapping-Spodaryk.xml
@@ -4,7 +4,7 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
-    <changeSet id="Spodaryk-25" author="Oksana Spodaryk">
-        <sqlFile path="db/functions/delete-values-employee_authorities.sql"/>
+    <changeSet id="Spodaryk-26" author="Oksana Spodaryk">
+        <sqlFile path="db/functions/delete-values-positions_authorities.sql"/>
     </changeSet>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/functions/delete-values-employee_authorities.sql
+++ b/dao/src/main/resources/db/functions/delete-values-employee_authorities.sql
@@ -1,0 +1,35 @@
+DELETE FROM employee_authorities_mapping
+WHERE user_id IN (
+    SELECT empl.user_id
+    FROM employee_authorities_mapping AS empl
+             INNER JOIN employee_positions_mapping AS epm ON empl.user_id = epm.user_id
+    WHERE epm.position_id IN (
+        SELECT id
+        FROM positions p
+        WHERE p.name_eng = 'Admin'
+    )
+      AND empl.authority_id IN (
+        SELECT id
+        FROM employee_authorities
+        WHERE name = 'CREATE_NEW_LOCATION'
+           OR name = 'CREATE_NEW_COURIER'
+           OR name = 'CREATE_NEW_STATION'
+           OR name = 'CREATE_PRICING_CARD'
+    )
+);
+DELETE FROM employee_authorities_mapping
+WHERE user_id IN (
+    SELECT empl.user_id
+    FROM employee_authorities_mapping AS empl
+             INNER JOIN employee_positions_mapping AS epm ON empl.user_id = epm.user_id
+    WHERE epm.position_id IN (
+        SELECT id
+        FROM positions p
+        WHERE p.name_eng = 'Service Manager'
+    )
+      AND empl.authority_id IN (
+        SELECT id
+        FROM employee_authorities
+        WHERE name = 'CREATE_PRICING_CARD'
+    )
+);

--- a/dao/src/main/resources/db/functions/delete-values-positions_authorities.sql
+++ b/dao/src/main/resources/db/functions/delete-values-positions_authorities.sql
@@ -1,0 +1,22 @@
+DELETE FROM positions_authorities_mapping AS pam
+    USING positions AS p
+WHERE pam.position_id = p.id
+  AND p.name_eng = 'Admin'
+  AND pam.authorities_id IN (
+    SELECT id
+    FROM employee_authorities
+    WHERE name = 'CREATE_NEW_LOCATION'
+   OR name = 'CREATE_NEW_COURIER'
+   OR name = 'CREATE_NEW_STATION'
+   OR name = 'CREATE_PRICING_CARD'
+    );
+
+DELETE FROM positions_authorities_mapping AS pam
+    USING positions AS p
+WHERE pam.position_id = p.id
+  AND p.name_eng = 'Service Manager'
+  AND pam.authorities_id IN (
+    SELECT id
+    FROM employee_authorities
+    WHERE name = 'CREATE_PRICING_CARD'
+    );


### PR DESCRIPTION
# GreenCity PR
[[Employee (Super Admin cabinet)]An employee in the position of Admin has access to authorities that is not allowed by default #6403](https://github.com/ita-social-projects/GreenCity/issues/6403)
[[Employee (Admin cabinet)]An employee in the position of Service Manager has access to authority that is not allowed by default #6402](https://github.com/ita-social-projects/GreenCity/issues/6402)

## Summary Of Changes :fire:
Deleted values from employee_authorities-mapping for exact moments

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers