### PR TITLE
[API] [DELETE/Events delete] There is error 500 instead of 404 NOT FOUND when ADMIN deletes non-existent event #6597

### DIFF
--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -139,7 +139,8 @@ public class EventServiceImpl implements EventService {
     @Override
     public void delete(Long eventId, String email) {
         UserVO userVO = restClient.findByEmail(email);
-        Event toDelete = eventRepo.getOne(eventId);
+        Event toDelete =
+            eventRepo.findById(eventId).orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND));
         List<String> eventImages = new ArrayList<>();
         eventImages.add(toDelete.getTitleImage());
         if (toDelete.getAdditionalImages() != null) {


### PR DESCRIPTION
# GreenCity
https://github.com/ita-social-projects/GreenCity/issues/6597

## Summary Of Changes :fire:
Implemented event presence verification in the database.

## Added
* Added a check for the presence of an event in the database.
* Tests to cover new lines of code

## How to test :clipboard:
It can be tests via swagger, endpoint [events-controller]:
DELETE [/events/delete/{eventId}]

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
