### PR TITLE
user cannot like his own econews comment

### DIFF
--- a/service/src/main/java/greencity/service/EcoNewsCommentServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsCommentServiceImpl.java
@@ -223,6 +223,9 @@ public class EcoNewsCommentServiceImpl implements EcoNewsCommentService {
             .anyMatch(user -> user.getId().equals(userVO.getId()))) {
             ecoNewsService.unlikeComment(userVO, ecoNewsCommentVO);
         } else {
+            if (comment.getUser().getId().equals(userVO.getId())) {
+                throw new BadRequestException(ErrorMessage.USER_HAS_NO_PERMISSION);
+            }
             ecoNewsService.likeComment(userVO, ecoNewsCommentVO);
             notificationService.sendEmailNotification(GeneralEmailMessage.builder()
                 .email(comment.getUser().getEmail())

--- a/service/src/test/java/greencity/service/EcoNewsCommentServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EcoNewsCommentServiceImplTest.java
@@ -590,4 +590,30 @@ class EcoNewsCommentServiceImplTest {
         verify(userRepo).findAll();
         verify(modelMapper).map(user, UserTagDto.class);
     }
+
+    @Test
+    void likeOwnCommentThrowsException() {
+        UserVO userVO = getUserVO();
+        EcoNewsComment ecoNewsComment = ModelUtils.getEcoNewsComment();
+        ecoNewsComment.setUsersLiked(new HashSet<>());
+
+        when(ecoNewsCommentRepo.findById(anyLong())).thenReturn(Optional.of(ecoNewsComment));
+        assertThrows(BadRequestException.class, () -> ecoNewsCommentService.like(1L, userVO));
+    }
+
+    @Test
+    void countOfCommentsTest() {
+        EcoNews ecoNews = new EcoNews();
+        ecoNews.setId(1L);
+        int commentCount = 5;
+
+        when(ecoNewsRepo.findById(1L)).thenReturn(java.util.Optional.of(ecoNews));
+        when(ecoNewsCommentRepo.countEcoNewsCommentByEcoNews(1L)).thenReturn(commentCount);
+
+        int result = ecoNewsCommentService.countOfComments(1L);
+
+        assertEquals(commentCount, result);
+        verify(ecoNewsRepo).findById(1L);
+        verify(ecoNewsCommentRepo).countEcoNewsCommentByEcoNews(1L);
+    }
 }


### PR DESCRIPTION
# GreenCity PR
User cannot like his own econews comment

## Summary Of Changes :fire:
Now current User cannot anymore like his own econews comment

## Issue Link :clipboard:
_&lt;[Link to the issue](https://github.com/ita-social-projects/GreenCity/issues/6916)&gt;_

## Changed
_Method like() of EcoNewsCommentServiceImpl class has been updated_

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
