### PR TITLE
validation time in events by GMT

### DIFF
--- a/core/src/main/java/greencity/controller/EventsController.java
+++ b/core/src/main/java/greencity/controller/EventsController.java
@@ -106,7 +106,7 @@ public class EventsController {
         consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<EventDto> update(
         @Parameter(required = true,
-            description = SwaggerExampleModel.UPDATE_EVENT) @RequestPart UpdateEventDto eventDto,
+            description = SwaggerExampleModel.UPDATE_EVENT) @ValidEventDtoRequest @RequestPart UpdateEventDto eventDto,
         @Parameter(hidden = true) Principal principal,
         @RequestPart(required = false) @Nullable MultipartFile[] images) {
         return ResponseEntity.status(HttpStatus.OK).body(

--- a/core/src/main/java/greencity/validator/EventDtoRequestValidator.java
+++ b/core/src/main/java/greencity/validator/EventDtoRequestValidator.java
@@ -4,49 +4,91 @@ import greencity.annotations.ValidEventDtoRequest;
 import greencity.constant.ErrorMessage;
 import greencity.constant.ValidationConstants;
 import greencity.dto.event.AddEventDtoRequest;
-import greencity.dto.event.AddressDto;
 import greencity.dto.event.EventDateLocationDto;
+import greencity.dto.event.UpdateEventDto;
 import greencity.exception.exceptions.EventDtoValidationException;
-import static greencity.validator.UrlValidator.isUrlValid;
-import java.time.ZonedDateTime;
-import java.util.List;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import static greencity.validator.UrlValidator.isUrlValid;
 
-public class EventDtoRequestValidator implements ConstraintValidator<ValidEventDtoRequest, AddEventDtoRequest> {
+public class EventDtoRequestValidator implements ConstraintValidator<ValidEventDtoRequest, Object> {
+    /**
+     * Validates whether the provided value adheres to the constraints defined for
+     * an event DTO. The validation includes checking event date locations, ensuring
+     * they fall within specified bounds, validating the tags count, and checking
+     * the validity of online links. Time zones of the event start dates are
+     * converted to Greenwich Mean Time (GMT) for comparison.
+     *
+     * @param value   The object to be validated, expected to be an instance of
+     *                AddEventDtoRequest or UpdateEventDto.
+     * @param context The context in which the validation is performed.
+     * @return True if the value is valid according to the defined constraints,
+     *         otherwise false.
+     * @throws EventDtoValidationException if the value does not meet the validation
+     *                                     criteria.
+     */
     @Override
-    public void initialize(ValidEventDtoRequest constraintAnnotation) {
-        // Initializes the validator in preparation for #isValid calls
-    }
-
-    @Override
-    public boolean isValid(AddEventDtoRequest value, ConstraintValidatorContext context) {
-        List<EventDateLocationDto> eventDateLocationDtos = value.getDatesLocations();
-
-        if (eventDateLocationDtos == null || eventDateLocationDtos.isEmpty()
-            || eventDateLocationDtos.size() > ValidationConstants.MAX_EVENT_DATES_AMOUNT) {
-            throw new EventDtoValidationException(ErrorMessage.WRONG_COUNT_OF_EVENT_DATES);
+    public boolean isValid(Object value, ConstraintValidatorContext context) {
+        if (!(value instanceof AddEventDtoRequest || value instanceof UpdateEventDto)) {
+            return false;
         }
 
+        List<EventDateLocationDto> eventDateLocationDtos = new ArrayList<>();
+
+        if (value instanceof AddEventDtoRequest addEventDtoRequest) {
+            if (addEventDtoRequest.getDatesLocations() == null || addEventDtoRequest.getDatesLocations().isEmpty()
+                || addEventDtoRequest.getDatesLocations().size() > ValidationConstants.MAX_EVENT_DATES_AMOUNT) {
+                throw new EventDtoValidationException(ErrorMessage.WRONG_COUNT_OF_EVENT_DATES);
+            } else {
+                eventDateLocationDtos = convertDatesToGMTZone(addEventDtoRequest.getDatesLocations());
+            }
+        } else if (value instanceof UpdateEventDto updateEventDto) {
+            if (updateEventDto.getDatesLocations() == null || updateEventDto.getDatesLocations().isEmpty()
+                || updateEventDto.getDatesLocations().size() > ValidationConstants.MAX_EVENT_DATES_AMOUNT) {
+                throw new EventDtoValidationException(ErrorMessage.WRONG_COUNT_OF_EVENT_DATES);
+            } else {
+                eventDateLocationDtos = convertDatesToGMTZone(updateEventDto.getDatesLocations());
+            }
+        }
+
+        validateEventDateLocations(eventDateLocationDtos);
+        validateTags(value);
+        return true;
+    }
+
+    private List<EventDateLocationDto> convertDatesToGMTZone(List<EventDateLocationDto> dates) {
+        return dates.stream()
+            .map(e -> e.setStartDate(e.getStartDate().withZoneSameInstant(ZoneOffset.UTC)))
+            .map(e -> e.setFinishDate(e.getFinishDate().withZoneSameInstant(ZoneOffset.UTC)))
+            .toList();
+    }
+
+    private void validateEventDateLocations(List<EventDateLocationDto> eventDateLocationDtos) {
         for (var eventDateLocationDto : eventDateLocationDtos) {
-            if (eventDateLocationDto.getStartDate().isBefore(ZonedDateTime.now())
+            if (eventDateLocationDto.getStartDate().isBefore(ZonedDateTime.now(ZoneOffset.UTC))
                 || eventDateLocationDto.getStartDate().isAfter(eventDateLocationDto.getFinishDate())) {
                 throw new EventDtoValidationException(ErrorMessage.EVENT_START_DATE_AFTER_FINISH_DATE_OR_IN_PAST);
             }
-            AddressDto addressDto = eventDateLocationDto.getCoordinates();
-            String onlineLink = eventDateLocationDto.getOnlineLink();
-            if (onlineLink == null && addressDto == null) {
+
+            if (eventDateLocationDto.getOnlineLink() == null && eventDateLocationDto.getCoordinates() == null) {
                 throw new EventDtoValidationException(ErrorMessage.NO_EVENT_LINK_OR_ADDRESS);
             }
-            if (onlineLink != null) {
-                isUrlValid(onlineLink);
+            if (eventDateLocationDto.getOnlineLink() != null) {
+                isUrlValid(eventDateLocationDto.getOnlineLink());
             }
         }
+    }
 
-        if (value.getTags().size() > ValidationConstants.MAX_AMOUNT_OF_TAGS) {
+    private void validateTags(Object value) {
+        int tagsSize = (value instanceof AddEventDtoRequest addEventDtoRequest) ? (addEventDtoRequest.getTags().size())
+            : ((UpdateEventDto) value).getTags().size();
+
+        if (tagsSize > ValidationConstants.MAX_AMOUNT_OF_TAGS) {
             throw new EventDtoValidationException(ErrorMessage.WRONG_COUNT_OF_TAGS_EXCEPTION);
         }
-
-        return true;
     }
 }

--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -20,6 +20,7 @@ import greencity.dto.econewscomment.EcoNewsCommentAuthorDto;
 import greencity.dto.econewscomment.EcoNewsCommentDto;
 import greencity.dto.event.AddEventDtoRequest;
 import greencity.dto.event.EventDateLocationDto;
+import greencity.dto.event.UpdateEventDto;
 import greencity.dto.factoftheday.FactOfTheDayDTO;
 import greencity.dto.factoftheday.FactOfTheDayPostDTO;
 import greencity.dto.factoftheday.FactOfTheDayTranslationEmbeddedPostDTO;
@@ -675,6 +676,26 @@ public class ModelUtils {
 
     public static AddEventDtoRequest getEventDtoWithoutDates() {
         return AddEventDtoRequest.builder().title("Title").description("Desc").isOpen(true).build();
+    }
+
+    public static UpdateEventDto getUpdateEventDtoWithotDates() {
+        return UpdateEventDto.builder().title("Title").description("Desc").isOpen(true).build();
+    }
+
+    public static UpdateEventDto getUpdateEventDto() {
+        return UpdateEventDto.builder().datesLocations(List.of(EventDateLocationDto.builder()
+            .startDate(ZonedDateTime.now().plusDays(5))
+            .finishDate(ZonedDateTime.now().plusDays(5).plusHours(1))
+            .onlineLink("http://localhost:8060/swagger-ui.html#/")
+            .build())).tags(List.of("first", "second", "third")).build();
+    }
+
+    public static UpdateEventDto getUpdateEventDtoWithTooManyDates() {
+        List<EventDateLocationDto> eventDateLocationDtos = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            eventDateLocationDtos.add(EventDateLocationDto.builder().id((long) i).build());
+        }
+        return UpdateEventDto.builder().datesLocations(eventDateLocationDtos).build();
     }
 
     public static AddEventDtoRequest getEventDtoWithZeroDates() {

--- a/core/src/test/java/greencity/validator/EventDtoRequestValidatorTest.java
+++ b/core/src/test/java/greencity/validator/EventDtoRequestValidatorTest.java
@@ -2,6 +2,7 @@ package greencity.validator;
 
 import greencity.ModelUtils;
 import greencity.dto.event.AddEventDtoRequest;
+import greencity.dto.event.UpdateEventDto;
 import greencity.exception.exceptions.EventDtoValidationException;
 import greencity.exception.exceptions.InvalidURLException;
 import org.junit.jupiter.api.Test;
@@ -9,8 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
 class EventDtoRequestValidatorTest {
@@ -66,8 +66,33 @@ class EventDtoRequestValidatorTest {
     }
 
     @Test
+    void updateWithtooManyTagsException() {
+        UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDtoWithTooManyDates();
+        assertThrows(EventDtoValidationException.class, () -> validator.isValid(updateEventDto, null));
+    }
+
+    @Test
+    void updateEventDtoWithoutDates() {
+        UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDtoWithotDates();
+        assertThrows(EventDtoValidationException.class, () -> validator.isValid(updateEventDto, null));
+
+    }
+
+    @Test
     void validEvent() {
         AddEventDtoRequest addEventDtoRequest = ModelUtils.getAddEventDtoRequest();
         assertTrue(validator.isValid(addEventDtoRequest, null));
+    }
+
+    @Test
+    void validEventUpdate() {
+        UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDto();
+        assertTrue(validator.isValid(updateEventDto, null));
+    }
+
+    @Test
+    void invalidObjectType() {
+        Object value = new Object();
+        assertFalse(validator.isValid(value, null));
     }
 }

--- a/service-api/src/main/java/greencity/dto/event/UpdateEventDto.java
+++ b/service-api/src/main/java/greencity/dto/event/UpdateEventDto.java
@@ -1,12 +1,17 @@
 package greencity.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
+import lombok.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
-@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+@EqualsAndHashCode
 public class UpdateEventDto {
     @NotNull
     private Long id;

--- a/service-api/src/main/java/greencity/dto/event/UpdateEventDto.java
+++ b/service-api/src/main/java/greencity/dto/event/UpdateEventDto.java
@@ -2,7 +2,6 @@ package greencity.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
@@ -18,7 +17,7 @@ public class UpdateEventDto {
     @Size(min = 20, max = 63206)
     private String description;
 
-    @Max(7)
+    @Size(min = 1, max = 7)
     private List<EventDateLocationDto> datesLocations;
 
     private String titleImage;


### PR DESCRIPTION
# GreenCity PR

## Summary Of Changes :fire:
Rewrite validation of the time while creating an events to compare it with Greenwich Mean Time. So basically right now server accepts time in any time zone around the world. After that server converts that time at the GMT timezone and compares it with actual time in GMT. 

## Issue Link :clipboard:
_&lt;[Link to the issue](https://github.com/ita-social-projects/GreenCity/issues/6961)&gt;_

## Added
* _Wrote new business logic of validation time while creating/updating events._

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers