### PR TITLE
changed endpoint /friends/{not-friends-yet}

### DIFF
--- a/core/src/main/java/greencity/controller/FriendController.java
+++ b/core/src/main/java/greencity/controller/FriendController.java
@@ -167,13 +167,14 @@ public class FriendController {
     })
     @GetMapping("/not-friends-yet")
     @ApiPageable
-    public ResponseEntity<PageableDto<UserFriendDto>> findAllUsersExceptMainUserAndUsersFriend(
+    public ResponseEntity<PageableDto<UserFriendDto>> findAllUsersExceptMainUserAndUsersFriendAndRequestersToMainUser(
         @ApiIgnore @PageableDefault Pageable page,
         @ApiIgnore @CurrentUser UserVO userVO,
         @RequestParam(required = false) @Nullable String name) {
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(friendService.findAllUsersExceptMainUserAndUsersFriend(userVO.getId(), name, page));
+            .body(friendService.findAllUsersExceptMainUserAndUsersFriendAndRequestersToMainUser(userVO.getId(), name,
+                page));
     }
 
     /**

--- a/core/src/main/java/greencity/controller/FriendController.java
+++ b/core/src/main/java/greencity/controller/FriendController.java
@@ -157,7 +157,8 @@ public class FriendController {
      *
      * @return {@link PageableDto} of {@link UserFriendDto}.
      */
-    @ApiOperation(value = "Find all users that are not friend for current users")
+    @ApiOperation(
+        value = "Find all users except current user and his friends and users who send request to current user")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = HttpStatuses.OK),
         @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),

--- a/core/src/test/java/greencity/controller/FriendControllerTest.java
+++ b/core/src/test/java/greencity/controller/FriendControllerTest.java
@@ -130,7 +130,8 @@ class FriendControllerTest {
             .andExpect(status().isOk());
 
         verify(userService).findByEmail(principal.getName());
-        verify(friendService).findAllUsersExceptMainUserAndUsersFriend(userVO.getId(), null, PageRequest.of(0, 10));
+        verify(friendService).findAllUsersExceptMainUserAndUsersFriendAndRequestersToMainUser(userVO.getId(), null,
+            PageRequest.of(0, 10));
     }
 
     @Test

--- a/dao/src/main/java/greencity/entity/User.java
+++ b/dao/src/main/java/greencity/entity/User.java
@@ -73,7 +73,8 @@ import java.util.Set;
                     @ColumnResult(name = "longitude", type = Double.class),
                     @ColumnResult(name = "mutualFriends", type = Long.class),
                     @ColumnResult(name = "profilePicturePath", type = String.class),
-                    @ColumnResult(name = "chatId", type = Long.class)
+                    @ColumnResult(name = "chatId", type = Long.class),
+                    @ColumnResult(name = "friendStatus", type = String.class)
                 })
         })
 })
@@ -108,7 +109,12 @@ import java.util.Set;
             + "       FROM chat_rooms_participants p"
             + "       WHERE p.participant_id IN (u.id, :userId) "
             + "       GROUP BY p.room_id "
-            + "       HAVING COUNT(DISTINCT p.participant_id) = 2 LIMIT 1) as chatId "
+            + "       HAVING COUNT(DISTINCT p.participant_id) = 2 LIMIT 1) as chatId, "
+            + "(SELECT uf2.status "
+            + "FROM users_friends uf2 "
+            + "WHERE ( uf2.user_id = :userId AND uf2.friend_id = u.id ) "
+            + "or ( uf2.user_id = u.id AND uf2.friend_id = :userId )"
+            + "LIMIT 1) as friendStatus "
             + "FROM users u "
             + "LEFT JOIN user_location ul ON u.user_location = ul.id "
             + "WHERE u.id IN (:users)",

--- a/dao/src/main/java/greencity/repository/UserRepo.java
+++ b/dao/src/main/java/greencity/repository/UserRepo.java
@@ -313,6 +313,29 @@ public interface UserRepo extends JpaRepository<User, Long>, JpaSpecificationExe
     Page<User> getAllUsersExceptMainUserAndFriends(Long userId, String filteringName, Pageable pageable);
 
     /**
+     * Method that finds all users except current user and his friends and users who
+     * send request to current user.
+     *
+     * @param userId        current user's id.
+     * @param filteringName name filter.
+     * @param pageable      current page.
+     *
+     * @return {@link Page} of {@link User}.
+     */
+    @Query(nativeQuery = true, value = "SELECT * FROM users u "
+        + "WHERE u.id != :userId "
+        + "AND u.id NOT IN ("
+        + "      SELECT user_id AS id FROM users_friends WHERE friend_id = :userId AND status = 'FRIEND' "
+        + "      UNION "
+        + "      SELECT friend_id AS id FROM users_friends WHERE user_id = :userId AND status = 'FRIEND' "
+        + "      UNION "
+        + "      SELECT friend_id AS id FROM users_friends WHERE friend_id = :userId AND status = 'REQUEST' "
+        + ") AND LOWER(u.name) LIKE LOWER(CONCAT('%', REPLACE(REPLACE(REPLACE(REPLACE(:filteringName, '&', '\\&'), "
+        + "'%', '\\%'), '_', '\\_'), '#', '\\#'), '%')) ")
+    Page<User> getAllUsersExceptMainUserAndFriendsAndRequestersToMainUser(Long userId, String filteringName,
+        Pageable pageable);
+
+    /**
      * Method that finds recommended friends of friends.
      *
      * @param userId   current user's id.

--- a/service-api/src/main/java/greencity/dto/friends/UserFriendDto.java
+++ b/service-api/src/main/java/greencity/dto/friends/UserFriendDto.java
@@ -20,7 +20,7 @@ public class UserFriendDto {
     private Long mutualFriends;
     private String profilePicturePath;
     private Long chatId;
-    private FriendStatus friendStatus;
+    private String friendStatus;
     private UserLocationDto userLocationDto;
 
     /**
@@ -28,7 +28,8 @@ public class UserFriendDto {
      */
     public UserFriendDto(Long id, String name, String email, Double rating, Long ulId, String cityEn,
         String cityUa, String regionEn, String regionUa, String countryEn, String countryUa,
-        Double latitude, Double longitude, Long mutualFriends, String profilePicturePath, Long chatId) {
+        Double latitude, Double longitude, Long mutualFriends, String profilePicturePath, Long chatId,
+        String friendStatus) {
         this.id = id;
         this.name = name;
         this.email = email;
@@ -36,6 +37,7 @@ public class UserFriendDto {
         this.mutualFriends = mutualFriends;
         this.profilePicturePath = profilePicturePath;
         this.chatId = chatId;
+        this.friendStatus = friendStatus;
         this.userLocationDto =
             new UserLocationDto(ulId, cityEn, cityUa, regionEn, regionUa, countryEn, countryUa, latitude, longitude);
     }

--- a/service-api/src/main/java/greencity/service/FriendService.java
+++ b/service-api/src/main/java/greencity/service/FriendService.java
@@ -66,7 +66,8 @@ public interface FriendService {
      *
      * @author Stepan Omeliukh
      */
-    PageableDto<UserFriendDto> findAllUsersExceptMainUserAndUsersFriend(long userId, @Nullable String name,
+    PageableDto<UserFriendDto> findAllUsersExceptMainUserAndUsersFriendAndRequestersToMainUser(long userId,
+        @Nullable String name,
         Pageable pageable);
 
     /**

--- a/service-api/src/test/java/greencity/dto/friends/UserFriendDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/friends/UserFriendDtoTest.java
@@ -17,10 +17,11 @@ class UserFriendDtoTest {
         Long mutualFriends = 2L;
         String profilePicture = "profilePicture";
         Long chatId = 4L;
+        String friendStatus = "FRIEND";
         UserFriendDto userFriendDto = new UserFriendDto(id, name, email, rating, uLocation.getId(),
             uLocation.getCityEn(), uLocation.getCityUa(), uLocation.getRegionEn(), uLocation.getRegionUa(),
             uLocation.getCountryEn(), uLocation.getCountryUa(), uLocation.getLatitude(), uLocation.getLongitude(),
-            mutualFriends, profilePicture, chatId);
+            mutualFriends, profilePicture, chatId, friendStatus);
 
         assertEquals(id, userFriendDto.getId());
         assertEquals(name, userFriendDto.getName());
@@ -29,5 +30,6 @@ class UserFriendDtoTest {
         assertEquals(mutualFriends, userFriendDto.getMutualFriends());
         assertEquals(profilePicture, userFriendDto.getProfilePicturePath());
         assertEquals(chatId, userFriendDto.getChatId());
+        assertEquals(friendStatus, userFriendDto.getFriendStatus());
     }
 }

--- a/service/src/main/java/greencity/service/FriendServiceImpl.java
+++ b/service/src/main/java/greencity/service/FriendServiceImpl.java
@@ -5,7 +5,6 @@ import greencity.dto.PageableDto;
 import greencity.dto.friends.UserFriendDto;
 import greencity.dto.user.UserManagementDto;
 import greencity.entity.User;
-import greencity.enums.FriendStatus;
 import greencity.enums.RecommendedFriendsType;
 import greencity.exception.exceptions.BadRequestException;
 import greencity.exception.exceptions.NotDeletedException;
@@ -112,7 +111,7 @@ public class FriendServiceImpl implements FriendService {
      * {@inheritDoc}
      */
     @Override
-    public PageableDto<UserFriendDto> findAllUsersExceptMainUserAndUsersFriend(long userId,
+    public PageableDto<UserFriendDto> findAllUsersExceptMainUserAndUsersFriendAndRequestersToMainUser(long userId,
         @Nullable String name, Pageable pageable) {
         Objects.requireNonNull(pageable);
 

--- a/service/src/main/java/greencity/service/FriendServiceImpl.java
+++ b/service/src/main/java/greencity/service/FriendServiceImpl.java
@@ -120,7 +120,7 @@ public class FriendServiceImpl implements FriendService {
         name = name == null ? "" : name;
         Page<User> users;
         if (pageable.getSort().isEmpty()) {
-            users = userRepo.getAllUsersExceptMainUserAndFriends(userId, name, pageable);
+            users = userRepo.getAllUsersExceptMainUserAndFriendsAndRequestersToMainUser(userId, name, pageable);
         } else {
             throw new UnsupportedSortException(ErrorMessage.INVALID_SORTING_VALUE);
         }
@@ -207,7 +207,6 @@ public class FriendServiceImpl implements FriendService {
         }
         List<UserFriendDto> userFriendDtoList =
             customUserRepo.fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser(userId, users.getContent());
-        userFriendDtoList.forEach(friend -> friend.setFriendStatus(FriendStatus.FRIEND));
         return new PageableDto<>(
             userFriendDtoList,
             users.getTotalElements(),

--- a/service/src/test/java/greencity/service/FriendServiceImplTest.java
+++ b/service/src/test/java/greencity/service/FriendServiceImplTest.java
@@ -521,7 +521,7 @@ class FriendServiceImplTest {
     }
 
     @Test
-    void findAllUsersExceptMainUserAndUsersFriendTest() {
+    void findAllUsersExceptMainUserAndUsersFriendAndRequestersToMainUserTest() {
         long userId = 1L;
         int page = 0;
         int size = 1;
@@ -539,7 +539,7 @@ class FriendServiceImplTest {
                 .thenReturn(List.of(expectedResult));
 
         PageableDto<UserFriendDto> pageableDto =
-            friendService.findAllUsersExceptMainUserAndUsersFriend(userId, name, pageable);
+            friendService.findAllUsersExceptMainUserAndUsersFriendAndRequestersToMainUser(userId, name, pageable);
 
         assertNotNull(pageableDto);
         assertNotNull(pageableDto.getPage());
@@ -556,7 +556,7 @@ class FriendServiceImplTest {
     }
 
     @Test
-    void findAllUsersExceptMainUserAndUsersFriendUnsupportedSortExceptionTest() {
+    void findAllUsersExceptMainUserAndUsersFriendAndRequestersToMainUserUnsupportedSortExceptionTest() {
         long userId = 1L;
 
         PageRequest pageable = PageRequest.of(0, 1, Sort.by("id"));
@@ -565,13 +565,13 @@ class FriendServiceImplTest {
         when(userRepo.existsById(userId)).thenReturn(true);
 
         assertThrows(UnsupportedSortException.class, () -> {
-            friendService.findAllUsersExceptMainUserAndUsersFriend(1L,
+            friendService.findAllUsersExceptMainUserAndUsersFriendAndRequestersToMainUser(1L,
                 name, pageable);
         });
     }
 
     @Test
-    void findAllUsersExceptMainUserAndUsersFriendWhenNameIsNullTest() {
+    void findAllUsersExceptMainUserAndUsersFriendAndRequestersToMainUserWhenNameIsNullTest() {
         long userId = 1L;
         int page = 0;
         int size = 1;
@@ -588,7 +588,7 @@ class FriendServiceImplTest {
                 .thenReturn(List.of(expectedResult));
 
         PageableDto<UserFriendDto> pageableDto =
-            friendService.findAllUsersExceptMainUserAndUsersFriend(userId, null, pageable);
+            friendService.findAllUsersExceptMainUserAndUsersFriendAndRequestersToMainUser(userId, null, pageable);
 
         assertNotNull(pageableDto);
         assertNotNull(pageableDto.getPage());
@@ -736,7 +736,7 @@ class FriendServiceImplTest {
     }
 
     @Test
-    void findAllUsersExceptMainUserAndUsersFriendWhenUserNotFoundTest() {
+    void findAllUsersExceptMainUserAndUsersFriendAndRequestersToMainUserWhenUserNotFoundTest() {
         long userId = 1L;
         String name = "vi";
         Pageable pageable = PageRequest.of(0, 20);
@@ -744,7 +744,8 @@ class FriendServiceImplTest {
         when(userRepo.existsById(userId)).thenReturn(false);
 
         NotFoundException exception = assertThrows(NotFoundException.class,
-            () -> friendService.findAllUsersExceptMainUserAndUsersFriend(userId, name, pageable));
+            () -> friendService.findAllUsersExceptMainUserAndUsersFriendAndRequestersToMainUser(userId, name,
+                pageable));
 
         assertEquals(ErrorMessage.USER_NOT_FOUND_BY_ID + userId, exception.getMessage());
 
@@ -754,12 +755,12 @@ class FriendServiceImplTest {
     }
 
     @Test
-    void findAllUsersExceptMainUserAndUsersFriendWhenPageableIsNullTest() {
+    void findAllUsersExceptMainUserAndUsersFriendAndRequestersToMainUserWhenPageableIsNullTest() {
         long userId = 1L;
         String name = "vi";
 
         assertThrows(NullPointerException.class,
-            () -> friendService.findAllUsersExceptMainUserAndUsersFriend(userId, name, null));
+            () -> friendService.findAllUsersExceptMainUserAndUsersFriendAndRequestersToMainUser(userId, name, null));
 
         verify(userRepo, never()).existsById(anyLong());
         verify(userRepo, never()).getAllUsersExceptMainUserAndFriends(anyLong(), anyString(), any());

--- a/service/src/test/java/greencity/service/FriendServiceImplTest.java
+++ b/service/src/test/java/greencity/service/FriendServiceImplTest.java
@@ -6,7 +6,6 @@ import greencity.dto.PageableDto;
 import greencity.dto.friends.UserFriendDto;
 import greencity.dto.user.UserManagementDto;
 import greencity.entity.User;
-import greencity.enums.FriendStatus;
 import greencity.enums.RecommendedFriendsType;
 import greencity.exception.exceptions.BadRequestException;
 import greencity.exception.exceptions.NotDeletedException;
@@ -533,7 +532,8 @@ class FriendServiceImplTest {
         String name = "vi";
 
         when(userRepo.existsById(userId)).thenReturn(true);
-        when(userRepo.getAllUsersExceptMainUserAndFriends(userId, name, pageable)).thenReturn(userPage);
+        when(userRepo.getAllUsersExceptMainUserAndFriendsAndRequestersToMainUser(userId, name, pageable))
+            .thenReturn(userPage);
         when(
             customUserRepo.fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser(userId, userPage.getContent()))
                 .thenReturn(List.of(expectedResult));
@@ -550,7 +550,7 @@ class FriendServiceImplTest {
         assertEquals(page, pageableDto.getCurrentPage());
 
         verify(userRepo).existsById(userId);
-        verify(userRepo).getAllUsersExceptMainUserAndFriends(userId, name, pageable);
+        verify(userRepo).getAllUsersExceptMainUserAndFriendsAndRequestersToMainUser(userId, name, pageable);
         verify(customUserRepo).fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser(userId,
             userPage.getContent());
     }
@@ -581,7 +581,8 @@ class FriendServiceImplTest {
         Page<User> userPage = new PageImpl<>(List.of(ModelUtils.getUser()), pageable, totalElements);
 
         when(userRepo.existsById(userId)).thenReturn(true);
-        when(userRepo.getAllUsersExceptMainUserAndFriends(userId, "", pageable)).thenReturn(userPage);
+        when(userRepo.getAllUsersExceptMainUserAndFriendsAndRequestersToMainUser(userId, "", pageable))
+            .thenReturn(userPage);
         when(
             customUserRepo.fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser(userId, userPage.getContent()))
                 .thenReturn(List.of(expectedResult));
@@ -598,7 +599,7 @@ class FriendServiceImplTest {
         assertEquals(page, pageableDto.getCurrentPage());
 
         verify(userRepo).existsById(userId);
-        verify(userRepo).getAllUsersExceptMainUserAndFriends(userId, "", pageable);
+        verify(userRepo).getAllUsersExceptMainUserAndFriendsAndRequestersToMainUser(userId, "", pageable);
         verify(customUserRepo).fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser(userId,
             userPage.getContent());
     }
@@ -835,7 +836,7 @@ class FriendServiceImplTest {
         long totalElements = 50;
         Pageable pageable = PageRequest.of(page, size);
         UserFriendDto expectedResult = ModelUtils.getUserFriendDto();
-        expectedResult.setFriendStatus(FriendStatus.FRIEND);
+        expectedResult.setFriendStatus("FRIEND");
         Page<User> userPage = new PageImpl<>(List.of(ModelUtils.getUser()), pageable, totalElements);
         String name = "vi";
 


### PR DESCRIPTION
## Summary Of Issue :
Need to get 
All users have one of 3 existing friendStatus type for "/friends/not-friends-yet":
REQUEST - for users who were REQUESTED for friendship by current user
REJECTED - for users, who have REJECTED the invitation for friendship
null - for users who are not friends, and the invitation for friendship hasn't been REJECTED.



**Issue Link**

https://github.com/ita-social-projects/GreenCity/issues/6536



## Summary Of Changes :
1) changed endpoint g("/{friends}/not-friends-yet")  in FriendController
2) changed named query "fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser" in  User
3)  added new method getAllUsersExceptMainUserAndFriendsAndRequestersToMainUser in UserRepo
4) changed constructor in UserFriendDto
5) changed UserFriendDtoTest
6) changed method findAllUsersExceptMainUserAndUsersFriend in FriendServiceImpl.java
7) changed test in FriendServiceImplTest.java


## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] All files reviewed before sending to reviewers