### PR TITLE
rounding time to next our

### DIFF
--- a/core/src/main/java/greencity/validator/EventDtoRequestValidator.java
+++ b/core/src/main/java/greencity/validator/EventDtoRequestValidator.java
@@ -77,7 +77,8 @@ public class EventDtoRequestValidator implements ConstraintValidator<ValidEventD
      */
     private void validateEventDateLocations(List<EventDateLocationDto> eventDateLocationDtos) {
         for (var eventDateLocationDto : eventDateLocationDtos) {
-            if (eventDateLocationDto.getStartDate().isBefore(ZonedDateTime.now(ZoneOffset.UTC).plusHours(1L))
+            if (eventDateLocationDto.getStartDate().isBefore(ZonedDateTime.now(ZoneOffset.UTC)
+                .plusHours(1L).withMinute(0).withSecond(0).withNano(0))
                 || eventDateLocationDto.getStartDate().isBefore(eventDateLocationDto.getFinishDate().minusDays(1L))
                 || eventDateLocationDto.getStartDate().isAfter(eventDateLocationDto.getFinishDate())
                 || eventDateLocationDto.getStartDate().isAfter(ZonedDateTime.now(ZoneOffset.UTC).plusYears(1L))) {


### PR DESCRIPTION
# GreenCity PR

## Summary Of Changes :fire:
Added possibility to create an event for next rounded hour

## Changed
For example, before this PR if we have local time `3:18AM`, then user can't create an event in `4:00AM`. Only at `4:18AM`. This PR changed this validation, so this one will work correctly

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers