### PR TITLE
Commit with online_link column length change from 255 to 2056

### DIFF
--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -187,5 +187,6 @@
     <include file="db/changelog/logs/ch-add-table-user_location-Midianyi.xml"/>
     <include file="db/changelog/logs/ch-add-column-userLocation-Midianyi.xml"/>
     <include file="db/changelog/logs/ch-drop-column-city-in-users-table-Midianyi.xml"/>
+    <include file="db/changelog/logs/ch-update-online-link-column-length-Sotnik.xml"/>
 </databaseChangeLog>
 

--- a/dao/src/main/resources/db/changelog/logs/ch-update-online-link-column-length-Sotnik.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-update-online-link-column-length-Sotnik.xml
@@ -4,6 +4,6 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
     <changeSet id="ch-update-online-link-column-length-Sotnik.xml" author="Olena Sotnik">
         <sqlFile path="db/changelog/sql/online-link-column-length-change.sql"/>
-        <comment>Changed online_link column length from 255 to 1000 chars in events_dates_locations table</comment>
+        <comment>Changed online_link column length from 255 to 2056 chars in events_dates_locations table</comment>
     </changeSet>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-update-online-link-column-length-Sotnik.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-update-online-link-column-length-Sotnik.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet id="ch-update-online-link-column-length-Sotnik.xml" author="Olena Sotnik">
+        <sqlFile path="db/changelog/sql/online-link-column-length-change.sql"/>
+        <comment>Changed online_link column length from 255 to 1000 chars in events_dates_locations table</comment>
+    </changeSet>
+</databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/sql/online-link-column-length-change.sql
+++ b/dao/src/main/resources/db/changelog/sql/online-link-column-length-change.sql
@@ -1,2 +1,2 @@
 ALTER TABLE events_dates_locations
-    ALTER COLUMN online_link TYPE varchar(1000);
+    ALTER COLUMN online_link TYPE varchar(2056);

--- a/dao/src/main/resources/db/changelog/sql/online-link-column-length-change.sql
+++ b/dao/src/main/resources/db/changelog/sql/online-link-column-length-change.sql
@@ -1,0 +1,2 @@
+ALTER TABLE events_dates_locations
+    ALTER COLUMN online_link TYPE varchar(1000);


### PR DESCRIPTION
# GreenCity PR
[[Create Event] User cannot create an event with a long link as the event location #6449](https://github.com/ita-social-projects/GreenCity/issues/6449)

## Summary Of Changes :fire:
Changed length of online_link column in events_dates_locations table from 255 to 2056 chars
Updated by sql file in db/changelog/sql.
## How to test :clipboard:

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
