### PR TITLE
Pageable parameter type fix

### DIFF
--- a/core/src/main/java/greencity/annotations/ApiLocale.java
+++ b/core/src/main/java/greencity/annotations/ApiLocale.java
@@ -16,7 +16,7 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-@Parameter(name = "lang", schema = @Schema(type = "string"), in = ParameterIn.DEFAULT,
+@Parameter(name = "lang", schema = @Schema(type = "string"), in = ParameterIn.QUERY,
     description = "Code of the needed language.")
 public @interface ApiLocale {
 }

--- a/core/src/main/java/greencity/annotations/ApiLocale.java
+++ b/core/src/main/java/greencity/annotations/ApiLocale.java
@@ -16,7 +16,7 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-@Parameter(name = "lang", schema = @Schema(type = "string"), in = ParameterIn.QUERY,
+@Parameter(name = "lang", schema = @Schema(type = "string"), in = ParameterIn.DEFAULT,
     description = "Code of the needed language.")
 public @interface ApiLocale {
 }

--- a/core/src/main/java/greencity/annotations/ApiPageable.java
+++ b/core/src/main/java/greencity/annotations/ApiPageable.java
@@ -11,14 +11,14 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Parameter(name = "page", schema = @Schema(type = "int", minimum = "0", defaultValue = "0"),
-    in = ParameterIn.QUERY, description = "Page index you want to retrieve [0..N]. "
+    in = ParameterIn.DEFAULT, description = "Page index you want to retrieve [0..N]. "
         + "If page index is less than 0 or not specified then default value is used!")
 @Parameter(name = "size", schema = @Schema(type = "int", minimum = "1", maximum = "100", defaultValue = "5"),
-    in = ParameterIn.QUERY, description = "Number of records per page [1..100]. "
+    in = ParameterIn.DEFAULT, description = "Number of records per page [1..100]. "
         + "If size is less than 1 or not specified then default value is used!"
         + "If size is bigger than 100, size becomes 100.")
 @Parameter(name = "sort", schema = @Schema(type = "array", implementation = String.class),
-    in = ParameterIn.QUERY, description = "Sorting criteria in the format: property(asc|desc). "
+    in = ParameterIn.DEFAULT, description = "Sorting criteria in the format: property(asc|desc). "
         + "Default sort order is ascending. " + "Multiple sort criteria are supported.")
 public @interface ApiPageable {
 }

--- a/core/src/main/java/greencity/annotations/ApiPageable.java
+++ b/core/src/main/java/greencity/annotations/ApiPageable.java
@@ -10,15 +10,15 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@Parameter(name = "page", schema = @Schema(type = "int", minimum = "0", defaultValue = "0"),
-    in = ParameterIn.DEFAULT, description = "Page index you want to retrieve [0..N]. "
+@Parameter(name = "page", schema = @Schema(type = "integer", minimum = "0", defaultValue = "0"),
+    in = ParameterIn.QUERY, description = "Page index you want to retrieve [0..N]. "
         + "If page index is less than 0 or not specified then default value is used!")
-@Parameter(name = "size", schema = @Schema(type = "int", minimum = "1", maximum = "100", defaultValue = "5"),
-    in = ParameterIn.DEFAULT, description = "Number of records per page [1..100]. "
+@Parameter(name = "size", schema = @Schema(type = "integer", minimum = "1", maximum = "100", defaultValue = "5"),
+    in = ParameterIn.QUERY, description = "Number of records per page [1..100]. "
         + "If size is less than 1 or not specified then default value is used!"
         + "If size is bigger than 100, size becomes 100.")
 @Parameter(name = "sort", schema = @Schema(type = "array", implementation = String.class),
-    in = ParameterIn.DEFAULT, description = "Sorting criteria in the format: property(asc|desc). "
+    in = ParameterIn.QUERY, description = "Sorting criteria in the format: property(asc|desc). "
         + "Default sort order is ascending. " + "Multiple sort criteria are supported.")
 public @interface ApiPageable {
 }

--- a/core/src/main/java/greencity/annotations/ApiPageableWithLocale.java
+++ b/core/src/main/java/greencity/annotations/ApiPageableWithLocale.java
@@ -12,8 +12,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Parameter(name = "lang", description = "Code of the needed language.",
     schema = @Schema(type = "string"), in = ParameterIn.QUERY)
-@Parameter(name = "page", schema = @Schema(type = "integer", minimum = "0", defaultValue = "0"),
-    in = ParameterIn.DEFAULT,
+@Parameter(name = "page", schema = @Schema(type = "integer", minimum = "0", defaultValue = "0"), in = ParameterIn.QUERY,
     description = "Page index you want to retrieve [0..N]. "
         + "If page index is less than 0 or not specified then default value is used!")
 @Parameter(name = "size", schema = @Schema(type = "integer", minimum = "1", maximum = "100", defaultValue = "5"),

--- a/core/src/main/java/greencity/annotations/ApiPageableWithLocale.java
+++ b/core/src/main/java/greencity/annotations/ApiPageableWithLocale.java
@@ -11,15 +11,15 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Parameter(name = "lang", description = "Code of the needed language.",
-    schema = @Schema(type = "string"), in = ParameterIn.QUERY)
-@Parameter(name = "page", schema = @Schema(type = "int", minimum = "0", defaultValue = "0"), in = ParameterIn.QUERY,
+    schema = @Schema(type = "string"), in = ParameterIn.DEFAULT)
+@Parameter(name = "page", schema = @Schema(type = "int", minimum = "0", defaultValue = "0"), in = ParameterIn.DEFAULT,
     description = "Page index you want to retrieve [0..N]. "
         + "If page index is less than 0 or not specified then default value is used!")
 @Parameter(name = "size", schema = @Schema(type = "int", minimum = "1", maximum = "100", defaultValue = "5"),
-    in = ParameterIn.QUERY, description = "Number of records per page [1..100]. "
+    in = ParameterIn.DEFAULT, description = "Number of records per page [1..100]. "
         + "If size is less than 1 or not specified then default value is used!"
         + "If size is bigger than 100, size becomes 100.")
-@Parameter(name = "sort", schema = @Schema(type = "string"), in = ParameterIn.QUERY,
+@Parameter(name = "sort", schema = @Schema(type = "string"), in = ParameterIn.DEFAULT,
     description = "Sorting criteria in the format: property(asc|desc). "
         + "Default sort order is ascending. " + "Multiple sort criteria are supported.")
 public @interface ApiPageableWithLocale {

--- a/core/src/main/java/greencity/annotations/ApiPageableWithLocale.java
+++ b/core/src/main/java/greencity/annotations/ApiPageableWithLocale.java
@@ -11,15 +11,16 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Parameter(name = "lang", description = "Code of the needed language.",
-    schema = @Schema(type = "string"), in = ParameterIn.DEFAULT)
-@Parameter(name = "page", schema = @Schema(type = "int", minimum = "0", defaultValue = "0"), in = ParameterIn.DEFAULT,
+    schema = @Schema(type = "string"), in = ParameterIn.QUERY)
+@Parameter(name = "page", schema = @Schema(type = "integer", minimum = "0", defaultValue = "0"),
+    in = ParameterIn.DEFAULT,
     description = "Page index you want to retrieve [0..N]. "
         + "If page index is less than 0 or not specified then default value is used!")
-@Parameter(name = "size", schema = @Schema(type = "int", minimum = "1", maximum = "100", defaultValue = "5"),
-    in = ParameterIn.DEFAULT, description = "Number of records per page [1..100]. "
+@Parameter(name = "size", schema = @Schema(type = "integer", minimum = "1", maximum = "100", defaultValue = "5"),
+    in = ParameterIn.QUERY, description = "Number of records per page [1..100]. "
         + "If size is less than 1 or not specified then default value is used!"
         + "If size is bigger than 100, size becomes 100.")
-@Parameter(name = "sort", schema = @Schema(type = "string"), in = ParameterIn.DEFAULT,
+@Parameter(name = "sort", schema = @Schema(type = "string"), in = ParameterIn.QUERY,
     description = "Sorting criteria in the format: property(asc|desc). "
         + "Default sort order is ascending. " + "Multiple sort criteria are supported.")
 public @interface ApiPageableWithLocale {

--- a/core/src/main/java/greencity/annotations/ApiPageableWithoutSort.java
+++ b/core/src/main/java/greencity/annotations/ApiPageableWithoutSort.java
@@ -10,11 +10,11 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@Parameter(name = "page", schema = @Schema(type = "int", minimum = "0", defaultValue = "0"), in = ParameterIn.DEFAULT,
+@Parameter(name = "page", schema = @Schema(type = "integer", minimum = "0", defaultValue = "0"), in = ParameterIn.QUERY,
     description = "Page index you want to retrieve [0..N]. "
         + "If page index is less than 0 or not specified then default value is used!")
-@Parameter(name = "size", schema = @Schema(type = "int", minimum = "1", maximum = "100", defaultValue = "5"),
-    in = ParameterIn.DEFAULT, description = "Number of records per page [1..100]. "
+@Parameter(name = "size", schema = @Schema(type = "integer", minimum = "1", maximum = "100", defaultValue = "5"),
+    in = ParameterIn.QUERY, description = "Number of records per page [1..100]. "
         + "If size is less than 1 or not specified then default value is used!"
         + "If size is bigger than 100, size becomes 100.")
 public @interface ApiPageableWithoutSort {

--- a/core/src/main/java/greencity/annotations/ApiPageableWithoutSort.java
+++ b/core/src/main/java/greencity/annotations/ApiPageableWithoutSort.java
@@ -10,11 +10,11 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@Parameter(name = "page", schema = @Schema(type = "int", minimum = "0", defaultValue = "0"), in = ParameterIn.QUERY,
+@Parameter(name = "page", schema = @Schema(type = "int", minimum = "0", defaultValue = "0"), in = ParameterIn.DEFAULT,
     description = "Page index you want to retrieve [0..N]. "
         + "If page index is less than 0 or not specified then default value is used!")
 @Parameter(name = "size", schema = @Schema(type = "int", minimum = "1", maximum = "100", defaultValue = "5"),
-    in = ParameterIn.QUERY, description = "Number of records per page [1..100]. "
+    in = ParameterIn.DEFAULT, description = "Number of records per page [1..100]. "
         + "If size is less than 1 or not specified then default value is used!"
         + "If size is bigger than 100, size becomes 100.")
 public @interface ApiPageableWithoutSort {


### PR DESCRIPTION
# GreenCity PR
Pageable size or page number must be of integer type and strings should not be allowed to be used.

## Summary Of Changes :fire:
Updated data type in @ApiPageable.... annotations: instead of "int" -> "integer"

This fixes the validation of data type in swagger operations

<img width="1470" alt="Screenshot 2024-02-22 at 16 15 19" src="https://github.com/ita-social-projects/GreenCity/assets/63450632/829c032d-da0e-42ec-9b32-cd6239c5ca8c">




# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers