### PR TITLE
Update all habits page to return default, custom habit of user and custom of his friends with status REQUESTED 

### DIFF
--- a/dao/src/main/java/greencity/repository/HabitAssignRepo.java
+++ b/dao/src/main/java/greencity/repository/HabitAssignRepo.java
@@ -307,4 +307,16 @@ public interface HabitAssignRepo extends JpaRepository<HabitAssign, Long>,
         + " WHERE ha.id = :habitAssignId and ha.user.id = :userId")
     void updateProgressNotificationHasDisplayed(@Param("habitAssignId") Long habitAssignId,
         @Param("userId") Long userId);
+
+    /**
+     * Method to find all Habit ids by user id and status REQUESTED by friends of
+     * current user.
+     *
+     * @param userId {@link Long} id.
+     * @return list of {@link Long} habit ids requested by friends of current user.
+     * @author Olena Sotnik
+     */
+    @Query(value = "SELECT DISTINCT ha.habit.id FROM HabitAssign ha"
+        + " WHERE ha.user.id = :userId AND upper(ha.status) = 'REQUESTED'")
+    List<Long> findAllHabitIdsByUserIdAndStatusIsRequested(@Param("userId") Long userId);
 }

--- a/dao/src/main/java/greencity/repository/HabitTranslationRepo.java
+++ b/dao/src/main/java/greencity/repository/HabitTranslationRepo.java
@@ -2,14 +2,13 @@ package greencity.repository;
 
 import greencity.entity.Habit;
 import greencity.entity.HabitTranslation;
-import greencity.entity.User;
 import java.util.List;
 import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 /**
  * Provides an interface to manage {@link HabitTranslation} entity.
@@ -18,15 +17,6 @@ import org.springframework.data.repository.query.Param;
  */
 public interface HabitTranslationRepo extends JpaRepository<HabitTranslation, Long> {
     /**
-     * Method with return {@link Optional} of {@link HabitTranslation}.
-     *
-     * @param name     of {@link HabitTranslation}.
-     * @param language code language.
-     * @return {@link Optional} of {@link HabitTranslation}.
-     */
-    Optional<HabitTranslation> findByNameAndLanguageCode(String name, String language);
-
-    /**
      * Method return {@link Optional} of {@link HabitTranslation}.
      *
      * @param habit    {@link Habit}.
@@ -34,40 +24,6 @@ public interface HabitTranslationRepo extends JpaRepository<HabitTranslation, Lo
      * @return {@link Optional} of {@link HabitTranslation}.
      */
     Optional<HabitTranslation> findByHabitAndLanguageCode(Habit habit, String language);
-
-    /**
-     * Method returns available {@link HabitTranslation}'s for specific user.
-     *
-     * @param userId   {@link User} id which we use to filter.
-     * @param language code language.
-     * @return List of available {@link HabitTranslation}`s.
-     */
-    @Query(value = "SELECT ht FROM HabitTranslation ht "
-        + "WHERE ht.language.code = :language AND ht.habit.id IN "
-        + "(SELECT ha.habit.id FROM HabitAssign ha "
-        + "WHERE ha.user.id = :userId AND upper(ha.status) <> 'AQCUIRED')")
-    List<HabitTranslation> findHabitTranslationsByUserAndAcquiredStatus(@Param("userId") Long userId,
-        @Param("language") String language);
-
-    /**
-     * Method returns all default and custom which created by current user his
-     * friends {@link Habit}'s by language.
-     *
-     * @param pageable          {@link Pageable}.
-     * @param language          code language.
-     * @param availableUsersIds {@link Long}
-     *
-     * @return Pageable of available {@link HabitTranslation}`s.
-     * @author Dovganyuk Taras
-     */
-
-    @Query("SELECT DISTINCT ht FROM HabitTranslation AS ht "
-        + "WHERE ht.language = "
-        + "(SELECT l FROM Language AS l WHERE l.code = :language) "
-        + "AND ht.habit IN "
-        + "(SELECT h FROM Habit AS h "
-        + "WHERE ( h.isCustomHabit = true AND h.userId IN (:availableUsersIds)) or h.isCustomHabit = false )")
-    Page<HabitTranslation> findAllByLanguageCode(Pageable pageable, String language, List<Long> availableUsersIds);
 
     /**
      * Method deletes all {@link HabitTranslation}'s by {@link Habit} instance.
@@ -95,18 +51,24 @@ public interface HabitTranslationRepo extends JpaRepository<HabitTranslation, Lo
         + "JOIN h.tags AS t "
         + "WHERE t.id IN "
         + "(SELECT tt.tag FROM TagTranslation AS tt "
-        + "WHERE lower(tt.name) IN (:tags)))")
+        + "WHERE lower(tt.name) IN (:tags))) "
+        + "ORDER BY ht.habit.id DESC")
     Page<HabitTranslation> findAllByTagsAndLanguageCode(Pageable pageable, List<String> tags, String languageCode);
 
     /**
-     * Method that find all habit's translations by language code and tags.
+     * Method that finds by language code and tags all default, custom habit's
+     * translations of current user or by habit assign status REQUESTED.
      *
-     * @param pageable     {@link Pageable}
-     * @param tags         {@link List} of {@link String} tags
-     * @param languageCode language code {@link String}
+     * @param pageable                {@link Pageable}
+     * @param tags                    {@link List} of {@link String} tags
+     * @param languageCode            language code {@link String}
+     * @param requestedCustomHabitIds {@link List} of {@link Long} habit ids with
+     *                                habit assign status REQUESTED.
+     * @param userId                  {@link Long} id of current user.
      *
-     * @return {@link List} of {@link HabitTranslation}.
+     * @return {@link Page} of {@link HabitTranslation}.
      * @author Lilia Mokhnatska
+     * @author Olena Sotnik
      */
 
     @Query("SELECT DISTINCT ht FROM HabitTranslation AS ht "
@@ -115,13 +77,14 @@ public interface HabitTranslationRepo extends JpaRepository<HabitTranslation, Lo
         + "AND ht.habit IN "
         + "(SELECT h FROM Habit AS h "
         + "JOIN h.tags AS t "
-        + "WHERE((h.isCustomHabit = true AND h.userId IN (:availableUsersIds)) OR (h.isCustomHabit = false ))"
-        + " AND t.id IN "
+        + "WHERE ((h.isCustomHabit = true AND (h.id IN (:requestedCustomHabitIds) OR h.userId = :userId))  "
+        + "OR (h.isCustomHabit = false)) "
+        + "AND t.id IN "
         + "(SELECT tt.tag FROM TagTranslation AS tt "
-        + "WHERE lower(tt.name) IN (:tags)))")
-    Page<HabitTranslation> findAllByTagsAndLanguageCodeAndForAvailableUsersIfIsCustomHabitTrue(Pageable pageable,
-        List<String> tags, String languageCode,
-        List<Long> availableUsersIds);
+        + "WHERE lower(tt.name) IN (:tags))) "
+        + "ORDER BY ht.habit.id DESC")
+    Page<HabitTranslation> findAllByTagsAndLanguageCodeAndByUserIdAndRequestedStatus(Pageable pageable,
+        List<String> tags, String languageCode, List<Long> requestedCustomHabitIds, Long userId);
 
     /**
      * Method that find all habit's translations by tags, complexities, language
@@ -144,21 +107,25 @@ public interface HabitTranslationRepo extends JpaRepository<HabitTranslation, Lo
         + "JOIN h.tags AS t "
         + "WHERE h.isCustomHabit = false AND h.complexity IN (:complexities) AND t.id IN "
         + "(SELECT tt.tag FROM TagTranslation AS tt "
-        + "WHERE lower(tt.name) IN (:tags)))")
+        + "WHERE lower(tt.name) IN (:tags))) "
+        + "ORDER BY ht.habit.id DESC")
     Page<HabitTranslation> findAllByDifferentParametersIsCustomHabitFalse(Pageable pageable, List<String> tags,
         Optional<List<Integer>> complexities, String languageCode);
 
     /**
-     * Method that find all habit's translations by tags, complexities, language
-     * code in case when isCustomHabit true.
+     * Method that finds all custom habit's translations of current user or by habit
+     * assign status REQUESTED by tags, complexities, language code.
      *
-     * @param pageable          {@link Pageable}.
-     * @param tags              {@link List} of {@link String}.
-     * @param complexities      {@link List} of {@link Integer}.
-     * @param languageCode      language code {@link String}.
-     * @param availableUsersIds {@link Long}
-     * @return {@link List} of {@link HabitTranslation}.
+     * @param pageable                {@link Pageable}.
+     * @param tags                    {@link List} of {@link String}.
+     * @param complexities            {@link List} of {@link Integer}.
+     * @param languageCode            language code {@link String}.
+     * @param requestedCustomHabitIds {@link List} of {@link Long} habit ids with
+     *                                habit assign status REQUESTED.
+     * @return {@link Page} of {@link HabitTranslation}.
+     *
      * @author Lilia Mokhnatska
+     * @author Olena Sotnik
      */
 
     @Query("SELECT DISTINCT ht FROM HabitTranslation AS ht "
@@ -167,21 +134,28 @@ public interface HabitTranslationRepo extends JpaRepository<HabitTranslation, Lo
         + "AND ht.habit IN "
         + "(SELECT h FROM Habit AS h "
         + "JOIN h.tags AS t "
-        + "WHERE h.isCustomHabit = true AND h.userId IN (:availableUsersIds) "
-        + "AND h.complexity IN (:complexities) AND t.id IN"
+        + "WHERE (h.isCustomHabit = true AND (h.id IN (:requestedCustomHabitIds) OR h.userId = :userId)) "
+        + "AND h.complexity IN (:complexities) AND t.id IN "
         + "(SELECT tt.tag FROM TagTranslation AS tt "
-        + "WHERE lower(tt.name) IN (:tags)))")
-    Page<HabitTranslation> findAllByDifferentParametersIsCustomHabitTrue(Pageable pageable, List<String> tags,
-        Optional<List<Integer>> complexities, String languageCode, List<Long> availableUsersIds);
+        + "WHERE lower(tt.name) IN (:tags))) "
+        + "ORDER BY ht.habit.id DESC")
+    Page<HabitTranslation> findCustomHabitsByDifferentParametersByUserIdAndStatusRequested(Pageable pageable,
+        List<String> tags, Optional<List<Integer>> complexities, String languageCode,
+        List<Long> requestedCustomHabitIds, Long userId);
 
     /**
-     * Method that find all habit's translations by language code in case when
-     * isCustomHabit true.
+     * Method that finds all custom habit's translations of current user or by habit
+     * assign status REQUESTED by language code.
      *
-     * @param pageable     {@link Pageable}
-     * @param languageCode language code {@link String}
-     * @return {@link List} of {@link HabitTranslation}.
+     * @param pageable                {@link Pageable}.
+     * @param languageCode            language code {@link String}.
+     * @param userId                  {@link Long} id of current user.
+     * @param requestedCustomHabitIds {@link List} of {@link Long} habit ids with
+     *                                habit assign status REQUESTED.
+     * @return {@link Page} of {@link HabitTranslation}.
+     *
      * @author Lilia Mokhnatska
+     * @author Olena Sotnik
      */
 
     @Query("SELECT DISTINCT ht FROM HabitTranslation AS ht "
@@ -189,9 +163,10 @@ public interface HabitTranslationRepo extends JpaRepository<HabitTranslation, Lo
         + "(SELECT l FROM Language AS l WHERE l.code = :languageCode) "
         + "AND ht.habit IN "
         + "(SELECT h FROM Habit AS h "
-        + "WHERE h.isCustomHabit = true AND h.userId IN (:availableUsersIds))")
-    Page<HabitTranslation> findAllByIsCustomHabitTrueAndLanguageCode(Pageable pageable,
-        String languageCode, List<Long> availableUsersIds);
+        + "WHERE (h.isCustomHabit = true AND (h.id IN (:requestedCustomHabitIds) OR h.userId = :userId))) "
+        + "ORDER BY ht.habit.id DESC")
+    Page<HabitTranslation> findCustomHabitsByLanguageCodeAndByUserIdAndStatusRequested(Pageable pageable,
+        String languageCode, List<Long> requestedCustomHabitIds, Long userId);
 
     /**
      * Method that find all habit's translations by language code in case when
@@ -208,17 +183,24 @@ public interface HabitTranslationRepo extends JpaRepository<HabitTranslation, Lo
         + "(SELECT l FROM Language AS l WHERE l.code = :languageCode) "
         + "AND ht.habit IN "
         + "(SELECT h FROM Habit AS h "
-        + "WHERE h.isCustomHabit = false)")
+        + "WHERE h.isCustomHabit = false) "
+        + "ORDER BY ht.habit.id DESC")
     Page<HabitTranslation> findAllByIsCustomFalseHabitAndLanguageCode(Pageable pageable, String languageCode);
 
     /**
-     * Method that find all habit's translations by complexities and language code.
+     * Method that finds by complexities and language code all default, custom
+     * habit's translations of current user or by habit assign status REQUESTED.
      *
-     * @param pageable     {@link Pageable}.
-     * @param complexities {@link List} of {@link Integer}.
-     * @param languageCode language code {@link String}.
-     * @return {@link List} of {@link HabitTranslation}.
+     * @param pageable                {@link Pageable}.
+     * @param complexities            {@link List} of {@link Integer}.
+     * @param languageCode            language code {@link String}.
+     * @param userId                  {@link Long} id of current user.
+     * @param requestedCustomHabitIds {@link List} of {@link Long} habit ids with
+     *                                habit assign status REQUESTED.
+     * @return {@link Page} of {@link HabitTranslation}.
+     *
      * @author Lilia Mokhnatska
+     * @author Olena Sotnik
      */
 
     @Query("SELECT DISTINCT ht FROM HabitTranslation AS ht "
@@ -226,21 +208,27 @@ public interface HabitTranslationRepo extends JpaRepository<HabitTranslation, Lo
         + "(SELECT l FROM Language AS l WHERE l.code = :languageCode) "
         + "AND ht.habit IN "
         + "(SELECT h FROM Habit AS h "
-        + "WHERE (( h.isCustomHabit = true AND h.userId IN (:availableUsersIds )) OR (h.isCustomHabit = false)) "
-        + "AND h.complexity IN (:complexities))")
-    Page<HabitTranslation> findAllByComplexityAndLanguageCodeAndForAvailableUsersIfIsCustomHabit(Pageable pageable,
-        Optional<List<Integer>> complexities,
-        String languageCode, List<Long> availableUsersIds);
+        + "WHERE ((h.isCustomHabit = true AND (h.id IN (:requestedCustomHabitIds) OR h.userId = :userId)) "
+        + "OR (h.isCustomHabit = false)) "
+        + "AND h.complexity IN (:complexities)) "
+        + "ORDER BY ht.habit.id DESC")
+    Page<HabitTranslation> findAllByComplexityAndLanguageCodeAndUserIdAndStatusRequested(Pageable pageable,
+        Optional<List<Integer>> complexities, String languageCode, List<Long> requestedCustomHabitIds, Long userId);
 
     /**
-     * Method that find all habit's translations by tags, language code in case when
-     * isCustomHabit.
+     * Method that finds by tags and language code all default, custom habit's
+     * translations of current user or by habit assign status REQUESTED.
      *
-     * @param pageable     {@link Pageable}
-     * @param tags         {@link List} of {@link String} tags
-     * @param languageCode language code {@link String}
-     * @return {@link List} of {@link HabitTranslation}.
+     * @param pageable                {@link Pageable}.
+     * @param tags                    {@link List} of {@link String} tags.
+     * @param languageCode            language code {@link String}.
+     * @param userId                  {@link Long} id of current user.
+     * @param requestedCustomHabitIds {@link List} of {@link Long} habit ids with
+     *                                habit assign status REQUESTED.
+     * @return {@link Page} of {@link HabitTranslation}.
+     *
      * @author Lilia Mokhnatska
+     * @author Olena Sotnik
      */
 
     @Query("SELECT DISTINCT ht FROM HabitTranslation AS ht "
@@ -249,11 +237,12 @@ public interface HabitTranslationRepo extends JpaRepository<HabitTranslation, Lo
         + "AND ht.habit IN "
         + "(SELECT h FROM Habit AS h "
         + "JOIN h.tags AS t "
-        + "WHERE h.isCustomHabit = true AND h.userId IN (:availableUsersIds) AND t.id IN "
+        + "WHERE (h.isCustomHabit = true AND (h.id IN (:requestedCustomHabitIds) OR h.userId = :userId)) AND t.id IN "
         + "(SELECT tt.tag FROM TagTranslation AS tt "
-        + "WHERE lower(tt.name) IN (:tags)))")
-    Page<HabitTranslation> findAllByTagsAndIsCustomHabitTrueAndLanguageCode(Pageable pageable, List<String> tags,
-        String languageCode, List<Long> availableUsersIds);
+        + "WHERE lower(tt.name) IN (:tags))) "
+        + "ORDER BY ht.habit.id DESC")
+    Page<HabitTranslation> findCustomHabitsByTagsAndLanguageCodeAndByUserIdAndStatusRequested(Pageable pageable,
+        List<String> tags, String languageCode, List<Long> requestedCustomHabitIds, Long userId);
 
     /**
      * Method that find all habit's translations by tags,and language code in case
@@ -274,20 +263,26 @@ public interface HabitTranslationRepo extends JpaRepository<HabitTranslation, Lo
         + "JOIN h.tags AS t "
         + "WHERE h.isCustomHabit = false AND t.id IN "
         + "(SELECT tt.tag FROM TagTranslation AS tt "
-        + "WHERE lower(tt.name) IN (:tags)))")
+        + "WHERE lower(tt.name) IN (:tags))) "
+        + "ORDER BY ht.habit.id DESC")
     Page<HabitTranslation> findAllByTagsAndIsCustomHabitFalseAndLanguageCode(Pageable pageable, List<String> tags,
         String languageCode);
 
     /**
-     * Method that find all habit's translations by tags, complexities and language
-     * code.
+     * Method that finds by tags, complexities and language code all default, custom
+     * habit's translations of current user or by habit assign status REQUESTED.
      *
-     * @param pageable     {@link Pageable}.
-     * @param tags         {@link List} of {@link String}.
-     * @param complexities {@link List} of {@link Integer}.
-     * @param languageCode language code {@link String}.
-     * @return {@link List} of {@link HabitTranslation}.
+     * @param pageable                {@link Pageable}.
+     * @param tags                    {@link List} of {@link String}.
+     * @param complexities            {@link List} of {@link Integer}.
+     * @param languageCode            language code {@link String}.
+     * @param userId                  {@link Long} id of current user.
+     * @param requestedCustomHabitIds {@link List} of {@link Long} habit ids with
+     *                                habit assign status REQUESTED.
+     * @return {@link Page} of {@link HabitTranslation}.
+     *
      * @author Lilia Mokhnatska
+     * @author Olena Sotnik
      */
 
     @Query("SELECT DISTINCT ht FROM HabitTranslation AS ht "
@@ -296,23 +291,31 @@ public interface HabitTranslationRepo extends JpaRepository<HabitTranslation, Lo
         + "AND ht.habit IN "
         + "(SELECT h FROM Habit AS h "
         + "JOIN h.tags AS t "
-        + "WHERE ((h.isCustomHabit = true AND h.userId IN (:availableUsersIds)) OR (h.isCustomHabit = false )) "
+        + "WHERE ((h.isCustomHabit = true AND (h.id IN (:requestedCustomHabitIds) OR h.userId = :userId)) "
+        + "OR (h.isCustomHabit = false)) "
         + "AND h.complexity IN (:complexities) AND  t.id IN "
         + "(SELECT tt.tag FROM TagTranslation AS tt "
-        + "WHERE lower(tt.name) IN (:tags)))")
-    Page<HabitTranslation> findAllByTagsAndComplexityAndLanguageCodeForAvailableUsersIfIsCustomTrue(Pageable pageable,
-        List<String> tags,
-        Optional<List<Integer>> complexities, String languageCode, List<Long> availableUsersIds);
+        + "WHERE lower(tt.name) IN (:tags))) "
+        + "ORDER BY ht.habit.id DESC")
+    Page<HabitTranslation> findAllByTagsAndComplexityAndLanguageCodeAndByUserIdAndStatusRequested(Pageable pageable,
+        List<String> tags, Optional<List<Integer>> complexities, String languageCode,
+        List<Long> requestedCustomHabitIds,
+        Long userId);
 
     /**
-     * Method that find all habit's translations in case when isCustomHabit true,
-     * complexities and language code.
+     * Method that finds by complexities and language code all custom habit's
+     * translations of current user or by habit assign status REQUESTED.
      *
-     * @param pageable     {@link Pageable}.
-     * @param complexities {@link List} of {@link Integer}.
-     * @param languageCode language code {@link String}.
-     * @return {@link List} of {@link HabitTranslation}.
+     * @param pageable                {@link Pageable}.
+     * @param complexities            {@link List} of {@link Integer}.
+     * @param languageCode            language code {@link String}.
+     * @param userId                  {@link Long} id of current user.
+     * @param requestedCustomHabitIds {@link List} of {@link Long} habit ids with
+     *                                habit assign status REQUESTED.
+     * @return {@link Page} of {@link HabitTranslation}.
+     *
      * @author Lilia Mokhnatska
+     * @author Olena Sotnik
      */
 
     @Query("SELECT DISTINCT  ht FROM HabitTranslation AS ht "
@@ -320,10 +323,11 @@ public interface HabitTranslationRepo extends JpaRepository<HabitTranslation, Lo
         + "(SELECT l FROM Language AS l WHERE l.code = :languageCode) "
         + "AND ht.habit IN "
         + "(SELECT h FROM Habit AS h "
-        + "WHERE h.isCustomHabit = true AND h.userId IN (:availableUsersIds) "
-        + "AND h.complexity IN (:complexities))")
-    Page<HabitTranslation> findAllByIsCustomHabitTrueAndComplexityAndLanguageCode(Pageable pageable,
-        Optional<List<Integer>> complexities, String languageCode, List<Long> availableUsersIds);
+        + "WHERE (h.isCustomHabit = true AND (h.id IN (:requestedCustomHabitIds) OR h.userId = :userId)) "
+        + "AND h.complexity IN (:complexities)) "
+        + "ORDER BY ht.habit.id DESC")
+    Page<HabitTranslation> findCustomHabitsByComplexityAndLanguageCodeAndUserIdAndStatusRequested(Pageable pageable,
+        Optional<List<Integer>> complexities, String languageCode, List<Long> requestedCustomHabitIds, Long userId);
 
     /**
      * Method that find all habit's translations by in case when isCustomHabit false
@@ -341,7 +345,8 @@ public interface HabitTranslationRepo extends JpaRepository<HabitTranslation, Lo
         + "(SELECT l FROM Language AS l WHERE l.code = :languageCode) "
         + "AND ht.habit IN "
         + "(SELECT h FROM Habit AS h "
-        + "WHERE h.isCustomHabit = false AND h.complexity IN (:complexities))")
+        + "WHERE h.isCustomHabit = false AND h.complexity IN (:complexities)) "
+        + "ORDER BY ht.habit.id DESC")
     Page<HabitTranslation> findAllByIsCustomHabitFalseAndComplexityAndLanguageCode(Pageable pageable,
         Optional<List<Integer>> complexities, String languageCode);
 
@@ -353,4 +358,28 @@ public interface HabitTranslationRepo extends JpaRepository<HabitTranslation, Lo
      * @author Lilia Mokhnatska
      */
     List<HabitTranslation> findAllByHabit(Habit habit);
+
+    /**
+     * Method that finds by language all default, custom habits of current user or
+     * by habit assign status REQUESTED.
+     *
+     * @param pageable                {@link Pageable}.
+     * @param language                code language.
+     * @param requestedCustomHabitIds {@link List} of {@link Long} habit ids with
+     *                                habit assign status REQUESTED.
+     * @param userId                  {@link Long} id of current user.
+     * @return {@link Page} of {@link HabitTranslation}`s.
+     *
+     * @author Olena Sotnik
+     */
+    @Query("SELECT DISTINCT ht FROM HabitTranslation AS ht "
+        + "WHERE ht.language = "
+        + "(SELECT l FROM Language AS l WHERE l.code = :language) "
+        + "AND ht.habit IN "
+        + "(SELECT h FROM Habit AS h "
+        + "WHERE (h.isCustomHabit = true AND (h.id IN (:requestedCustomHabitIds) OR h.userId = :userId)) "
+        + "OR h.isCustomHabit = false) "
+        + "ORDER BY ht.habit.id DESC")
+    Page<HabitTranslation> findAllByLanguageCodeAndHabitAssignIdsRequestedAndUserId(Pageable pageable, String language,
+        List<Long> requestedCustomHabitIds, Long userId);
 }

--- a/service/src/test/java/greencity/service/HabitServiceImplTest.java
+++ b/service/src/test/java/greencity/service/HabitServiceImplTest.java
@@ -53,11 +53,11 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.stream.Collectors;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
+import java.util.ArrayList;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -186,9 +186,10 @@ class HabitServiceImplTest {
         HabitDto habitDto = ModelUtils.getHabitDto();
         habitDto.setIsCustomHabit(true);
         UserVO userVO = ModelUtils.getUserVO();
-        List<Long> availableUsersIds = List.of(1L);
-        when(habitTranslationRepo.findAllByLanguageCode(pageable, "en", availableUsersIds))
-            .thenReturn(habitTranslationPage);
+        List<Long> requestedCustomHabitIds = List.of(1L);
+        when(habitAssignRepo.findAllHabitIdsByUserIdAndStatusIsRequested(1L)).thenReturn(requestedCustomHabitIds);
+        when(habitTranslationRepo.findAllByLanguageCodeAndHabitAssignIdsRequestedAndUserId(pageable, "en",
+            requestedCustomHabitIds, userVO.getId())).thenReturn(habitTranslationPage);
         when(modelMapper.map(habitTranslation, HabitDto.class)).thenReturn(habitDto);
         when(habitAssignRepo.findAmountOfUsersAcquired(anyLong())).thenReturn(5L);
         when(habitRepo.findById(1L)).thenReturn(Optional.ofNullable(habit));
@@ -197,6 +198,48 @@ class HabitServiceImplTest {
         PageableDto pageableDto = new PageableDto(habitDtoList, habitTranslationPage.getTotalElements(),
             habitTranslationPage.getPageable().getPageNumber(), habitTranslationPage.getTotalPages());
         assertEquals(pageableDto, habitService.getAllHabitsByLanguageCode(userVO, pageable, "en"));
+
+        verify(habitTranslationRepo).findAllByLanguageCodeAndHabitAssignIdsRequestedAndUserId(any(Pageable.class),
+            anyString(), anyList(), anyLong());
+        verify(modelMapper).map(habitTranslation, HabitDto.class);
+        verify(habitAssignRepo).findAmountOfUsersAcquired(anyLong());
+        verify(habitAssignRepo).findByHabitIdAndUserId(anyLong(), anyLong());
+        verify(habitAssignRepo).findAllHabitIdsByUserIdAndStatusIsRequested(anyLong());
+        verify(habitRepo).findById(1L);
+    }
+
+    @Test
+    void getAllHabitsByLanguageCodeWhenRequestedCustomHabitIdsIsEmpty() {
+        Pageable pageable = PageRequest.of(0, 2);
+        HabitTranslation habitTranslation = ModelUtils.getHabitTranslation();
+        Page<HabitTranslation> habitTranslationPage =
+            new PageImpl<>(Collections.singletonList(habitTranslation), pageable, 10);
+        Habit habit = ModelUtils.getHabit();
+        habit.setIsCustomHabit(true);
+        habit.setUserId(1L);
+        HabitDto habitDto = ModelUtils.getHabitDto();
+        habitDto.setIsCustomHabit(true);
+        UserVO userVO = ModelUtils.getUserVO();
+        List<Long> requestedCustomHabitIds = new ArrayList<>();
+        when(habitAssignRepo.findAllHabitIdsByUserIdAndStatusIsRequested(1L)).thenReturn(requestedCustomHabitIds);
+        when(habitTranslationRepo.findAllByLanguageCodeAndHabitAssignIdsRequestedAndUserId(pageable, "en",
+            requestedCustomHabitIds, userVO.getId())).thenReturn(habitTranslationPage);
+        when(modelMapper.map(habitTranslation, HabitDto.class)).thenReturn(habitDto);
+        when(habitAssignRepo.findAmountOfUsersAcquired(anyLong())).thenReturn(5L);
+        when(habitRepo.findById(1L)).thenReturn(Optional.ofNullable(habit));
+        when(habitAssignRepo.findByHabitIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
+        List<HabitDto> habitDtoList = Collections.singletonList(habitDto);
+        PageableDto pageableDto = new PageableDto(habitDtoList, habitTranslationPage.getTotalElements(),
+            habitTranslationPage.getPageable().getPageNumber(), habitTranslationPage.getTotalPages());
+        assertEquals(pageableDto, habitService.getAllHabitsByLanguageCode(userVO, pageable, "en"));
+
+        verify(habitTranslationRepo).findAllByLanguageCodeAndHabitAssignIdsRequestedAndUserId(any(Pageable.class),
+            anyString(), anyList(), anyLong());
+        verify(modelMapper).map(habitTranslation, HabitDto.class);
+        verify(habitAssignRepo).findAmountOfUsersAcquired(anyLong());
+        verify(habitAssignRepo).findByHabitIdAndUserId(anyLong(), anyLong());
+        verify(habitAssignRepo).findAllHabitIdsByUserIdAndStatusIsRequested(anyLong());
+        verify(habitRepo).findById(1L);
     }
 
     @Test
@@ -239,9 +282,9 @@ class HabitServiceImplTest {
     @MethodSource("getAllByDifferentParametersArguments")
     void getAllByDifferentParameters(Optional<List<String>> tags, Optional<Boolean> isCustomHabit,
         Optional<List<Integer>> complexities) {
-
         Pageable pageable = PageRequest.of(0, 2);
         String tag = "HABIT";
+        Long userId = ModelUtils.getUser().getId();
         List<String> lowerCaseTags = Collections.singletonList(tag.toLowerCase());
         HabitTranslation habitTranslation = ModelUtils.getHabitTranslationWithCustom();
         HabitDto habitDto = ModelUtils.getHabitDto();
@@ -251,80 +294,76 @@ class HabitServiceImplTest {
         PageableDto pageableDto = new PageableDto(habitDtoList, habitTranslationPage.getTotalElements(),
             habitTranslationPage.getPageable().getPageNumber(), habitTranslationPage.getTotalPages());
 
-        List<Long> userIds = userRepo.getAllUserFriends(1L).stream().map(User::getId).collect(Collectors.toList());
-
+        List<Long> requestedCustomHabitIds = List.of(1L);
+        when(habitAssignRepo.findAllHabitIdsByUserIdAndStatusIsRequested(userId)).thenReturn(requestedCustomHabitIds);
         when(modelMapper.map(habitTranslation, HabitDto.class)).thenReturn(habitDto);
         when(habitAssignRepo.findAmountOfUsersAcquired(anyLong())).thenReturn(5L);
         when(habitRepo.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getHabitWithCustom()));
-        List<User> users = Collections.singletonList(ModelUtils.getUser());
-        when(userRepo.getAllUserFriends(ModelUtils.getUser().getId())).thenReturn(users);
 
-        when(habitTranslationRepo.findAllByDifferentParametersIsCustomHabitTrue(any(Pageable.class), anyList(), any(),
-            anyString(), anyList())).thenReturn(habitTranslationPage);
+        when(habitTranslationRepo.findCustomHabitsByDifferentParametersByUserIdAndStatusRequested(any(Pageable.class),
+            anyList(), any(), anyString(), anyList(), anyLong())).thenReturn(habitTranslationPage);
         when(habitTranslationRepo.findAllByDifferentParametersIsCustomHabitFalse(any(Pageable.class), anyList(), any(),
             anyString())).thenReturn(habitTranslationPage);
-        when(habitTranslationRepo.findAllByTagsAndIsCustomHabitTrueAndLanguageCode(any(Pageable.class), anyList(),
-            anyString(), anyList())).thenReturn(habitTranslationPage);
+        when(habitTranslationRepo.findCustomHabitsByTagsAndLanguageCodeAndByUserIdAndStatusRequested(
+            any(Pageable.class), anyList(), anyString(), anyList(), anyLong())).thenReturn(habitTranslationPage);
         when(habitTranslationRepo.findAllByTagsAndIsCustomHabitFalseAndLanguageCode(any(Pageable.class), anyList(),
             anyString())).thenReturn(habitTranslationPage);
-        when(habitTranslationRepo.findAllByIsCustomHabitTrueAndComplexityAndLanguageCode(any(Pageable.class), any(),
-            anyString(),
-            anyList())).thenReturn(habitTranslationPage);
+        when(habitTranslationRepo.findCustomHabitsByComplexityAndLanguageCodeAndUserIdAndStatusRequested(
+            any(Pageable.class), any(), anyString(), anyList(), anyLong())).thenReturn(habitTranslationPage);
         when(habitTranslationRepo.findAllByIsCustomHabitFalseAndComplexityAndLanguageCode(any(Pageable.class), any(),
             anyString())).thenReturn(habitTranslationPage);
-        when(habitTranslationRepo.findAllByTagsAndComplexityAndLanguageCodeForAvailableUsersIfIsCustomTrue(
-            any(Pageable.class), anyList(), any(), anyString(),
-            anyList())).thenReturn(habitTranslationPage);
-        when(
-            habitTranslationRepo.findAllByIsCustomHabitTrueAndLanguageCode(any(Pageable.class), anyString(), anyList()))
+        when(habitTranslationRepo.findAllByTagsAndComplexityAndLanguageCodeAndByUserIdAndStatusRequested(
+            any(Pageable.class), anyList(), any(), anyString(), anyList(), anyLong())).thenReturn(habitTranslationPage);
+        when(habitTranslationRepo.findCustomHabitsByLanguageCodeAndByUserIdAndStatusRequested(any(Pageable.class),
+            anyString(), anyList(), anyLong()))
                 .thenReturn(habitTranslationPage);
         when(habitTranslationRepo.findAllByIsCustomFalseHabitAndLanguageCode(any(Pageable.class), anyString()))
             .thenReturn(habitTranslationPage);
-        when(habitTranslationRepo.findAllByTagsAndLanguageCodeAndForAvailableUsersIfIsCustomHabitTrue(
-            any(Pageable.class), any(), anyString(),
-            anyList())).thenReturn(habitTranslationPage);
-        when(habitTranslationRepo.findAllByComplexityAndLanguageCodeAndForAvailableUsersIfIsCustomHabit(
-            any(Pageable.class), any(), anyString(),
-            anyList())).thenReturn(habitTranslationPage);
+        when(habitTranslationRepo.findAllByTagsAndLanguageCodeAndByUserIdAndRequestedStatus(any(Pageable.class), any(),
+            anyString(), anyList(), anyLong())).thenReturn(habitTranslationPage);
+        when(habitTranslationRepo.findAllByComplexityAndLanguageCodeAndUserIdAndStatusRequested(
+            any(Pageable.class), any(), anyString(), anyList(), anyLong())).thenReturn(habitTranslationPage);
 
         if (isCustomHabit.isPresent() && tags.isPresent() && complexities.isPresent()) {
             if (isCustomHabit.get()) {
-                habitTranslationRepo.findAllByDifferentParametersIsCustomHabitTrue(pageable, lowerCaseTags,
-                    complexities, "en", userIds);
+                habitTranslationRepo.findCustomHabitsByDifferentParametersByUserIdAndStatusRequested(pageable,
+                    lowerCaseTags, complexities, "en", requestedCustomHabitIds, userId);
             } else {
                 habitTranslationRepo.findAllByDifferentParametersIsCustomHabitFalse(pageable, lowerCaseTags,
                     complexities, "en");
             }
         } else if (isCustomHabit.isPresent() && tags.isPresent()) {
             if (isCustomHabit.get()) {
-                habitTranslationRepo.findAllByTagsAndIsCustomHabitTrueAndLanguageCode(pageable, lowerCaseTags, "en",
-                    userIds);
+                habitTranslationRepo.findCustomHabitsByTagsAndLanguageCodeAndByUserIdAndStatusRequested(pageable,
+                    lowerCaseTags, "en", requestedCustomHabitIds, userId);
             } else {
-                habitTranslationRepo.findAllByTagsAndIsCustomHabitFalseAndLanguageCode(pageable, lowerCaseTags, "en");
+                habitTranslationRepo.findAllByTagsAndIsCustomHabitFalseAndLanguageCode(pageable, lowerCaseTags,
+                    "en");
             }
         } else if (isCustomHabit.isPresent() && complexities.isPresent()) {
             if (isCustomHabit.get()) {
-                habitTranslationRepo.findAllByIsCustomHabitTrueAndComplexityAndLanguageCode(pageable, complexities,
-                    "en", userIds);
+                habitTranslationRepo.findCustomHabitsByComplexityAndLanguageCodeAndUserIdAndStatusRequested(pageable,
+                    complexities, "en", requestedCustomHabitIds, userId);
             } else {
                 habitTranslationRepo.findAllByIsCustomHabitFalseAndComplexityAndLanguageCode(pageable, complexities,
                     "en");
             }
         } else if (complexities.isPresent() && tags.isPresent()) {
-            habitTranslationRepo.findAllByTagsAndComplexityAndLanguageCodeForAvailableUsersIfIsCustomTrue(pageable,
-                lowerCaseTags, complexities, "en", userIds);
+            habitTranslationRepo.findAllByTagsAndComplexityAndLanguageCodeAndByUserIdAndStatusRequested(pageable,
+                lowerCaseTags, complexities, "en", requestedCustomHabitIds, userId);
         } else if (isCustomHabit.isPresent()) {
             if (isCustomHabit.get()) {
-                habitTranslationRepo.findAllByIsCustomHabitTrueAndLanguageCode(pageable, "en", userIds);
+                habitTranslationRepo.findCustomHabitsByLanguageCodeAndByUserIdAndStatusRequested(pageable,
+                    "en", requestedCustomHabitIds, userId);
             } else {
                 habitTranslationRepo.findAllByIsCustomFalseHabitAndLanguageCode(pageable, "en");
             }
         } else if (tags.isPresent()) {
-            habitTranslationRepo.findAllByTagsAndLanguageCodeAndForAvailableUsersIfIsCustomHabitTrue(pageable,
-                lowerCaseTags, "en", userIds);
+            habitTranslationRepo.findAllByTagsAndLanguageCodeAndByUserIdAndRequestedStatus(pageable,
+                lowerCaseTags, "en", requestedCustomHabitIds, userId);
         } else if (complexities.isPresent()) {
-            habitTranslationRepo.findAllByComplexityAndLanguageCodeAndForAvailableUsersIfIsCustomHabit(pageable,
-                complexities, "en", userIds);
+            habitTranslationRepo.findAllByComplexityAndLanguageCodeAndUserIdAndStatusRequested(pageable,
+                complexities, "en", requestedCustomHabitIds, userId);
         }
 
         assertEquals(pageableDto, habitService.getAllByDifferentParameters(ModelUtils.getUserVO(), pageable, tags,
@@ -336,45 +375,202 @@ class HabitServiceImplTest {
 
         if (isCustomHabit.isPresent() && tags.isPresent() && complexities.isPresent()) {
             if (isCustomHabit.get()) {
-                verify(habitTranslationRepo).findAllByDifferentParametersIsCustomHabitTrue(pageable, lowerCaseTags,
-                    complexities, "en", userIds);
+                verify(habitTranslationRepo, times(2))
+                    .findCustomHabitsByDifferentParametersByUserIdAndStatusRequested(pageable,
+                        lowerCaseTags, complexities, "en", requestedCustomHabitIds, userId);
             } else {
-                verify(habitTranslationRepo, times(2)).findAllByDifferentParametersIsCustomHabitFalse(pageable,
-                    lowerCaseTags,
+                verify(habitTranslationRepo, times(2))
+                    .findAllByDifferentParametersIsCustomHabitFalse(pageable, lowerCaseTags, complexities,
+                        "en");
+            }
+        } else if (isCustomHabit.isPresent() && tags.isPresent()) {
+            if (isCustomHabit.get()) {
+                verify(habitTranslationRepo, times(2))
+                    .findCustomHabitsByTagsAndLanguageCodeAndByUserIdAndStatusRequested(pageable,
+                        lowerCaseTags, "en", requestedCustomHabitIds, userId);
+            } else {
+                verify(habitTranslationRepo, times(2))
+                    .findAllByTagsAndIsCustomHabitFalseAndLanguageCode(pageable, lowerCaseTags, "en");
+            }
+        } else if (isCustomHabit.isPresent() && complexities.isPresent()) {
+            if (isCustomHabit.get()) {
+                verify(habitTranslationRepo, times(2))
+                    .findCustomHabitsByComplexityAndLanguageCodeAndUserIdAndStatusRequested(pageable, complexities,
+                        "en", requestedCustomHabitIds, userId);
+            } else {
+                verify(habitTranslationRepo, times(2))
+                    .findAllByIsCustomHabitFalseAndComplexityAndLanguageCode(pageable, complexities,
+                        "en");
+            }
+        } else if (complexities.isPresent() && tags.isPresent()) {
+            verify(habitTranslationRepo, times(2))
+                .findAllByTagsAndComplexityAndLanguageCodeAndByUserIdAndStatusRequested(pageable, lowerCaseTags,
+                    complexities, "en", requestedCustomHabitIds, userId);
+        } else if (isCustomHabit.isPresent()) {
+            if (isCustomHabit.get()) {
+                verify(habitTranslationRepo, times(2))
+                    .findCustomHabitsByLanguageCodeAndByUserIdAndStatusRequested(pageable, "en",
+                        requestedCustomHabitIds, userId);
+            } else {
+                verify(habitTranslationRepo, times(2))
+                    .findAllByIsCustomFalseHabitAndLanguageCode(pageable, "en");
+            }
+        } else if (tags.isPresent()) {
+            verify(habitTranslationRepo, times(2))
+                .findAllByTagsAndLanguageCodeAndByUserIdAndRequestedStatus(pageable,
+                    lowerCaseTags, "en", requestedCustomHabitIds, userId);
+        } else if (complexities.isPresent()) {
+            verify(habitTranslationRepo, times(2))
+                .findAllByComplexityAndLanguageCodeAndUserIdAndStatusRequested(pageable,
+                    complexities, "en", requestedCustomHabitIds, userId);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("getAllByDifferentParametersArguments")
+    void getAllByDifferentParametersWhenRequestedCustomHabitIdsIsEmpty(Optional<List<String>> tags,
+        Optional<Boolean> isCustomHabit, Optional<List<Integer>> complexities) {
+        Pageable pageable = PageRequest.of(0, 2);
+        String tag = "HABIT";
+        Long userId = ModelUtils.getUser().getId();
+        List<String> lowerCaseTags = Collections.singletonList(tag.toLowerCase());
+        HabitTranslation habitTranslation = ModelUtils.getHabitTranslationWithCustom();
+        HabitDto habitDto = ModelUtils.getHabitDto();
+        Page<HabitTranslation> habitTranslationPage =
+            new PageImpl<>(Collections.singletonList(habitTranslation), pageable, 10);
+        List<HabitDto> habitDtoList = Collections.singletonList(habitDto);
+        PageableDto pageableDto = new PageableDto(habitDtoList, habitTranslationPage.getTotalElements(),
+            habitTranslationPage.getPageable().getPageNumber(), habitTranslationPage.getTotalPages());
+
+        List<Long> requestedCustomHabitIds = new ArrayList<>();
+        when(habitAssignRepo.findAllHabitIdsByUserIdAndStatusIsRequested(userId)).thenReturn(requestedCustomHabitIds);
+        when(modelMapper.map(habitTranslation, HabitDto.class)).thenReturn(habitDto);
+        when(habitAssignRepo.findAmountOfUsersAcquired(anyLong())).thenReturn(5L);
+        when(habitRepo.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getHabitWithCustom()));
+
+        when(habitTranslationRepo.findCustomHabitsByDifferentParametersByUserIdAndStatusRequested(any(Pageable.class),
+            anyList(), any(), anyString(), anyList(), anyLong())).thenReturn(habitTranslationPage);
+        when(habitTranslationRepo.findAllByDifferentParametersIsCustomHabitFalse(any(Pageable.class), anyList(), any(),
+            anyString())).thenReturn(habitTranslationPage);
+        when(habitTranslationRepo.findCustomHabitsByTagsAndLanguageCodeAndByUserIdAndStatusRequested(
+            any(Pageable.class), anyList(), anyString(), anyList(), anyLong())).thenReturn(habitTranslationPage);
+        when(habitTranslationRepo.findAllByTagsAndIsCustomHabitFalseAndLanguageCode(any(Pageable.class), anyList(),
+            anyString())).thenReturn(habitTranslationPage);
+        when(habitTranslationRepo.findCustomHabitsByComplexityAndLanguageCodeAndUserIdAndStatusRequested(
+            any(Pageable.class), any(), anyString(), anyList(), anyLong())).thenReturn(habitTranslationPage);
+        when(habitTranslationRepo.findAllByIsCustomHabitFalseAndComplexityAndLanguageCode(any(Pageable.class), any(),
+            anyString())).thenReturn(habitTranslationPage);
+        when(habitTranslationRepo.findAllByTagsAndComplexityAndLanguageCodeAndByUserIdAndStatusRequested(
+            any(Pageable.class), anyList(), any(), anyString(), anyList(), anyLong())).thenReturn(habitTranslationPage);
+        when(habitTranslationRepo.findCustomHabitsByLanguageCodeAndByUserIdAndStatusRequested(any(Pageable.class),
+            anyString(), anyList(), anyLong()))
+                .thenReturn(habitTranslationPage);
+        when(habitTranslationRepo.findAllByIsCustomFalseHabitAndLanguageCode(any(Pageable.class), anyString()))
+            .thenReturn(habitTranslationPage);
+        when(habitTranslationRepo.findAllByTagsAndLanguageCodeAndByUserIdAndRequestedStatus(any(Pageable.class), any(),
+            anyString(), anyList(), anyLong())).thenReturn(habitTranslationPage);
+        when(habitTranslationRepo.findAllByComplexityAndLanguageCodeAndUserIdAndStatusRequested(
+            any(Pageable.class), any(), anyString(), anyList(), anyLong())).thenReturn(habitTranslationPage);
+
+        if (isCustomHabit.isPresent() && tags.isPresent() && complexities.isPresent()) {
+            if (isCustomHabit.get()) {
+                habitTranslationRepo.findCustomHabitsByDifferentParametersByUserIdAndStatusRequested(pageable,
+                    lowerCaseTags, complexities, "en", requestedCustomHabitIds, userId);
+            } else {
+                habitTranslationRepo.findAllByDifferentParametersIsCustomHabitFalse(pageable, lowerCaseTags,
                     complexities, "en");
             }
         } else if (isCustomHabit.isPresent() && tags.isPresent()) {
             if (isCustomHabit.get()) {
-                verify(habitTranslationRepo).findAllByTagsAndIsCustomHabitTrueAndLanguageCode(pageable, lowerCaseTags,
-                    "en", userIds);
+                habitTranslationRepo.findCustomHabitsByTagsAndLanguageCodeAndByUserIdAndStatusRequested(pageable,
+                    lowerCaseTags, "en", requestedCustomHabitIds, userId);
             } else {
-                verify(habitTranslationRepo, times(2)).findAllByTagsAndIsCustomHabitFalseAndLanguageCode(pageable,
-                    lowerCaseTags,
+                habitTranslationRepo.findAllByTagsAndIsCustomHabitFalseAndLanguageCode(pageable, lowerCaseTags,
                     "en");
             }
         } else if (isCustomHabit.isPresent() && complexities.isPresent()) {
             if (isCustomHabit.get()) {
-                verify(habitTranslationRepo).findAllByIsCustomHabitTrueAndComplexityAndLanguageCode(pageable,
-                    complexities, "en", userIds);
+                habitTranslationRepo.findCustomHabitsByComplexityAndLanguageCodeAndUserIdAndStatusRequested(pageable,
+                    complexities, "en", requestedCustomHabitIds, userId);
             } else {
-                verify(habitTranslationRepo, times(2)).findAllByIsCustomHabitFalseAndComplexityAndLanguageCode(pageable,
-                    complexities, "en");
+                habitTranslationRepo.findAllByIsCustomHabitFalseAndComplexityAndLanguageCode(pageable, complexities,
+                    "en");
             }
         } else if (complexities.isPresent() && tags.isPresent()) {
-            verify(habitTranslationRepo).findAllByTagsAndComplexityAndLanguageCodeForAvailableUsersIfIsCustomTrue(
-                pageable, lowerCaseTags, complexities, "en", userIds);
+            habitTranslationRepo.findAllByTagsAndComplexityAndLanguageCodeAndByUserIdAndStatusRequested(pageable,
+                lowerCaseTags, complexities, "en", requestedCustomHabitIds, userId);
         } else if (isCustomHabit.isPresent()) {
             if (isCustomHabit.get()) {
-                verify(habitTranslationRepo).findAllByIsCustomHabitTrueAndLanguageCode(pageable, "en", userIds);
+                habitTranslationRepo.findCustomHabitsByLanguageCodeAndByUserIdAndStatusRequested(pageable,
+                    "en", requestedCustomHabitIds, userId);
             } else {
-                verify(habitTranslationRepo, times(2)).findAllByIsCustomFalseHabitAndLanguageCode(pageable, "en");
+                habitTranslationRepo.findAllByIsCustomFalseHabitAndLanguageCode(pageable, "en");
             }
         } else if (tags.isPresent()) {
-            verify(habitTranslationRepo).findAllByTagsAndLanguageCodeAndForAvailableUsersIfIsCustomHabitTrue(pageable,
-                lowerCaseTags, "en", userIds);
+            habitTranslationRepo.findAllByTagsAndLanguageCodeAndByUserIdAndRequestedStatus(pageable,
+                lowerCaseTags, "en", requestedCustomHabitIds, userId);
         } else if (complexities.isPresent()) {
-            verify(habitTranslationRepo).findAllByComplexityAndLanguageCodeAndForAvailableUsersIfIsCustomHabit(pageable,
-                complexities, "en", userIds);
+            habitTranslationRepo.findAllByComplexityAndLanguageCodeAndUserIdAndStatusRequested(pageable,
+                complexities, "en", requestedCustomHabitIds, userId);
+        }
+
+        assertEquals(pageableDto, habitService.getAllByDifferentParameters(ModelUtils.getUserVO(), pageable, tags,
+            isCustomHabit, complexities, "en"));
+
+        verify(modelMapper).map(habitTranslation, HabitDto.class);
+        verify(habitAssignRepo).findAmountOfUsersAcquired(anyLong());
+        verify(habitRepo).findById(1L);
+
+        if (isCustomHabit.isPresent() && tags.isPresent() && complexities.isPresent()) {
+            if (isCustomHabit.get()) {
+                verify(habitTranslationRepo, times(2))
+                    .findCustomHabitsByDifferentParametersByUserIdAndStatusRequested(pageable,
+                        lowerCaseTags, complexities, "en", requestedCustomHabitIds, userId);
+            } else {
+                verify(habitTranslationRepo, times(2))
+                    .findAllByDifferentParametersIsCustomHabitFalse(pageable, lowerCaseTags, complexities,
+                        "en");
+            }
+        } else if (isCustomHabit.isPresent() && tags.isPresent()) {
+            if (isCustomHabit.get()) {
+                verify(habitTranslationRepo, times(2))
+                    .findCustomHabitsByTagsAndLanguageCodeAndByUserIdAndStatusRequested(pageable,
+                        lowerCaseTags, "en", requestedCustomHabitIds, userId);
+            } else {
+                verify(habitTranslationRepo, times(2))
+                    .findAllByTagsAndIsCustomHabitFalseAndLanguageCode(pageable, lowerCaseTags, "en");
+            }
+        } else if (isCustomHabit.isPresent() && complexities.isPresent()) {
+            if (isCustomHabit.get()) {
+                verify(habitTranslationRepo, times(2))
+                    .findCustomHabitsByComplexityAndLanguageCodeAndUserIdAndStatusRequested(pageable, complexities,
+                        "en", requestedCustomHabitIds, userId);
+            } else {
+                verify(habitTranslationRepo, times(2))
+                    .findAllByIsCustomHabitFalseAndComplexityAndLanguageCode(pageable, complexities,
+                        "en");
+            }
+        } else if (complexities.isPresent() && tags.isPresent()) {
+            verify(habitTranslationRepo, times(2))
+                .findAllByTagsAndComplexityAndLanguageCodeAndByUserIdAndStatusRequested(pageable, lowerCaseTags,
+                    complexities, "en", requestedCustomHabitIds, userId);
+        } else if (isCustomHabit.isPresent()) {
+            if (isCustomHabit.get()) {
+                verify(habitTranslationRepo, times(2))
+                    .findCustomHabitsByLanguageCodeAndByUserIdAndStatusRequested(pageable, "en",
+                        requestedCustomHabitIds, userId);
+            } else {
+                verify(habitTranslationRepo, times(2))
+                    .findAllByIsCustomFalseHabitAndLanguageCode(pageable, "en");
+            }
+        } else if (tags.isPresent()) {
+            verify(habitTranslationRepo, times(2))
+                .findAllByTagsAndLanguageCodeAndByUserIdAndRequestedStatus(pageable,
+                    lowerCaseTags, "en", requestedCustomHabitIds, userId);
+        } else if (complexities.isPresent()) {
+            verify(habitTranslationRepo, times(2))
+                .findAllByComplexityAndLanguageCodeAndUserIdAndStatusRequested(pageable,
+                    complexities, "en", requestedCustomHabitIds, userId);
         }
     }
 
@@ -386,7 +582,7 @@ class HabitServiceImplTest {
         ShoppingListItemDto shoppingListItemDto = new ShoppingListItemDto(1L, "test", "ACTIVE");
         List<ShoppingListItemDto> shoppingListItemDtos = Collections.singletonList(shoppingListItemDto);
         when(modelMapper.map(shoppingListItemTranslation, ShoppingListItemDto.class)).thenReturn(shoppingListItemDto);
-        when(shoppingListItemTranslationRepo.findShoppingListByHabitIdAndByLanguageCode("en", 1l))
+        when(shoppingListItemTranslationRepo.findShoppingListByHabitIdAndByLanguageCode("en", 1L))
             .thenReturn(shoppingListItemTranslations);
         assertEquals(shoppingListItemDtos, habitService.getShoppingListForHabit(1L, "en"));
     }


### PR DESCRIPTION
# GreenCity PR
[[All Habits] All Habits page shows all custom habits created by user's friends. Only custom habits REQUESTED to assign by friends should be shown instead of all. #6666](https://github.com/ita-social-projects/GreenCity/issues/6666)

## Summary Of Changes :fire:
- Updated HabitTranslationRepo, updated queries and methods names, docs for methods due to new meaning.

- Deleted few methods that are not used in code : findByNameAndLanguageCode, findHabitTranslationsByUserAndAcquiredStatus, findAllByLanguageCode; 

- Added new method findAllHabitIdsByUserIdAndStatusIsRequested() that returns  List<Long> of all habit ids REQUESTED by friends of current user.

- Updated implementations of methods in HabitServiceImpl: getAllHabitsByLanguageCode() and getAllByDifferentParameters();

- Updated tests in HabitServiceImplTest class for methods in HabitServiceImpl;

## Deleted
Methods in HabitTranslationRepo that are not used in code : findByNameAndLanguageCode(), findHabitTranslationsByUserAndAcquiredStatus(), findAllByLanguageCode(); 

# PR Checklist Forms
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers