### PR TITLE
Added "isOrganizedByFriend" field to EventDto

### DIFF
--- a/service-api/src/main/java/greencity/dto/event/EventDto.java
+++ b/service-api/src/main/java/greencity/dto/event/EventDto.java
@@ -55,6 +55,8 @@ public class EventDto {
 
     private int countComments;
 
+    private boolean isOrganizedByFriend;
+
     /**
      * Return String of event tags in English.
      *

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -776,6 +776,22 @@ public class EventServiceImpl implements EventService {
             new TypeToken<List<EventDto>>() {
             }.getType());
 
+        if (Objects.nonNull(eventDtos)) {
+            eventDtos.forEach(eventDto -> {
+                if (Objects.nonNull(eventDto.getOrganizer())) {
+                    Long idOrganizer = eventDto.getOrganizer().getId();
+                    if (Objects.nonNull(idOrganizer)) {
+                        boolean isOrganizedByFriend = userRepo.isFriend(idOrganizer, userId);
+                        eventDto.setOrganizedByFriend(isOrganizedByFriend);
+                    } else {
+                        eventDto.setOrganizedByFriend(false);
+                    }
+                } else {
+                    eventDto.setOrganizedByFriend(false);
+                }
+            });
+        }
+
         if (CollectionUtils.isNotEmpty(eventDtos)) {
             setSubscribes(eventDtos, userId);
             setFollowers(eventDtos, userId);

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -8,6 +8,7 @@ import greencity.constant.AppConstant;
 import greencity.dto.PageableAdvancedDto;
 import greencity.dto.event.AddEventDtoRequest;
 import greencity.dto.event.EventAttenderDto;
+import greencity.dto.event.EventAuthorDto;
 import greencity.dto.event.EventDto;
 import greencity.dto.event.UpdateEventDto;
 import greencity.dto.event.AddressDto;
@@ -1178,6 +1179,74 @@ class EventServiceImplTest {
             }.getType());
         verify(eventRepo).findFavoritesAmongEventIds(eventIds, user.getId());
         verify(eventRepo).findSubscribedAmongEventIds(eventIds, user.getId());
+    }
+
+    @Test
+    void getAllWithCurrentUser_WithNullInOrganizerEvent() {
+        List<Event> events = List.of(ModelUtils.getEvent().setOrganizer(null));
+        EventDto expected = ModelUtils.getEventDto().setOrganizer(null);
+        Principal principal = ModelUtils.getPrincipal();
+        PageRequest pageRequest = PageRequest.of(0, 1);
+
+        when(eventRepo.findAllByOrderByIdDesc(pageRequest))
+            .thenReturn(new PageImpl<>(events, pageRequest, events.size()));
+        when(restClient.findByEmail(principal.getName())).thenReturn(TEST_USER_VO);
+        when(modelMapper.map(TEST_USER_VO, User.class)).thenReturn(ModelUtils.getUser());
+        when(modelMapper.map(events,
+            new TypeToken<List<EventDto>>() {
+            }.getType())).thenReturn(List.of(expected));
+
+        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getAll(pageRequest, principal);
+        EventDto actual = eventDtoPageableAdvancedDto.getPage().get(0);
+
+        assertEquals(expected.getId(), actual.getId());
+        assertEquals(expected.getDescription(), actual.getDescription());
+
+        verify(modelMapper).map(events,
+            new TypeToken<List<EventDto>>() {
+            }.getType());
+
+        verify(eventRepo).findAllByOrderByIdDesc(any());
+        verify(restClient).findByEmail(any());
+        verify(modelMapper).map(TEST_USER_VO, User.class);
+
+        verify(modelMapper).map(events,
+            new TypeToken<List<EventDto>>() {
+            }.getType());
+    }
+
+    @Test
+    void getAllWithCurrentUser_WithNullInIdOrganizerEvent() {
+        User user = ModelUtils.getUser();
+        List<Event> events = List.of(ModelUtils.getEvent().setOrganizer(user.setId(null)));
+        EventDto expected = ModelUtils.getEventDto().setOrganizer(EventAuthorDto.builder()
+            .name("User")
+            .id(null)
+            .build());
+        Principal principal = ModelUtils.getPrincipal();
+        PageRequest pageRequest = PageRequest.of(0, 1);
+
+        when(eventRepo.findAllByOrderByIdDesc(pageRequest))
+            .thenReturn(new PageImpl<>(events, pageRequest, events.size()));
+        when(restClient.findByEmail(principal.getName())).thenReturn(TEST_USER_VO);
+        when(modelMapper.map(TEST_USER_VO, User.class)).thenReturn(ModelUtils.getUser());
+        when(modelMapper.map(events,
+            new TypeToken<List<EventDto>>() {
+            }.getType())).thenReturn(List.of(expected));
+
+        PageableAdvancedDto<EventDto> eventDtoPageableAdvancedDto = eventService.getAll(pageRequest, principal);
+        EventDto actual = eventDtoPageableAdvancedDto.getPage().get(0);
+
+        assertEquals(expected.getId(), actual.getId());
+        assertEquals(expected.getDescription(), actual.getDescription());
+
+        verify(eventRepo).findAllByOrderByIdDesc(any());
+        verify(restClient).findByEmail(any());
+        verify(modelMapper).map(TEST_USER_VO, User.class);
+
+        verify(modelMapper).map(events,
+            new TypeToken<List<EventDto>>() {
+            }.getType());
     }
 
     @Test


### PR DESCRIPTION
## Summary Of Issue :
Need to add a field "isOrganizedByFriend" (boolean) which indicates whether the event organizer is a friend of the current user.



**Issue Link**

https://github.com/ita-social-projects/GreenCity/issues/6686



## Summary Of Changes :
1) added field isOrganizedByFriend to EventDto
2) changed private method buildPageableAdvancedDto in EventServiceImpl.
3) added new tests in EventServiceImplTest



## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [ ] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers