### PR TITLE
[GreenCity] Limit the search query result for Friends List to first 10 items #6774

### DIFF
--- a/service/src/main/java/greencity/service/EcoNewsCommentServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsCommentServiceImpl.java
@@ -339,7 +339,9 @@ public class EcoNewsCommentServiceImpl implements EcoNewsCommentService {
     }
 
     /**
-     * Method that allow you to search users by name.
+     * Method that allow you to search users by name. The search results will be
+     * limited to the first 10 entries, and the list will decrease as the search
+     * query is refined.
      *
      * @param searchUsers dto with current user ID and search query
      *                    {@link UserSearchDto}.
@@ -354,6 +356,7 @@ public class EcoNewsCommentServiceImpl implements EcoNewsCommentService {
 
         List<UserTagDto> usersToTag = users.stream()
             .map(u -> modelMapper.map(u, UserTagDto.class))
+            .limit(10)
             .collect(Collectors.toList());
 
         messagingTemplate.convertAndSend("/topic/" + searchUsers.getCurrentUserId() + "/searchUsers", usersToTag);


### PR DESCRIPTION
# GreenCity PR
https://github.com/ita-social-projects/GreenCity/issues/6774

## Summary Of Changes :fire:
The search results will be limited to the first 10 entries, and the list will decrease as the search query is refined.

## Added
* Limit for the search query result

## How to test :clipboard:
It can be tests on the site of our project.

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
