### PR TITLE
Update custom habit implementation change

### DIFF
--- a/service/src/main/java/greencity/service/HabitServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitServiceImpl.java
@@ -432,13 +432,17 @@ public class HabitServiceImpl implements HabitService {
     }
 
     private void updateHabitTranslationsForCustomHabit(CustomHabitDtoRequest habitDto, Habit habit) {
-        HabitTranslationDto habitTranslationDto = habitDto.getHabitTranslations().get(0);
-        List<HabitTranslation> habitTranslations = habitTranslationRepo.findAllByHabit(habit);
-        habitTranslations.forEach(habitTranslation -> {
-            habitTranslation.setName(habitTranslationDto.getName());
-            habitTranslation.setDescription(habitTranslationDto.getDescription());
-            habitTranslation.setHabitItem(habitTranslationDto.getHabitItem());
-        });
+        Optional<HabitTranslationDto> habitTranslationDtoOptional = habitDto.getHabitTranslations().stream()
+            .findFirst();
+        if (habitTranslationDtoOptional.isPresent()) {
+            HabitTranslationDto habitTranslationDto = habitTranslationDtoOptional.get();
+            List<HabitTranslation> habitTranslations = habitTranslationRepo.findAllByHabit(habit);
+            habitTranslations.forEach(habitTranslation -> {
+                habitTranslation.setName(habitTranslationDto.getName());
+                habitTranslation.setDescription(habitTranslationDto.getDescription());
+                habitTranslation.setHabitItem(habitTranslationDto.getHabitItem());
+            });
+        }
     }
 
     private void saveHabitTranslationListsToHabitTranslationRepo(CustomHabitDtoRequest habitDto, Habit habit) {

--- a/service/src/main/java/greencity/service/HabitServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitServiceImpl.java
@@ -434,15 +434,14 @@ public class HabitServiceImpl implements HabitService {
     private void updateHabitTranslationsForCustomHabit(CustomHabitDtoRequest habitDto, Habit habit) {
         Optional<HabitTranslationDto> habitTranslationDtoOptional = habitDto.getHabitTranslations().stream()
             .findFirst();
-        if (habitTranslationDtoOptional.isPresent()) {
-            HabitTranslationDto habitTranslationDto = habitTranslationDtoOptional.get();
-            List<HabitTranslation> habitTranslations = habitTranslationRepo.findAllByHabit(habit);
-            habitTranslations.forEach(habitTranslation -> {
-                habitTranslation.setName(habitTranslationDto.getName());
-                habitTranslation.setDescription(habitTranslationDto.getDescription());
-                habitTranslation.setHabitItem(habitTranslationDto.getHabitItem());
-            });
-        }
+        habitTranslationDtoOptional.ifPresent(habitTranslationDto -> {
+            habitTranslationRepo.findAllByHabit(habit)
+                .forEach(habitTranslation -> {
+                    habitTranslation.setName(habitTranslationDto.getName());
+                    habitTranslation.setDescription(habitTranslationDto.getDescription());
+                    habitTranslation.setHabitItem(habitTranslationDto.getHabitItem());
+                });
+        });
     }
 
     private void saveHabitTranslationListsToHabitTranslationRepo(CustomHabitDtoRequest habitDto, Habit habit) {

--- a/service/src/main/java/greencity/service/HabitServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitServiceImpl.java
@@ -6,6 +6,7 @@ import greencity.dto.PageableDto;
 import greencity.dto.habit.CustomHabitDtoRequest;
 import greencity.dto.habit.CustomHabitDtoResponse;
 import greencity.dto.habit.HabitDto;
+import greencity.dto.habittranslation.HabitTranslationDto;
 import greencity.dto.shoppinglistitem.ShoppingListItemDto;
 import greencity.dto.user.UserProfilePictureDto;
 import greencity.dto.user.UserVO;
@@ -382,12 +383,11 @@ public class HabitServiceImpl implements HabitService {
             toUpdate.setDefaultDuration(habitDto.getDefaultDuration());
         }
         if (isNotEmpty(habitDto.getHabitTranslations())) {
-            habitTranslationRepo.deleteAllByHabit(toUpdate);
-            saveHabitTranslationListsToHabitTranslationRepo(habitDto, toUpdate);
+            updateHabitTranslationsForCustomHabit(habitDto, toUpdate);
         }
         if (isNotEmpty(habitDto.getCustomShoppingListItemDto())) {
-            customShoppingListItemRepo.deleteCustomShoppingListItemsByHabitId(toUpdate.getId());
-            setCustomShoppingListItemToHabit(habitDto, toUpdate, user);
+            saveNewCustomShoppingListItemsToUpdate(habitDto, toUpdate, user);
+            updateExistingCustomShoppingListItems(habitDto, toUpdate, user);
         }
         if (StringUtils.isNotBlank(habitDto.getImage())) {
             image = fileService.convertToMultipartImage(habitDto.getImage());
@@ -398,6 +398,47 @@ public class HabitServiceImpl implements HabitService {
         if (isNotEmpty(habitDto.getTagIds())) {
             setTagsIdsToHabit(habitDto, toUpdate);
         }
+    }
+
+    private void saveNewCustomShoppingListItemsToUpdate(CustomHabitDtoRequest habitDto, Habit habit, User user) {
+        List<CustomShoppingListItem> customShoppingListItems = customShoppingListMapper
+            .mapAllToList(habitDto.getCustomShoppingListItemDto());
+
+        customShoppingListItems.stream()
+            .filter(item -> Objects.isNull(item.getId()))
+            .forEach(customShoppingListItem -> {
+                customShoppingListItem.setHabit(habit);
+                customShoppingListItem.setUser(user);
+                customShoppingListItemRepo.save(customShoppingListItem);
+            });
+    }
+
+    private void updateExistingCustomShoppingListItems(CustomHabitDtoRequest habitDto, Habit habit, User user) {
+        List<CustomShoppingListItem> customShoppingListItems = customShoppingListItemRepo
+            .findAllByUserIdAndHabitId(user.getId(), habit.getId());
+
+        customShoppingListItems.stream()
+            .forEach(item -> habitDto.getCustomShoppingListItemDto().stream()
+                .filter(itemToUpdate -> item.getId().equals(itemToUpdate.getId()))
+                .forEach(itemToUpdate -> {
+                    item.setStatus(itemToUpdate.getStatus());
+                    item.setText(itemToUpdate.getText());
+                }));
+
+        customShoppingListItemRepo.deleteAll(customShoppingListItems.stream()
+            .filter(item -> habitDto.getCustomShoppingListItemDto().stream()
+                .noneMatch(itemToUpdate -> item.getId().equals(itemToUpdate.getId())))
+            .collect(Collectors.toList()));
+    }
+
+    private void updateHabitTranslationsForCustomHabit(CustomHabitDtoRequest habitDto, Habit habit) {
+        HabitTranslationDto habitTranslationDto = habitDto.getHabitTranslations().get(0);
+        List<HabitTranslation> habitTranslations = habitTranslationRepo.findAllByHabit(habit);
+        habitTranslations.forEach(habitTranslation -> {
+            habitTranslation.setName(habitTranslationDto.getName());
+            habitTranslation.setDescription(habitTranslationDto.getDescription());
+            habitTranslation.setHabitItem(habitTranslationDto.getHabitItem());
+        });
     }
 
     private void saveHabitTranslationListsToHabitTranslationRepo(CustomHabitDtoRequest habitDto, Habit habit) {

--- a/service/src/main/java/greencity/service/HabitServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitServiceImpl.java
@@ -434,14 +434,12 @@ public class HabitServiceImpl implements HabitService {
     private void updateHabitTranslationsForCustomHabit(CustomHabitDtoRequest habitDto, Habit habit) {
         Optional<HabitTranslationDto> habitTranslationDtoOptional = habitDto.getHabitTranslations().stream()
             .findFirst();
-        habitTranslationDtoOptional.ifPresent(habitTranslationDto -> {
-            habitTranslationRepo.findAllByHabit(habit)
-                .forEach(habitTranslation -> {
-                    habitTranslation.setName(habitTranslationDto.getName());
-                    habitTranslation.setDescription(habitTranslationDto.getDescription());
-                    habitTranslation.setHabitItem(habitTranslationDto.getHabitItem());
-                });
-        });
+        habitTranslationDtoOptional.ifPresent(habitTranslationDto -> habitTranslationRepo.findAllByHabit(habit)
+            .forEach(habitTranslation -> {
+                habitTranslation.setName(habitTranslationDto.getName());
+                habitTranslation.setDescription(habitTranslationDto.getDescription());
+                habitTranslation.setHabitItem(habitTranslationDto.getHabitItem());
+            }));
     }
 
     private void saveHabitTranslationListsToHabitTranslationRepo(CustomHabitDtoRequest habitDto, Habit habit) {

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -2838,9 +2838,23 @@ public class ModelUtils {
             .build();
     }
 
-    public static CustomHabitDtoRequest getСustomHabitDtoRequestWithTagsForServiceTest() {
+    public static CustomHabitDtoRequest getСustomHabitDtoRequestWithNewCustomShoppingListItem() {
         return CustomHabitDtoRequest.builder()
+            .customShoppingListItemDto(List.of(
+                CustomShoppingListItemResponseDto.builder()
+                    .id(null)
+                    .status(ShoppingListItemStatus.ACTIVE)
+                    .text(SHOPPING_LIST_TEXT)
+                    .build()))
             .tagIds(Set.of(20L))
+            .build();
+    }
+
+    public static CustomShoppingListItem getCustomShoppingListItemForUpdate() {
+        return CustomShoppingListItem.builder()
+            .id(1L)
+            .status(ShoppingListItemStatus.ACTIVE)
+            .text(SHOPPING_LIST_TEXT)
             .build();
     }
 

--- a/service/src/test/java/greencity/service/HabitServiceImplTest.java
+++ b/service/src/test/java/greencity/service/HabitServiceImplTest.java
@@ -906,7 +906,7 @@ class HabitServiceImplTest {
             habitService.updateCustomHabit(customHabitDtoRequest, 1L, "user@email.com", image));
 
         verify(customShoppingListItemRepo, times(2)).findAllByUserIdAndHabitId(2L, 1L);
-        // verify(customShoppingListItemRepo).save(any());
+        verify(customShoppingListItemRepo).save(any());
         verify(habitRepo).findById(anyLong());
         verify(userRepo).findByEmail(user.getEmail());
         verify(habitRepo).save(any());

--- a/service/src/test/java/greencity/service/HabitServiceImplTest.java
+++ b/service/src/test/java/greencity/service/HabitServiceImplTest.java
@@ -816,10 +816,6 @@ class HabitServiceImplTest {
         when(habitRepo.findById(1L)).thenReturn(Optional.of(habit));
         when(habitRepo.save(customHabitMapper.convert(customHabitDtoRequest))).thenReturn(habit);
         when(tagsRepo.findById(20L)).thenReturn(Optional.of(tag));
-        when(habitTranslationMapper.mapAllToList(List.of(habitTranslationDto)))
-            .thenReturn(List.of(habitTranslationUa));
-        when(languageRepo.findByCode("ua")).thenReturn(Optional.of(languageUa));
-        when(languageRepo.findByCode("en")).thenReturn(Optional.of(languageEn));
         when(customShoppingListItemRepo.findAllByUserIdAndHabitId(anyLong(), anyLong()))
             .thenReturn(List.of(customShoppingListItem));
         when(customShoppingListMapper.mapAllToList(List.of(customShoppingListItemResponseDto)))
@@ -838,13 +834,11 @@ class HabitServiceImplTest {
         verify(habitRepo).save(any());
         verify(customHabitMapper).convert(customHabitDtoRequest);
         verify(tagsRepo).findById(20L);
-        verify(habitTranslationMapper, times(2)).mapAllToList(List.of(habitTranslationDto));
-        verify(languageRepo, times(2)).findByCode(anyString());
-        verify(customShoppingListItemRepo).findAllByUserIdAndHabitId(anyLong(), anyLong());
+        verify(customShoppingListItemRepo, times(2)).findAllByUserIdAndHabitId(anyLong(), anyLong());
         verify(customShoppingListMapper).mapAllToList(anyList());
         verify(modelMapper).map(habit, CustomHabitDtoResponse.class);
         verify(customShoppingListResponseDtoMapper).mapAllToList(List.of(customShoppingListItem));
-        verify(habitTranslationRepo).findAllByHabit(habit);
+        verify(habitTranslationRepo, times(2)).findAllByHabit(habit);
         verify(habitTranslationDtoMapper).mapAllToList(habitTranslationList);
     }
 
@@ -860,44 +854,6 @@ class HabitServiceImplTest {
 
         verify(userRepo).findByEmail("user@gmail.com");
         verify(customHabitMapper).convert(customHabitDtoRequest);
-    }
-
-    @Test
-    void updateCustomHabitNoSuchElementExceptionWithNotExistingLanguageCodes() throws IOException {
-        User user = ModelUtils.getUser();
-        user.setRole(Role.ROLE_MODERATOR);
-        Tag tag = ModelUtils.getTagHabitForServiceTest();
-        Language languageUa = ModelUtils.getLanguageUa();
-        Habit habit = ModelUtils.getCustomHabitForServiceTest();
-        MultipartFile image = ModelUtils.getFile();
-        String imageToEncode = Base64.getEncoder().encodeToString(image.getBytes());
-        habit.setTags(Set.of(tag));
-        habit.setUserId(1L);
-        habit.setImage(imageToEncode);
-
-        CustomHabitDtoRequest customHabitDtoRequest =
-            ModelUtils.getAddCustomHabitDtoRequestForServiceTest();
-        customHabitDtoRequest.setImage(ModelUtils.HABIT_DEFAULT_IMAGE);
-
-        HabitTranslationDto habitTranslationDto = ModelUtils.getHabitTranslationDto();
-        habitTranslationDto.setLanguageCode("ua");
-        HabitTranslation habitTranslationUa = ModelUtils.getHabitTranslationForServiceTest();
-
-        when(habitRepo.findById(1L)).thenReturn(Optional.of(habit));
-        when(userRepo.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
-        when(habitTranslationMapper.mapAllToList(List.of(habitTranslationDto)))
-            .thenReturn(List.of(habitTranslationUa));
-        when(languageRepo.findByCode("ua")).thenReturn(Optional.of(languageUa));
-        when(languageRepo.findByCode("en")).thenReturn(Optional.empty());
-
-        assertThrows(NoSuchElementException.class, () -> habitService.updateCustomHabit(
-            customHabitDtoRequest, 1L, "taras@gmail.com", image));
-
-        verify(habitRepo).findById(anyLong());
-        verify(userRepo).findByEmail(user.getEmail());
-        verify(habitTranslationMapper, times(2))
-            .mapAllToList(customHabitDtoRequest.getHabitTranslations());
-        verify(languageRepo, times(2)).findByCode(anyString());
     }
 
     @Test
@@ -921,7 +877,7 @@ class HabitServiceImplTest {
     }
 
     @Test
-    void updateCustomHabitWithOneParameterToUpdateTest() throws IOException {
+    void updateCustomHabitWithNewCustomShoppingListItemToUpdateTest() throws IOException {
         User user = ModelUtils.getTestUser();
         user.setRole(Role.ROLE_ADMIN);
         Tag tag = ModelUtils.getTagHabitForServiceTest();
@@ -930,10 +886,15 @@ class HabitServiceImplTest {
         String imageToEncode = Base64.getEncoder().encodeToString(image.getBytes());
         habit.setUserId(1L);
         habit.setImage(imageToEncode);
+        CustomShoppingListItem newItem = ModelUtils.getCustomShoppingListItemForUpdate();
+        newItem.setId(null);
 
-        CustomHabitDtoRequest customHabitDtoRequest = ModelUtils.getСustomHabitDtoRequestWithTagsForServiceTest();
+        CustomHabitDtoRequest customHabitDtoRequest = ModelUtils
+            .getСustomHabitDtoRequestWithNewCustomShoppingListItem();
         CustomHabitDtoResponse customHabitDtoResponse = ModelUtils.getAddCustomHabitDtoResponse();
-
+        when(customShoppingListMapper.mapAllToList(any()))
+            .thenReturn(List.of(newItem));
+        when(customShoppingListItemRepo.save(any())).thenReturn(ModelUtils.getCustomShoppingListItemForUpdate());
         when(userRepo.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
         when(habitRepo.findById(1L)).thenReturn(Optional.of(habit));
         when(tagsRepo.findById(20L)).thenReturn(Optional.of(tag));
@@ -944,6 +905,8 @@ class HabitServiceImplTest {
         assertEquals(customHabitDtoResponse,
             habitService.updateCustomHabit(customHabitDtoRequest, 1L, "user@email.com", image));
 
+        verify(customShoppingListItemRepo, times(2)).findAllByUserIdAndHabitId(2L, 1L);
+        // verify(customShoppingListItemRepo).save(any());
         verify(habitRepo).findById(anyLong());
         verify(userRepo).findByEmail(user.getEmail());
         verify(habitRepo).save(any());


### PR DESCRIPTION
# GreenCity PR
[Add ability to edit custom habits which user has created #6214](https://github.com/ita-social-projects/GreenCity/issues/6214)

## Summary Of Changes :fire:
Changed update of collections (HabitTranslations and CustomShoppingListItem).
- for HabitTranslations update -  only fields are to be updated, as translation is not necessary to apply for custom habit, during creation of new custom  habit it saves the same data for 'en' language and for 'ua'. 
for CustomShoppingListItem now: 
- it saves new customShoppingListItems to CustomShoppingListItemRepo and for current habit. (this is applied if user decides to add some new customShoppingListItems to his custom habit)
- if CustomShoppingListItem  exists already in habit customShoppingListItems, so only update is applied. (used for update of existing)
- if some of habit customShoppingListItems are absent in received dto, but they existed before, they are deleted(this applied if user decides to delete some of his customShoppingListItems in habit)
