### PR TITLE
correct response in econews/comments/replies/active/{parentCommentId}

### DIFF
--- a/service/src/main/java/greencity/service/EcoNewsCommentServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsCommentServiceImpl.java
@@ -325,6 +325,9 @@ public class EcoNewsCommentServiceImpl implements EcoNewsCommentService {
         Page<EcoNewsComment> pages = ecoNewsCommentRepo
             .findAllByParentCommentIdAndStatusNotOrderByCreatedDateDesc(pageable, parentCommentId,
                 CommentStatus.DELETED);
+        if (pages.isEmpty()) {
+            throw new NotFoundException(ErrorMessage.COMMENT_NOT_FOUND_BY_PARENT_COMMENT_ID);
+        }
         UserVO user = userVO == null ? UserVO.builder().build() : userVO;
         List<EcoNewsCommentDto> ecoNewsCommentDtos = pages
             .stream()

--- a/service/src/test/java/greencity/service/EcoNewsCommentServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EcoNewsCommentServiceImplTest.java
@@ -524,4 +524,23 @@ class EcoNewsCommentServiceImplTest {
         PageableDto<EcoNewsCommentDto> actual = ecoNewsCommentService.findAllActiveReplies(pageRequest, 1L, userVO);
         assertEquals(pageableDto, actual);
     }
+
+    @Test
+    void findAllActiveRepliesThrowException() {
+        UserVO userVO = ModelUtils.getUserVO();
+        List<EcoNewsComment> ecoNewsComments1 = List.of();
+        PageRequest pageRequest = PageRequest.of(0, 2);
+        Page<EcoNewsComment> page1 = new PageImpl<>(ecoNewsComments1, pageRequest, ecoNewsComments1.size());
+
+        when(ecoNewsCommentRepo
+            .findAllByParentCommentIdAndStatusNotOrderByCreatedDateDesc(pageRequest, 11111L,
+                CommentStatus.DELETED))
+                    .thenReturn(page1);
+
+        assertThrows(NotFoundException.class,
+            () -> ecoNewsCommentService.findAllActiveReplies(pageRequest, 11111L, userVO));
+
+        verify(ecoNewsCommentRepo).findAllByParentCommentIdAndStatusNotOrderByCreatedDateDesc(pageRequest,
+            11111L, CommentStatus.DELETED);
+    }
 }


### PR DESCRIPTION
## Summary Of Issue :
The response is 200 instead 404 when enter not existing parameter of parentCommentId


**Issue Link**
https://github.com/ita-social-projects/GreenCity/issues/6368


## Summary Of Changes :
1)add check if exist active replies for parentCommentId
2)added new test in EcoNewsCommentServiceImplTest



## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [ ] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers