### PR TITLE
Change logic for tag event filters

### DIFF
--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -686,17 +686,21 @@ public class EventServiceImpl implements EventService {
 
     private List<Event> filterByTags(List<Event> events, List<String> tags) {
         List<Event> filteredByTags = new ArrayList<>();
-        for (String eventTag : tags) {
-            if (ECONOMIC_TAG.equalsIgnoreCase(eventTag)) {
-                filteredByTags.addAll(getEconomicEvents(events));
+        tags.stream().filter(Objects::nonNull).map(String::toUpperCase).forEach(tag -> {
+            switch (tag) {
+                case ECONOMIC_TAG:
+                    filteredByTags.addAll(getEventsByTagName(events, ECONOMIC_TAG));
+                    break;
+                case ENVIRONMENTAL_TAG:
+                    filteredByTags.addAll(getEventsByTagName(events, ENVIRONMENTAL_TAG));
+                    break;
+                case SOCIAL_TAG:
+                    filteredByTags.addAll(getEventsByTagName(events, SOCIAL_TAG));
+                    break;
+                default:
+                    break;
             }
-            if (ENVIRONMENTAL_TAG.equalsIgnoreCase(eventTag)) {
-                filteredByTags.addAll(getEnvironmentalEvents(events));
-            }
-            if (SOCIAL_TAG.equalsIgnoreCase(eventTag)) {
-                filteredByTags.addAll(getSocialEvents(events));
-            }
-        }
+        });
         return filteredByTags;
     }
 
@@ -731,24 +735,11 @@ public class EventServiceImpl implements EventService {
             .collect(Collectors.toList()).contains(userId)).collect(Collectors.toList());
     }
 
-    private List<Event> getSocialEvents(List<Event> events) {
+    private List<Event> getEventsByTagName(final List<Event> events, final String tag) {
         return events.stream().filter(event -> event.getTags().stream()
-            .anyMatch(tag -> tag.getTagTranslations().stream()
-                .anyMatch(tagTranslation -> tagTranslation.getName().equalsIgnoreCase(SOCIAL_TAG))))
-            .collect(Collectors.toList());
-    }
-
-    private List<Event> getEnvironmentalEvents(List<Event> events) {
-        return events.stream().filter(event -> event.getTags().stream()
-            .anyMatch(tag -> tag.getTagTranslations().stream()
-                .anyMatch(tagTranslation -> tagTranslation.getName().equalsIgnoreCase(ENVIRONMENTAL_TAG))))
-            .collect(Collectors.toList());
-    }
-
-    private List<Event> getEconomicEvents(List<Event> events) {
-        return events.stream().filter(event -> event.getTags().stream()
-            .anyMatch(tag -> tag.getTagTranslations().stream()
-                .anyMatch(tagTranslation -> tagTranslation.getName().equalsIgnoreCase(ECONOMIC_TAG))))
+            .map(Tag::getTagTranslations)
+            .flatMap(Collection::stream)
+            .anyMatch(tagTranslation -> tag.equalsIgnoreCase(tagTranslation.getName())))
             .collect(Collectors.toList());
     }
 

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -686,7 +686,7 @@ public class EventServiceImpl implements EventService {
 
     private List<Event> filterByTags(List<Event> events, List<String> tags) {
         List<Event> filteredByTags = new ArrayList<>();
-        tags.stream().filter(Objects::nonNull).map(String::toUpperCase).forEach(tag -> {
+        tags.stream().filter(Objects::nonNull).forEach(tag -> {
             switch (tag) {
                 case ECONOMIC_TAG:
                     filteredByTags.addAll(getEventsByTagName(events, ECONOMIC_TAG));

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -733,19 +733,19 @@ public class EventServiceImpl implements EventService {
 
     private List<Event> getSocialEvents(List<Event> events) {
         return events.stream().filter(event -> event.getTags().stream()
-            .allMatch(tag -> tag.getType().equals(TagType.EVENT) && tag.getId() == 12L))
+            .anyMatch(tag -> tag.getType().equals(TagType.EVENT) && tag.getId() == 12L))
             .collect(Collectors.toList());
     }
 
     private List<Event> getEnvironmentalEvents(List<Event> events) {
         return events.stream().filter(event -> event.getTags().stream()
-            .allMatch(tag -> tag.getType().equals(TagType.EVENT) && tag.getId() == 13L))
+            .anyMatch(tag -> tag.getType().equals(TagType.EVENT) && tag.getId() == 13L))
             .collect(Collectors.toList());
     }
 
     private List<Event> getEconomicEvents(List<Event> events) {
         return events.stream().filter(event -> event.getTags().stream()
-            .allMatch(tag -> tag.getType().equals(TagType.EVENT) && tag.getId() == 14L))
+            .anyMatch(tag -> tag.getType().equals(TagType.EVENT) && tag.getId() == 14L))
             .collect(Collectors.toList());
     }
 

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -733,19 +733,22 @@ public class EventServiceImpl implements EventService {
 
     private List<Event> getSocialEvents(List<Event> events) {
         return events.stream().filter(event -> event.getTags().stream()
-            .anyMatch(tag -> tag.getType().equals(TagType.EVENT) && tag.getId() == 12L))
+            .anyMatch(tag -> tag.getTagTranslations().stream()
+                .anyMatch(tagTranslation -> tagTranslation.getName().equalsIgnoreCase(SOCIAL_TAG))))
             .collect(Collectors.toList());
     }
 
     private List<Event> getEnvironmentalEvents(List<Event> events) {
         return events.stream().filter(event -> event.getTags().stream()
-            .anyMatch(tag -> tag.getType().equals(TagType.EVENT) && tag.getId() == 13L))
+            .anyMatch(tag -> tag.getTagTranslations().stream()
+                .anyMatch(tagTranslation -> tagTranslation.getName().equalsIgnoreCase(ENVIRONMENTAL_TAG))))
             .collect(Collectors.toList());
     }
 
     private List<Event> getEconomicEvents(List<Event> events) {
         return events.stream().filter(event -> event.getTags().stream()
-            .anyMatch(tag -> tag.getType().equals(TagType.EVENT) && tag.getId() == 14L))
+            .anyMatch(tag -> tag.getTagTranslations().stream()
+                .anyMatch(tagTranslation -> tagTranslation.getName().equalsIgnoreCase(ECONOMIC_TAG))))
             .collect(Collectors.toList());
     }
 

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -1843,6 +1843,10 @@ public class ModelUtils {
         Set<User> followers = new HashSet<>();
         Tag tag1 = getEventTag();
         tag1.setId(12L);
+        Tag tag2 = getEventTag();
+        tag2.setId(13L);
+        Tag tag3 = getEventTag();
+        tag3.setId(14L);
         followers.add(getUser());
         event.setOpen(true);
         event.setDescription("Description");
@@ -1856,7 +1860,7 @@ public class ModelUtils {
             ZonedDateTime.of(2022, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
             getKyivAddress(), null));
         event.setDates(dates);
-        event.setTags(List.of(tag1));
+        event.setTags(List.of(tag1, tag2, tag3));
         event.setTitleImage(AppConstant.DEFAULT_EVENT_IMAGES);
         return event;
     }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -3086,7 +3086,7 @@ public class ModelUtils {
 
     public static FilterEventDto getFilterEventDtoWithTags() {
         return FilterEventDto.builder()
-            .tags(List.of("SOCIAL", "ECONOMIC", "ENVIRONMENTAL"))
+            .tags(List.of("SOCIAL", "ECONOMIC", "ENVIRONMENTAL", "NOT_EVENT_TAG"))
             .build();
     }
 

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -1860,7 +1860,7 @@ public class ModelUtils {
             ZonedDateTime.of(2022, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
             getKyivAddress(), null));
         event.setDates(dates);
-        event.setTags(List.of(tag1, tag2, tag3));
+        event.setTags(List.of(tag1, tag2, tag3, getEventTag()));
         event.setTitleImage(AppConstant.DEFAULT_EVENT_IMAGES);
         return event;
     }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -1860,7 +1860,7 @@ public class ModelUtils {
             ZonedDateTime.of(2022, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
             getKyivAddress(), null));
         event.setDates(dates);
-        event.setTags(List.of(tag1, tag2, tag3, getEventTag()));
+        event.setTags(List.of(tag1, tag2, tag3));
         event.setTitleImage(AppConstant.DEFAULT_EVENT_IMAGES);
         return event;
     }

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -1204,6 +1204,10 @@ class EventServiceImplTest {
         PageRequest pageRequest = PageRequest.of(0, 2);
         User user = ModelUtils.getUser();
         Principal principal = ModelUtils.getPrincipal();
+        List<EventDto> expected = List.of(ModelUtils.getEventDto());
+        when(modelMapper.map(events,
+            new TypeToken<List<EventDto>>() {
+            }.getType())).thenReturn(expected);
 
         when(restClient.findByEmail(principal.getName())).thenReturn(TEST_USER_VO);
         when(modelMapper.map(TEST_USER_VO, User.class)).thenReturn(user);
@@ -1212,7 +1216,8 @@ class EventServiceImplTest {
         PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getEvents(
             pageRequest, principal, ModelUtils.getFilterEventDto());
         long actual = eventDtoPageableAdvancedDto.getTotalElements();
-        assertEquals(0, actual);
+        assertEquals(1, actual);
+        assertEquals(expected, eventDtoPageableAdvancedDto.getPage());
 
         verify(eventRepo).findAll();
         verify(restClient).findByEmail(principal.getName());

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -1303,7 +1303,7 @@ class EventServiceImplTest {
     }
 
     @Test
-    void getEventsWithFilterEventDtoWithTags() {
+    void getEventsWithFilterEventDtoWithTagsAndWrongTag() {
         List<Event> events = List.of(ModelUtils.getEventWithTags());
         PageRequest pageRequest = PageRequest.of(0, 2);
         User user = ModelUtils.getUser();


### PR DESCRIPTION
# GreenCity PR
[[Events / Event Dashboard] Quantity of "items found" after filter out by "type" does not match quantity created events with this kind of type #6530](https://github.com/ita-social-projects/GreenCity/issues/6530)

## Summary Of Changes :fire:
Changes in method to get events by tag type. Instead of allMatch, now is implemented anyMatch. 

Which means that events that has few tags will be filtered as well, before only events with current type has been filtered which has given difference with found by database select query. Now it gives right quantity.

# PR Checklist Forms
_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] All files reviewed before sending to reviewers