### PR TITLE
correct response in econews/comments/replies/{parentCommentId}

### DIFF
--- a/dao/src/main/java/greencity/repository/EcoNewsCommentRepo.java
+++ b/dao/src/main/java/greencity/repository/EcoNewsCommentRepo.java
@@ -8,6 +8,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface EcoNewsCommentRepo extends JpaRepository<EcoNewsComment, Long> {
@@ -21,6 +23,15 @@ public interface EcoNewsCommentRepo extends JpaRepository<EcoNewsComment, Long> 
      */
     Page<EcoNewsComment> findAllByParentCommentIsNullAndEcoNewsIdOrderByCreatedDateDesc(Pageable pageable,
         Long ecoNewsId);
+
+    /**
+     * Method returns all replies to comment, specified by parentCommentId.
+     *
+     * @param parentCommentId id of comment, replies to which we get.
+     * @return all replies to comment, specified by parentCommentId.
+     */
+    @Query("SELECT ec from EcoNewsComment ec where ec.parentComment.id = :parentCommentId ")
+    Optional<List<EcoNewsComment>> findAllByParentCommentId(Long parentCommentId);
 
     /**
      * Method returns all replies to comment, specified by parentCommentId and by

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -126,6 +126,8 @@ public final class ErrorMessage {
     public static final String PLACE_NOT_FOUND_BY_ID = "The place does not exist by this id: ";
     public static final String PLACE_STATUS_NOT_DIFFERENT = "Place with id: %d already has this status: %s";
     public static final String COMMENT_NOT_FOUND_EXCEPTION = "The comment with entered id doesn't exist";
+    public static final String COMMENT_NOT_FOUND_BY_PARENT_COMMENT_ID =
+        "The comment with entered parent_comment_id doesn't exist";
     public static final String COMMENT_PROPERTY_TYPE_NOT_FOUND = "For type comment not found this property :";
     public static final String CANNOT_REPLY_THE_REPLY = "Can not make a reply to a reply";
     public static final String NOT_A_CURRENT_USER = "You can't perform actions with the data of other user";

--- a/service/src/main/java/greencity/service/EcoNewsCommentServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsCommentServiceImpl.java
@@ -34,6 +34,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -132,6 +133,10 @@ public class EcoNewsCommentServiceImpl implements EcoNewsCommentService {
      */
     @Override
     public PageableDto<EcoNewsCommentDto> findAllReplies(Pageable pageable, Long parentCommentId, UserVO userVO) {
+        Optional<List<EcoNewsComment>> checkExistComment = ecoNewsCommentRepo.findAllByParentCommentId(parentCommentId);
+        if (checkExistComment.isEmpty()) {
+            throw new NotFoundException(ErrorMessage.COMMENT_NOT_FOUND_BY_PARENT_COMMENT_ID);
+        }
         Page<EcoNewsComment> pages = ecoNewsCommentRepo
             .findAllByParentCommentIdOrderByCreatedDateDesc(pageable, parentCommentId);
         List<EcoNewsCommentDto> ecoNewsCommentDtos = pages

--- a/service/src/test/java/greencity/service/EcoNewsCommentServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EcoNewsCommentServiceImplTest.java
@@ -222,6 +222,9 @@ class EcoNewsCommentServiceImplTest {
         assertEquals(4, allReplies.getTotalElements());
         assertEquals(1, allReplies.getCurrentPage());
         assertEquals(1, allReplies.getPage().size());
+        verify(ecoNewsCommentRepo).findAllByParentCommentId(parentCommentId);
+        verify(ecoNewsCommentRepo).findAllByParentCommentIdOrderByCreatedDateDesc(pageable, parentCommentId);
+        verify(modelMapper).map(ecoNewsCommentChild, EcoNewsCommentDto.class);
     }
 
     @Test
@@ -239,6 +242,8 @@ class EcoNewsCommentServiceImplTest {
 
         assertThrows(NotFoundException.class,
             () -> ecoNewsCommentService.findAllReplies(pageable, parentCommentId, userVO));
+
+        verify(ecoNewsCommentRepo).findAllByParentCommentId(parentCommentId);
     }
 
     @Test

--- a/service/src/test/java/greencity/service/EcoNewsCommentServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EcoNewsCommentServiceImplTest.java
@@ -202,12 +202,14 @@ class EcoNewsCommentServiceImplTest {
         int pageSize = 3;
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
         UserVO userVO = getUserVO();
-        User user = getUser();
         Long parentCommentId = 1L;
         EcoNewsComment ecoNewsCommentChild = ModelUtils.getEcoNewsComment();
         ecoNewsCommentChild.setParentComment(ModelUtils.getEcoNewsComment());
         ecoNewsCommentChild.setUsersLiked(new HashSet<>());
         Page<EcoNewsComment> pages = new PageImpl<>(Collections.singletonList(ecoNewsCommentChild), pageable, 1);
+
+        when(ecoNewsCommentRepo.findAllByParentCommentId(parentCommentId))
+            .thenReturn(Optional.of(List.of(ecoNewsCommentChild)));
 
         when(ecoNewsCommentRepo.findAllByParentCommentIdOrderByCreatedDateDesc(pageable, parentCommentId))
             .thenReturn(pages);
@@ -220,6 +222,23 @@ class EcoNewsCommentServiceImplTest {
         assertEquals(4, allReplies.getTotalElements());
         assertEquals(1, allReplies.getCurrentPage());
         assertEquals(1, allReplies.getPage().size());
+    }
+
+    @Test
+    void findAllRepliesThrewException() {
+        int pageNumber = 1;
+        int pageSize = 3;
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        UserVO userVO = getUserVO();
+        Long parentCommentId = 1L;
+        EcoNewsComment ecoNewsCommentChild = ModelUtils.getEcoNewsComment();
+        ecoNewsCommentChild.setParentComment(ModelUtils.getEcoNewsComment());
+        ecoNewsCommentChild.setUsersLiked(new HashSet<>());
+
+        when(ecoNewsCommentRepo.findAllByParentCommentId(parentCommentId)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class,
+            () -> ecoNewsCommentService.findAllReplies(pageable, parentCommentId, userVO));
     }
 
     @Test


### PR DESCRIPTION
## Summary Of Issue :
The response is 200 instead 404 when enter not existing parameter of parentCommentId


**Issue Link**
https://github.com/ita-social-projects/GreenCity/issues/6367


## Summary Of Changes :
1)changed findAllReplies method in EcoNewsCommentServiceImpl
2)added findAllByParentCommentId method in EcoNewsCommentRepo 
3)added new error message
4) added new test in EcoNewsCommentServiceImplTest



## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [ ] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers