### PR TITLE
[DELETE/Events delete] There is error 400 instead of 403 FORBIDDEN when Organizer deletes past Event #6591

### DIFF
--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -152,7 +152,7 @@ public class EventServiceImpl implements EventService {
             deleteImagesFromServer(eventImages);
             eventRepo.delete(toDelete);
         } else {
-            throw new BadRequestException(ErrorMessage.USER_HAS_NO_PERMISSION);
+            throw new UserHasNoPermissionToAccessException(ErrorMessage.USER_HAS_NO_PERMISSION);
         }
         achievementCalculation.calculateAchievement(userVO,
             AchievementCategoryType.CREATE_EVENT, AchievementAction.DELETE);

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -456,7 +456,7 @@ class EventServiceImplTest {
         when(eventRepo.findById(1L)).thenReturn(Optional.of(event));
 
         Long eventId = event.getId();
-        assertThrows(BadRequestException.class, () -> eventService.delete(eventId, userEmail));
+        assertThrows(UserHasNoPermissionToAccessException.class, () -> eventService.delete(eventId, userEmail));
 
         verify(restClient).findByEmail(userEmail);
         verify(eventRepo).findById(1L);


### PR DESCRIPTION
# GreenCity PR
https://github.com/ita-social-projects/GreenCity/issues/6591

## Summary Of Changes :fire:
Changed the logic when a user tries to delete an event without permission to do so.

## Changed
* Changed the response status to 403 FORBIDDEN in cases where a user attempts to delete an event without the necessary permission.

## How to test :clipboard:
It can be tests via swagger, endpoint [events-controller]:
DELETE [/events/delete/{eventId}]

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
