### PR TITLE
Update of get all events endpoint

### DIFF
--- a/core/src/main/java/greencity/controller/EventsController.java
+++ b/core/src/main/java/greencity/controller/EventsController.java
@@ -35,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.multipart.MultipartFile;
 import java.security.Principal;
 import java.util.Set;
@@ -147,7 +146,7 @@ public class EventsController {
     @GetMapping
     public ResponseEntity<PageableAdvancedDto<EventDto>> getEvent(
         @Parameter(hidden = true) Pageable pageable, @Parameter(hidden = true) Principal principal,
-        @RequestBody(required = false) FilterEventDto filterEventDto, @RequestParam(required = false) String title) {
+        FilterEventDto filterEventDto, @RequestParam(required = false) String title) {
         return ResponseEntity.status(HttpStatus.OK)
             .body(eventService.getEvents(pageable, principal, filterEventDto, title));
     }

--- a/core/src/test/java/greencity/controller/EventsControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventsControllerTest.java
@@ -2,10 +2,12 @@ package greencity.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import greencity.ModelUtils;
 import greencity.dto.PageableAdvancedDto;
 import greencity.dto.event.AddressDto;
 import greencity.dto.event.EventAuthorDto;
 import greencity.dto.event.EventDateLocationDto;
+import greencity.dto.filter.FilterEventDto;
 import greencity.dto.tag.TagUaEnDto;
 import greencity.exception.exceptions.BadRequestException;
 import greencity.exception.exceptions.NotFoundException;
@@ -36,12 +38,10 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
 import java.security.Principal;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
-
 import static greencity.ModelUtils.getPrincipal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.times;
@@ -112,7 +112,9 @@ class EventsControllerTest {
         ObjectWriter ow = objectMapper.writer();
         String expectedJson = ow.writeValueAsString(pageableAdvancedDto);
 
-        when(eventService.getEvents(pageable, principal, null, null))
+        FilterEventDto filterEventDto = ModelUtils.getNullFilterEventDto();
+
+        when(eventService.getEvents(pageable, principal, filterEventDto, null))
             .thenReturn(pageableAdvancedDto);
 
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK)
@@ -122,7 +124,7 @@ class EventsControllerTest {
             .andExpect(status().isOk())
             .andExpect(content().json(expectedJson));
 
-        verify(eventService).getEvents(pageable, principal, null, null);
+        verify(eventService).getEvents(pageable, principal, filterEventDto, null);
     }
 
     @Test


### PR DESCRIPTION
# GreenCity PR
Endpoint [GET] /events does not work with filters

## Summary Of Changes :fire:
Removed annotation @RequestBody for FilterEventDto as it is not acceptable for GET operations

## Changed
Updated test of controller and arguments for [GET] /events endpoint

# PR Checklist Forms
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers