### PR TITLE
Fixed the response status is 500 instead of 400 when sort with invalid parameter [Friend list] [/friends/not-friends-yet]

### DIFF
--- a/service/src/main/java/greencity/service/FriendServiceImpl.java
+++ b/service/src/main/java/greencity/service/FriendServiceImpl.java
@@ -8,6 +8,7 @@ import greencity.entity.User;
 import greencity.exception.exceptions.BadRequestException;
 import greencity.exception.exceptions.NotDeletedException;
 import greencity.exception.exceptions.NotFoundException;
+import greencity.exception.exceptions.UnsupportedSortException;
 import greencity.repository.CustomUserRepo;
 import greencity.repository.UserRepo;
 import lombok.AllArgsConstructor;
@@ -105,8 +106,12 @@ public class FriendServiceImpl implements FriendService {
 
         validateUserExistence(userId);
         name = name == null ? "" : name;
-        Page<User> users =
-            userRepo.getAllUsersExceptMainUserAndFriends(userId, name, pageable);
+        Page<User> users;
+        if (pageable.getSort().isEmpty()) {
+            users = userRepo.getAllUsersExceptMainUserAndFriends(userId, name, pageable);
+        } else {
+            throw new UnsupportedSortException(ErrorMessage.INVALID_SORTING_VALUE);
+        }
         List<UserFriendDto> userFriendDtoList =
             customUserRepo.fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser(userId, users.getContent());
         return new PageableDto<>(

--- a/service/src/test/java/greencity/service/FriendServiceImplTest.java
+++ b/service/src/test/java/greencity/service/FriendServiceImplTest.java
@@ -9,6 +9,7 @@ import greencity.entity.User;
 import greencity.exception.exceptions.BadRequestException;
 import greencity.exception.exceptions.NotDeletedException;
 import greencity.exception.exceptions.NotFoundException;
+import greencity.exception.exceptions.UnsupportedSortException;
 import greencity.repository.CustomUserRepo;
 import greencity.repository.UserRepo;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 
@@ -534,6 +536,21 @@ class FriendServiceImplTest {
         verify(userRepo).getAllUsersExceptMainUserAndFriends(userId, name, pageable);
         verify(customUserRepo).fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser(userId,
             userPage.getContent());
+    }
+
+    @Test
+    void findAllUsersExceptMainUserAndUsersFriendUnsupportedSortExceptionTest() {
+        long userId = 1L;
+
+        PageRequest pageable = PageRequest.of(0, 1, Sort.by("id"));
+        String name = "vi";
+
+        when(userRepo.existsById(userId)).thenReturn(true);
+
+        assertThrows(UnsupportedSortException.class, () -> {
+            friendService.findAllUsersExceptMainUserAndUsersFriend(1L,
+                name, pageable);
+        });
     }
 
     @Test


### PR DESCRIPTION
## Summary Of Issue :
The response status is 500 instead of 400 when sort with invalid parameter



**Issue Link**

https://github.com/ita-social-projects/GreenCity/issues/6382


## Summary Of Changes :
1) changed findAllUsersExceptMainUserAndUsersFriend method in FriendServiceImpl

2) added test in FriendServiceImplTest



## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [ ] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers

