### PR TITLE
changed constructor in UserFriendDto

### DIFF
--- a/service-api/src/main/java/greencity/dto/friends/UserFriendDto.java
+++ b/service-api/src/main/java/greencity/dto/friends/UserFriendDto.java
@@ -38,7 +38,12 @@ public class UserFriendDto {
         this.profilePicturePath = profilePicturePath;
         this.chatId = chatId;
         this.friendStatus = friendStatus;
-        this.userLocationDto =
-            new UserLocationDto(ulId, cityEn, cityUa, regionEn, regionUa, countryEn, countryUa, latitude, longitude);
+        if (ulId != null) {
+            this.userLocationDto =
+                new UserLocationDto(ulId, cityEn, cityUa, regionEn, regionUa, countryEn, countryUa, latitude,
+                    longitude);
+        } else {
+            this.userLocationDto = null;
+        }
     }
 }

--- a/service-api/src/test/java/greencity/dto/friends/UserFriendDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/friends/UserFriendDtoTest.java
@@ -4,6 +4,7 @@ import greencity.dto.location.UserLocationDto;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class UserFriendDtoTest {
     @Test
@@ -32,4 +33,24 @@ class UserFriendDtoTest {
         assertEquals(chatId, userFriendDto.getChatId());
         assertEquals(friendStatus, userFriendDto.getFriendStatus());
     }
+
+    @Test
+    void testUserFriendDtoConstructorWithoutUserLocation() {
+        Long id = 1L;
+        String name = "name";
+        String email = "email";
+        Double rating = 1.0;
+        Long ulId = null;
+        Long mutualFriends = 2L;
+        String profilePicturePath = "/path/to/profile/picture";
+        Long chatId = 4L;
+        String friendStatus = "FRIEND";
+
+        UserFriendDto userFriendDto = new UserFriendDto(
+            id, name, email, rating, ulId, null, null, null, null, null, null,
+            null, null, mutualFriends, profilePicturePath, chatId, friendStatus);
+
+        assertNull(userFriendDto.getUserLocationDto());
+    }
+
 }


### PR DESCRIPTION
## Summary Of Issue :
in UserFriendDTO all UserLocationDTO fields are set to null when User does not have a location



**Issue Link**


https://github.com/ita-social-projects/GreenCity/issues/6694

## Summary Of Changes :
1) changed constructor in UserFriendDto
2) added test in UserFriendDtoTest



## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] All files reviewed before sending to reviewers