### PR TITLE
Commit with CustomUserRepoImpl ids instead of entity solution

### DIFF
--- a/dao/src/main/java/greencity/repository/impl/CustomUserRepoImpl.java
+++ b/dao/src/main/java/greencity/repository/impl/CustomUserRepoImpl.java
@@ -7,8 +7,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Repository
@@ -28,9 +30,10 @@ public class CustomUserRepoImpl implements CustomUserRepo {
                 UserFriendDto.class);
         query.setParameter("userId", userId);
         if (users.isEmpty()) {
-            query.setParameter("users", List.of(-1));
+            query.setParameter("users", Collections.singletonList(-1L));
         } else {
-            query.setParameter("users", users);
+            List<Long> userIds = users.stream().map(User::getId).collect(Collectors.toList());
+            query.setParameter("users", userIds);
         }
         return query.getResultList();
     }

--- a/dao/src/test/java/greencity/repository/impl/CustomUserRepoImplTest.java
+++ b/dao/src/test/java/greencity/repository/impl/CustomUserRepoImplTest.java
@@ -10,7 +10,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -28,6 +30,7 @@ class CustomUserRepoImplTest {
     void fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUserTest() {
         long userId = 1L;
         List<User> users = List.of(ModelUtils.getUser());
+        List<Long> userIds = users.stream().map(User::getId).collect(Collectors.toList());
         TypedQuery<UserFriendDto> query = mock(TypedQuery.class);
 
         when(entityManager.createNamedQuery("User.fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser",
@@ -36,7 +39,7 @@ class CustomUserRepoImplTest {
         customUserRepo.fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser(userId, users);
 
         verify(query).setParameter("userId", userId);
-        verify(query).setParameter("users", users);
+        verify(query).setParameter("users", userIds);
     }
 
     @Test
@@ -51,7 +54,7 @@ class CustomUserRepoImplTest {
         customUserRepo.fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser(userId, users);
 
         verify(query).setParameter("userId", userId);
-        verify(query).setParameter("users", List.of(-1));
+        verify(query).setParameter("users", Collections.singletonList(-1L));
     }
 
     @Test


### PR DESCRIPTION
# GreenCity PR
Fix of problem with Native Query for FriendsController endpoints

## Summary Of Changes :fire:
Updated method using TypedQuery in  method of CustomUserRepo fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser()

## Added
Added List of ids of user instead of entities itself

## Changed 
Tests for this method.

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers