### PR TITLE
Updated implementation of event filters and getAllEventAddresses

### DIFF
--- a/core/src/main/java/greencity/controller/EventsController.java
+++ b/core/src/main/java/greencity/controller/EventsController.java
@@ -144,8 +144,7 @@ public class EventsController {
     @GetMapping
     public ResponseEntity<PageableAdvancedDto<EventDto>> getEvent(
         @ApiIgnore Pageable pageable, @ApiIgnore Principal principal, FilterEventDto filterEventDto) {
-        return ResponseEntity.status(HttpStatus.OK).body(eventService.getAllFilteredEvents(
-            pageable, principal, filterEventDto));
+        return ResponseEntity.status(HttpStatus.OK).body(eventService.getEvents(pageable, principal, filterEventDto));
     }
 
     /**

--- a/core/src/test/java/greencity/controller/EventsControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventsControllerTest.java
@@ -117,7 +117,7 @@ class EventsControllerTest {
 
         FilterEventDto filterEventDto = ModelUtils.getNullFilterEventDto();
 
-        when(eventService.getAllFilteredEvents(pageable, principal, filterEventDto))
+        when(eventService.getEvents(pageable, principal, filterEventDto))
             .thenReturn(pageableAdvancedDto);
 
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK)
@@ -127,7 +127,7 @@ class EventsControllerTest {
             .andExpect(status().isOk())
             .andExpect(content().json(expectedJson));
 
-        verify(eventService).getAllFilteredEvents(pageable, principal, filterEventDto);
+        verify(eventService).getEvents(pageable, principal, filterEventDto);
     }
 
     @Test

--- a/dao/src/main/java/greencity/repository/EventRepo.java
+++ b/dao/src/main/java/greencity/repository/EventRepo.java
@@ -1,6 +1,7 @@
 package greencity.repository;
 
 import greencity.entity.User;
+import greencity.entity.event.Address;
 import greencity.entity.event.Event;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 public interface EventRepo extends JpaRepository<Event, Long>, JpaSpecificationExecutor<Event> {
     /**
@@ -125,4 +127,12 @@ public interface EventRepo extends JpaRepository<Event, Long>, JpaSpecificationE
     @Query(nativeQuery = true, value = " SELECT distinct * FROM public.fn_searchevents "
         + "( :searchQuery, :languageCode) ")
     Page<Event> searchEvents(Pageable pageable, String searchQuery, String languageCode);
+
+    /**
+     * Get all events addresses.
+     *
+     * @author Olena Sotnik.
+     */
+    @Query(value = "SELECT edl.address FROM Event e LEFT JOIN e.dates edl WHERE edl.address IS NOT NULL")
+    Set<Address> findAllEventsAddresses();
 }

--- a/service-api/src/main/java/greencity/service/EventService.java
+++ b/service-api/src/main/java/greencity/service/EventService.java
@@ -52,8 +52,7 @@ public interface EventService {
      *
      * @return List of {@link EventDto} instance.
      */
-    PageableAdvancedDto<EventDto> getAllFilteredEvents(
-        Pageable page, Principal principal, FilterEventDto filterEventDto);
+    PageableAdvancedDto<EventDto> getEvents(Pageable page, Principal principal, FilterEventDto filterEventDto);
 
     /**
      * Method for getting all Event instances that user attended.

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -80,6 +80,8 @@ public class EventServiceImpl implements EventService {
 
     private static final String FUTURE_EVENT = "FUTURE";
     private static final String PAST_EVENT = "PAST";
+    private static final String ONLINE_EVENT = "ONLINE";
+    private static final String OFFLINE_EVENT = "OFFLINE";
     private static final String OPEN_STATUS = "OPEN";
     private static final String CLOSED_STATUS = "CLOSED";
     private static final String JOINED_STATUS = "JOINED";
@@ -88,8 +90,6 @@ public class EventServiceImpl implements EventService {
     private static final String ECONOMIC_TAG = "ECONOMIC";
     private static final String ENVIRONMENTAL_TAG = "ENVIRONMENTAL";
     private static final String SOCIAL_TAG = "SOCIAL";
-    private static final String ONLINE_EVENT = "ONLINE";
-    private static final String OFFLINE_EVENT = "OFFLINE";
 
     @Override
     public EventDto save(AddEventDtoRequest addEventDtoRequest, String email,

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -86,7 +86,7 @@ public class EventServiceImpl implements EventService {
     private static final String CREATED_STATUS = "CREATED";
     private static final String SAVED_STATUS = "SAVED";
     private static final String ECONOMIC_TAG = "ECONOMIC";
-    private static final String ENVIRONMENT_TAG = "ENVIRONMENT";
+    private static final String ENVIRONMENTAL_TAG = "ENVIRONMENTAL";
     private static final String SOCIAL_TAG = "SOCIAL";
     private static final String ONLINE_EVENT = "ONLINE";
     private static final String OFFLINE_EVENT = "OFFLINE";
@@ -690,7 +690,7 @@ public class EventServiceImpl implements EventService {
             if (ECONOMIC_TAG.equalsIgnoreCase(eventTag)) {
                 filteredByTags.addAll(getEconomicEvents(events));
             }
-            if (ENVIRONMENT_TAG.equalsIgnoreCase(eventTag)) {
+            if (ENVIRONMENTAL_TAG.equalsIgnoreCase(eventTag)) {
                 filteredByTags.addAll(getEnvironmentalEvents(events));
             }
             if (SOCIAL_TAG.equalsIgnoreCase(eventTag)) {

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -591,7 +591,6 @@ public class EventServiceImpl implements EventService {
                 filtered = filterByStatusOpenClosed(filtered, filterEventDto.getStatuses());
             }
         }
-
         return getSortedListByEventId(filtered);
     }
 

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -3032,7 +3032,7 @@ public class ModelUtils {
         return FilterEventDto.builder()
             .eventTime(List.of("FUTURE", "PAST"))
             .cities(List.of("Kyiv"))
-            .statuses(List.of("OPEN", "CLOSED", "SUBSCRIBED", "CREATED", "SAVED"))
+            .statuses(List.of("OPEN", "CLOSED", "JOINED", "CREATED", "SAVED"))
             .tags(List.of("SOCIAL", "ECONOMIC", "ENVIRONMENTAL"))
             .build();
     }
@@ -3047,7 +3047,7 @@ public class ModelUtils {
         return FilterEventDto.builder()
             .eventTime(List.of("PAST"))
             .cities(List.of("Kyiv"))
-            .statuses(List.of("SUBSCRIBED", "CREATED", "SAVED"))
+            .statuses(List.of("JOINED", "CREATED", "SAVED"))
             .build();
     }
 
@@ -3077,6 +3077,12 @@ public class ModelUtils {
             .events(List.of(getSearchEvents()))
             .countOfEcoNewsResults(4L)
             .countOfEventsResults(4L)
+            .build();
+    }
+
+    public static FilterEventDto getFilterEventDtoWithClosedStatus() {
+        return FilterEventDto.builder()
+            .statuses(List.of("CLOSED"))
             .build();
     }
 }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -1838,6 +1838,29 @@ public class ModelUtils {
         return event;
     }
 
+    public static Event getEventWithTags() {
+        Event event = new Event();
+        Set<User> followers = new HashSet<>();
+        Tag tag1 = getEventTag();
+        tag1.setId(12L);
+        followers.add(getUser());
+        event.setOpen(true);
+        event.setDescription("Description");
+        event.setId(1L);
+        event.setOrganizer(getUser());
+        event.setFollowers(followers);
+        event.setTitle("Title");
+        List<EventDateLocation> dates = new ArrayList<>();
+        dates.add(new EventDateLocation(1L, event,
+            ZonedDateTime.of(2022, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+            ZonedDateTime.of(2022, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
+            getKyivAddress(), null));
+        event.setDates(dates);
+        event.setTags(List.of(tag1));
+        event.setTitleImage(AppConstant.DEFAULT_EVENT_IMAGES);
+        return event;
+    }
+
     public static Event getCloseEvent() {
         Event event = new Event();
         event.setOpen(false);
@@ -3037,7 +3060,7 @@ public class ModelUtils {
             .build();
     }
 
-    public static FilterEventDto getFilterEventDtoWithStatuses() {
+    public static FilterEventDto getFilterEventDtoWithOpenStatus() {
         return FilterEventDto.builder()
             .statuses(List.of("OPEN"))
             .build();
@@ -3053,7 +3076,7 @@ public class ModelUtils {
 
     public static FilterEventDto getFilterEventDtoWithCities() {
         return FilterEventDto.builder()
-            .cities(List.of("Kyiv", "Lviv", "Odessa"))
+            .cities(List.of("Kyiv", "Lviv", "City"))
             .build();
     }
 

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -10,7 +10,6 @@ import greencity.dto.event.EventAttenderDto;
 import greencity.dto.event.EventDto;
 import greencity.dto.event.UpdateEventDto;
 import greencity.dto.event.AddressDto;
-import greencity.dto.filter.FilterEventDto;
 import greencity.dto.tag.TagVO;
 import greencity.dto.user.UserVO;
 import greencity.entity.Tag;
@@ -1245,21 +1244,26 @@ class EventServiceImplTest {
     void getAllFilteredEventsWithNullFilters() {
         List<Event> events = List.of(ModelUtils.getEvent(), ModelUtils.getSecondEvent());
         PageRequest pageRequest = PageRequest.of(0, 2);
-        User user = ModelUtils.getUser();
-        Principal principal = ModelUtils.getPrincipal();
+        List<EventDto> expected = List.of(ModelUtils.getEventDto(), ModelUtils.getSecondEventDto());
 
-        when(restClient.findByEmail(principal.getName())).thenReturn(TEST_USER_VO);
-        when(modelMapper.map(TEST_USER_VO, User.class)).thenReturn(user);
-        when(eventRepo.findAll()).thenReturn(events);
+        when(eventRepo.findAllByOrderByIdDesc(pageRequest))
+            .thenReturn(new PageImpl<>(events, pageRequest, events.size()));
+        when(modelMapper.map(events,
+            new TypeToken<List<EventDto>>() {
+            }.getType())).thenReturn(expected);
 
         PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getAllFilteredEvents(
-            pageRequest, principal, FilterEventDto.builder().build());
-        long actual = eventDtoPageableAdvancedDto.getTotalElements();
-        assertEquals(2, actual);
+            pageRequest, null, null);
+        List<EventDto> actual = eventDtoPageableAdvancedDto.getPage();
+        long actualSize = eventDtoPageableAdvancedDto.getTotalElements();
 
-        verify(eventRepo).findAll();
-        verify(restClient).findByEmail(principal.getName());
-        verify(modelMapper).map(TEST_USER_VO, User.class);
+        assertEquals(expected, actual);
+        assertEquals(expected.size(), actualSize);
+
+        verify(eventRepo).findAllByOrderByIdDesc(pageRequest);
+        verify(modelMapper).map(events,
+            new TypeToken<List<EventDto>>() {
+            }.getType());
     }
 
     @Test
@@ -1268,40 +1272,59 @@ class EventServiceImplTest {
         PageRequest pageRequest = PageRequest.of(0, 2);
         User user = ModelUtils.getUser();
         Principal principal = ModelUtils.getPrincipal();
+        List<EventDto> expected = List.of(ModelUtils.getSecondEventDto());
 
         when(restClient.findByEmail(principal.getName())).thenReturn(TEST_USER_VO);
         when(modelMapper.map(TEST_USER_VO, User.class)).thenReturn(user);
         when(eventRepo.findAll()).thenReturn(events);
+        when(modelMapper.map(events,
+            new TypeToken<List<EventDto>>() {
+            }.getType())).thenReturn(expected);
 
         PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getAllFilteredEvents(
             pageRequest, principal, ModelUtils.getFilterEventDtoWithCities());
-        long actual = eventDtoPageableAdvancedDto.getTotalElements();
-        assertEquals(0, actual);
+        List<EventDto> actual = eventDtoPageableAdvancedDto.getPage();
+        long actualSize = eventDtoPageableAdvancedDto.getTotalElements();
+
+        assertEquals(expected.size(), actualSize);
+        assertEquals(expected, actual);
 
         verify(eventRepo).findAll();
         verify(restClient).findByEmail(principal.getName());
         verify(modelMapper).map(TEST_USER_VO, User.class);
+        verify(modelMapper).map(events,
+            new TypeToken<List<EventDto>>() {
+            }.getType());
     }
 
     @Test
     void getAllFilteredEventsWithFilterEventDtoWithTags() {
-        List<Event> events = List.of(ModelUtils.getEvent(), ModelUtils.getOfflineOnlineEventIfEventFinalDateToday());
+        List<Event> events = List.of(ModelUtils.getEventWithTags());
         PageRequest pageRequest = PageRequest.of(0, 2);
         User user = ModelUtils.getUser();
         Principal principal = ModelUtils.getPrincipal();
+        List<EventDto> expected = List.of(ModelUtils.getSecondEventDto());
 
         when(restClient.findByEmail(principal.getName())).thenReturn(TEST_USER_VO);
         when(modelMapper.map(TEST_USER_VO, User.class)).thenReturn(user);
         when(eventRepo.findAll()).thenReturn(events);
+        when(modelMapper.map(events,
+            new TypeToken<List<EventDto>>() {
+            }.getType())).thenReturn(expected);
 
         PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getAllFilteredEvents(
             pageRequest, principal, ModelUtils.getFilterEventDtoWithTags());
-        long actual = eventDtoPageableAdvancedDto.getTotalElements();
-        assertEquals(0, actual);
+        List<EventDto> actual = eventDtoPageableAdvancedDto.getPage();
+        long actualSize = eventDtoPageableAdvancedDto.getTotalElements();
+
+        assertEquals(expected.size(), actualSize);
+        assertEquals(expected, actual);
 
         verify(eventRepo).findAll();
         verify(restClient).findByEmail(principal.getName());
         verify(modelMapper).map(TEST_USER_VO, User.class);
+        verify(modelMapper).map(events, new TypeToken<List<EventDto>>() {
+        }.getType());
     }
 
     @Test
@@ -1316,7 +1339,7 @@ class EventServiceImplTest {
         when(eventRepo.findAll()).thenReturn(events);
 
         PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getAllFilteredEvents(
-            pageRequest, principal, ModelUtils.getFilterEventDtoWithStatuses());
+            pageRequest, principal, ModelUtils.getFilterEventDtoWithOpenStatus());
         long actual = eventDtoPageableAdvancedDto.getTotalElements();
         assertEquals(0, actual);
 
@@ -1329,14 +1352,25 @@ class EventServiceImplTest {
     void getAllFilteredEventsWithAnonymousUser() {
         List<Event> events = List.of(ModelUtils.getCloseEvent());
         PageRequest pageRequest = PageRequest.of(0, 2);
+        List<EventDto> expected = List.of(ModelUtils.getSecondEventDto());
+
         when(eventRepo.findAll()).thenReturn(events);
+        when(modelMapper.map(events,
+            new TypeToken<List<EventDto>>() {
+            }.getType())).thenReturn(expected);
 
         PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getAllFilteredEvents(
             pageRequest, null, ModelUtils.getFilterEventDtoWithClosedStatus());
-        long actual = eventDtoPageableAdvancedDto.getTotalElements();
-        assertEquals(1, actual);
+        List<EventDto> actual = eventDtoPageableAdvancedDto.getPage();
+        long actualSize = eventDtoPageableAdvancedDto.getTotalElements();
+
+        assertEquals(expected.size(), actualSize);
+        assertEquals(expected, actual);
 
         verify(eventRepo).findAll();
+        verify(modelMapper).map(events,
+            new TypeToken<List<EventDto>>() {
+            }.getType());
     }
 
     @Test
@@ -1346,7 +1380,7 @@ class EventServiceImplTest {
         when(eventRepo.findAll()).thenReturn(events);
 
         PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getAllFilteredEvents(
-            pageRequest, null, ModelUtils.getFilterEventDtoWithStatuses());
+            pageRequest, null, ModelUtils.getFilterEventDtoWithOpenStatus());
         long actual = eventDtoPageableAdvancedDto.getTotalElements();
         assertEquals(0, actual);
 
@@ -1357,15 +1391,24 @@ class EventServiceImplTest {
     void getAllFilteredEventsWithNullFilterEventDtoAndAnonymousUser() {
         List<Event> events = List.of(ModelUtils.getCloseEvent());
         PageRequest pageRequest = PageRequest.of(0, 2);
+        List<EventDto> expected = List.of(ModelUtils.getSecondEventDto());
+
+        when(modelMapper.map(events, new TypeToken<List<EventDto>>() {
+        }.getType())).thenReturn(expected);
         when(eventRepo.findAllByOrderByIdDesc(pageRequest))
             .thenReturn(new PageImpl<>(events, pageRequest, events.size()));
 
         PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getAllFilteredEvents(
             pageRequest, null, null);
-        long actual = eventDtoPageableAdvancedDto.getTotalElements();
-        assertEquals(1, actual);
+        List<EventDto> actual = eventDtoPageableAdvancedDto.getPage();
+        long actualSize = eventDtoPageableAdvancedDto.getTotalElements();
+
+        assertEquals(expected.size(), actualSize);
+        assertEquals(expected, actual);
 
         verify(eventRepo).findAllByOrderByIdDesc(pageRequest);
+        verify(modelMapper).map(events, new TypeToken<List<EventDto>>() {
+        }.getType());
     }
 
     @Test
@@ -1403,10 +1446,9 @@ class EventServiceImplTest {
 
     @Test
     void getAllEventAddressesTest() {
-        Event event = ModelUtils.getEvent();
         AddressDto expectedAddressDto = ModelUtils.getAddressDto();
         Set<AddressDto> expectedAddresses = Set.of(expectedAddressDto);
-        Address address = event.getDates().get(event.getDates().size() - 1).getAddress();
+        Address address = ModelUtils.getAddress();
 
         when(eventRepo.findAllEventsAddresses()).thenReturn(Set.of(address));
         when(modelMapper.map(address, AddressDto.class)).thenReturn(expectedAddressDto);

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -1199,7 +1199,7 @@ class EventServiceImplTest {
     }
 
     @Test
-    void getAllFilteredEventsWithAllFilters() {
+    void getEventsWithAllFilters() {
         List<Event> events = List.of(ModelUtils.getEvent());
         PageRequest pageRequest = PageRequest.of(0, 2);
         User user = ModelUtils.getUser();
@@ -1209,7 +1209,7 @@ class EventServiceImplTest {
         when(modelMapper.map(TEST_USER_VO, User.class)).thenReturn(user);
         when(eventRepo.findAll()).thenReturn(events);
 
-        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getAllFilteredEvents(
+        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getEvents(
             pageRequest, principal, ModelUtils.getFilterEventDto());
         long actual = eventDtoPageableAdvancedDto.getTotalElements();
         assertEquals(0, actual);
@@ -1220,7 +1220,7 @@ class EventServiceImplTest {
     }
 
     @Test
-    void getAllFilteredEventsWithSomeFilters() {
+    void getEventsWithSomeFilters() {
         List<Event> events = List.of(ModelUtils.getSecondEvent(), ModelUtils.getCloseEvent());
         PageRequest pageRequest = PageRequest.of(0, 2);
         User user = ModelUtils.getUser();
@@ -1230,7 +1230,7 @@ class EventServiceImplTest {
         when(modelMapper.map(TEST_USER_VO, User.class)).thenReturn(user);
         when(eventRepo.findAll()).thenReturn(events);
 
-        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getAllFilteredEvents(
+        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getEvents(
             pageRequest, principal, ModelUtils.getFilterEventDtoWithSomeFilters());
         long actual = eventDtoPageableAdvancedDto.getTotalElements();
         assertEquals(0, actual);
@@ -1241,7 +1241,7 @@ class EventServiceImplTest {
     }
 
     @Test
-    void getAllFilteredEventsWithNullFilters() {
+    void getEventsWithoutFilters() {
         List<Event> events = List.of(ModelUtils.getEvent(), ModelUtils.getSecondEvent());
         PageRequest pageRequest = PageRequest.of(0, 2);
         List<EventDto> expected = List.of(ModelUtils.getEventDto(), ModelUtils.getSecondEventDto());
@@ -1252,7 +1252,7 @@ class EventServiceImplTest {
             new TypeToken<List<EventDto>>() {
             }.getType())).thenReturn(expected);
 
-        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getAllFilteredEvents(
+        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getEvents(
             pageRequest, null, null);
         List<EventDto> actual = eventDtoPageableAdvancedDto.getPage();
         long actualSize = eventDtoPageableAdvancedDto.getTotalElements();
@@ -1267,7 +1267,7 @@ class EventServiceImplTest {
     }
 
     @Test
-    void getAllFilteredEventsWithFilterEventDtoWithCities() {
+    void getEventsWithFilterEventDtoWithCities() {
         List<Event> events = List.of(ModelUtils.getSecondEvent());
         PageRequest pageRequest = PageRequest.of(0, 2);
         User user = ModelUtils.getUser();
@@ -1281,7 +1281,7 @@ class EventServiceImplTest {
             new TypeToken<List<EventDto>>() {
             }.getType())).thenReturn(expected);
 
-        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getAllFilteredEvents(
+        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getEvents(
             pageRequest, principal, ModelUtils.getFilterEventDtoWithCities());
         List<EventDto> actual = eventDtoPageableAdvancedDto.getPage();
         long actualSize = eventDtoPageableAdvancedDto.getTotalElements();
@@ -1298,7 +1298,7 @@ class EventServiceImplTest {
     }
 
     @Test
-    void getAllFilteredEventsWithFilterEventDtoWithTags() {
+    void getEventsWithFilterEventDtoWithTags() {
         List<Event> events = List.of(ModelUtils.getEventWithTags());
         PageRequest pageRequest = PageRequest.of(0, 2);
         User user = ModelUtils.getUser();
@@ -1312,7 +1312,7 @@ class EventServiceImplTest {
             new TypeToken<List<EventDto>>() {
             }.getType())).thenReturn(expected);
 
-        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getAllFilteredEvents(
+        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getEvents(
             pageRequest, principal, ModelUtils.getFilterEventDtoWithTags());
         List<EventDto> actual = eventDtoPageableAdvancedDto.getPage();
         long actualSize = eventDtoPageableAdvancedDto.getTotalElements();
@@ -1328,7 +1328,7 @@ class EventServiceImplTest {
     }
 
     @Test
-    void getAllFilteredEventsWithNullEventTime() {
+    void getEventsWithNullEventTime() {
         List<Event> events = List.of(ModelUtils.getCloseEvent());
         PageRequest pageRequest = PageRequest.of(0, 2);
         User user = ModelUtils.getUser();
@@ -1338,7 +1338,7 @@ class EventServiceImplTest {
         when(modelMapper.map(TEST_USER_VO, User.class)).thenReturn(user);
         when(eventRepo.findAll()).thenReturn(events);
 
-        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getAllFilteredEvents(
+        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getEvents(
             pageRequest, principal, ModelUtils.getFilterEventDtoWithOpenStatus());
         long actual = eventDtoPageableAdvancedDto.getTotalElements();
         assertEquals(0, actual);
@@ -1349,7 +1349,7 @@ class EventServiceImplTest {
     }
 
     @Test
-    void getAllFilteredEventsWithAnonymousUser() {
+    void getEventsFilteredWithAnonymousUser() {
         List<Event> events = List.of(ModelUtils.getCloseEvent());
         PageRequest pageRequest = PageRequest.of(0, 2);
         List<EventDto> expected = List.of(ModelUtils.getSecondEventDto());
@@ -1359,7 +1359,7 @@ class EventServiceImplTest {
             new TypeToken<List<EventDto>>() {
             }.getType())).thenReturn(expected);
 
-        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getAllFilteredEvents(
+        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getEvents(
             pageRequest, null, ModelUtils.getFilterEventDtoWithClosedStatus());
         List<EventDto> actual = eventDtoPageableAdvancedDto.getPage();
         long actualSize = eventDtoPageableAdvancedDto.getTotalElements();
@@ -1374,12 +1374,12 @@ class EventServiceImplTest {
     }
 
     @Test
-    void getAllFilteredEventsWithAnonymousUserAndClosedStatus() {
+    void getEventsFilteredWithAnonymousUserAndClosedStatus() {
         List<Event> events = List.of(ModelUtils.getCloseEvent());
         PageRequest pageRequest = PageRequest.of(0, 2);
         when(eventRepo.findAll()).thenReturn(events);
 
-        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getAllFilteredEvents(
+        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getEvents(
             pageRequest, null, ModelUtils.getFilterEventDtoWithOpenStatus());
         long actual = eventDtoPageableAdvancedDto.getTotalElements();
         assertEquals(0, actual);
@@ -1388,7 +1388,7 @@ class EventServiceImplTest {
     }
 
     @Test
-    void getAllFilteredEventsWithNullFilterEventDtoAndAnonymousUser() {
+    void getEventsWithoutFilterEventDtoAndAnonymousUser() {
         List<Event> events = List.of(ModelUtils.getCloseEvent());
         PageRequest pageRequest = PageRequest.of(0, 2);
         List<EventDto> expected = List.of(ModelUtils.getSecondEventDto());
@@ -1398,7 +1398,7 @@ class EventServiceImplTest {
         when(eventRepo.findAllByOrderByIdDesc(pageRequest))
             .thenReturn(new PageImpl<>(events, pageRequest, events.size()));
 
-        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getAllFilteredEvents(
+        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getEvents(
             pageRequest, null, null);
         List<EventDto> actual = eventDtoPageableAdvancedDto.getPage();
         long actualSize = eventDtoPageableAdvancedDto.getTotalElements();


### PR DESCRIPTION
# GreenCity PR
[[Events / Event dashboard] Quantity of "items found" after filter out by "location" does not match quantity created events with the location of such a city 6529](https://github.com/ita-social-projects/GreenCity/issues/6529)

Change of getAllFilteredEvents method for anonymous user and logged in user.
Changed endpoint with addresses. 
Added check for events CollectionUtils.isNotEmpty before use of methods setFollowers and setSubscribers. 

## Summary Of Changes :fire:
- getAllFilteredEvents() change for anonymous user and logged in user scenarios.
- getAllEventsAddresses() before returned collection of  addresses in events, but only from last EventDateLocation in dates field in Events(which is supposed to be relevant), now returns all addresses from all events. 
- filterByLocation() changed in order to filterEvents by all addresses
- added check for events CollectionUtils.isNotEmpty before use of methods setFollowers and setSubscribers, because if collection is empty occurs SQL exception, now if collection of events is empty in case when user is logged in it returns empty PageableAdvancedDto<EventDto>.

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] All files reviewed before sending to reviewers