### PR TITLE
user can't create or update an event with two or more same event dates

### DIFF
--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -687,7 +687,13 @@ public class ModelUtils {
             .startDate(ZonedDateTime.now().plusDays(5))
             .finishDate(ZonedDateTime.now().plusDays(5).plusHours(1))
             .onlineLink("http://localhost:8060/swagger-ui.html#/")
-            .build())).tags(List.of("first", "second", "third")).build();
+            .build(),
+            EventDateLocationDto.builder()
+                .startDate(ZonedDateTime.now().plusDays(6))
+                .finishDate(ZonedDateTime.now().plusDays(6).plusHours(1))
+                .onlineLink("http://localhost:8060/swagger-ui.html#/")
+                .build()))
+            .tags(List.of("first", "second", "third")).build();
     }
 
     public static UpdateEventDto getUpdateEventDtoWithTooManyDates() {
@@ -753,11 +759,18 @@ public class ModelUtils {
     }
 
     public static AddEventDtoRequest getAddEventDtoRequest() {
-        return AddEventDtoRequest.builder().datesLocations(List.of(EventDateLocationDto.builder()
-            .startDate(ZonedDateTime.now().plusDays(5))
-            .finishDate(ZonedDateTime.now().plusDays(5).plusHours(1))
-            .onlineLink("http://localhost:8060/swagger-ui.html#/")
-            .build())).tags(List.of("first", "second", "third")).build();
+        return AddEventDtoRequest.builder().datesLocations(List.of(
+            EventDateLocationDto.builder()
+                .startDate(ZonedDateTime.now().plusDays(5))
+                .finishDate(ZonedDateTime.now().plusDays(5).plusHours(1))
+                .onlineLink("http://localhost:8060/swagger-ui.html#/")
+                .build(),
+            EventDateLocationDto.builder()
+                .startDate(ZonedDateTime.now().plusDays(6))
+                .finishDate(ZonedDateTime.now().plusDays(6).plusHours(1))
+                .onlineLink("http://localhost:8060/swagger-ui.html#/")
+                .build()))
+            .tags(List.of("first", "second", "third")).build();
     }
 
     public static CustomHabitDtoRequest getAddCustomHabitDtoRequest() {

--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -678,7 +678,7 @@ public class ModelUtils {
         return AddEventDtoRequest.builder().title("Title").description("Desc").isOpen(true).build();
     }
 
-    public static UpdateEventDto getUpdateEventDtoWithotDates() {
+    public static UpdateEventDto getUpdateEventDtoWithoutDates() {
         return UpdateEventDto.builder().title("Title").description("Desc").isOpen(true).build();
     }
 

--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -698,6 +698,16 @@ public class ModelUtils {
         return UpdateEventDto.builder().datesLocations(eventDateLocationDtos).build();
     }
 
+    public static UpdateEventDto getUpdateEventDtoWithEmptyDateLocations() {
+        return UpdateEventDto.builder().datesLocations(new ArrayList<>()).build();
+    }
+
+    public static UpdateEventDto getUpdateEventWithoutAddressAndLink() {
+        return UpdateEventDto.builder().datesLocations(List.of(EventDateLocationDto.builder()
+            .startDate(ZonedDateTime.now().plusDays(5))
+            .finishDate(ZonedDateTime.now().plusDays(5).plusHours(1)).build())).build();
+    }
+
     public static AddEventDtoRequest getEventDtoWithZeroDates() {
         return AddEventDtoRequest.builder().datesLocations(new ArrayList<>()).build();
     }

--- a/core/src/test/java/greencity/validator/EventDtoRequestValidatorTest.java
+++ b/core/src/test/java/greencity/validator/EventDtoRequestValidatorTest.java
@@ -69,8 +69,14 @@ class EventDtoRequestValidatorTest {
     }
 
     @Test
-    void updateWithtooManyTagsException() {
+    void updateWithTooManyTagsException() {
         UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDtoWithTooManyDates();
+        assertThrows(EventDtoValidationException.class, () -> validator.isValid(updateEventDto, null));
+    }
+
+    @Test
+    void updateWithEmptyDateLocations() {
+        UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDtoWithEmptyDateLocations();
         assertThrows(EventDtoValidationException.class, () -> validator.isValid(updateEventDto, null));
     }
 
@@ -79,6 +85,20 @@ class EventDtoRequestValidatorTest {
         UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDtoWithoutDates();
         assertThrows(EventDtoValidationException.class, () -> validator.isValid(updateEventDto, null));
 
+    }
+
+    @Test
+    void updateWithInvalidLinkException() {
+        UpdateEventDto updateEventDto = ModelUtils.getUpdateEventWithoutAddressAndLink();
+        assertThrows(EventDtoValidationException.class, () -> validator.isValid(updateEventDto, null));
+    }
+
+    @Test
+    void updateWithoutLinkAndCoordinates() {
+        UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDto();
+        updateEventDto.getDatesLocations().forEach(e -> e.setOnlineLink(null));
+        updateEventDto.getDatesLocations().forEach(e -> e.setCoordinates(null));
+        assertThrows(EventDtoValidationException.class, () -> validator.isValid(updateEventDto, null));
     }
 
     @Test

--- a/core/src/test/java/greencity/validator/EventDtoRequestValidatorTest.java
+++ b/core/src/test/java/greencity/validator/EventDtoRequestValidatorTest.java
@@ -116,7 +116,8 @@ class EventDtoRequestValidatorTest {
     @Test
     void saveEventWithSameDates() {
         AddEventDtoRequest addEventDto = ModelUtils.getAddEventDtoRequest();
-        addEventDto.getDatesLocations().forEach(e -> e.setStartDate(ZonedDateTime.now(ZoneOffset.UTC)));
+        addEventDto.getDatesLocations().forEach(e -> e.setStartDate(ZonedDateTime.now(ZoneOffset.UTC).plusHours(2L)));
+        addEventDto.getDatesLocations().forEach(e -> e.setFinishDate(ZonedDateTime.now(ZoneOffset.UTC).plusHours(2L)));
         assertThrows(EventDtoValidationException.class, () -> validator.isValid(addEventDto, null));
     }
 

--- a/core/src/test/java/greencity/validator/EventDtoRequestValidatorTest.java
+++ b/core/src/test/java/greencity/validator/EventDtoRequestValidatorTest.java
@@ -10,6 +10,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
@@ -73,7 +76,7 @@ class EventDtoRequestValidatorTest {
 
     @Test
     void updateEventDtoWithoutDates() {
-        UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDtoWithotDates();
+        UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDtoWithoutDates();
         assertThrows(EventDtoValidationException.class, () -> validator.isValid(updateEventDto, null));
 
     }
@@ -88,6 +91,20 @@ class EventDtoRequestValidatorTest {
     void validEventUpdate() {
         UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDto();
         assertTrue(validator.isValid(updateEventDto, null));
+    }
+
+    @Test
+    void saveEventWithSameDates() {
+        AddEventDtoRequest addEventDto = ModelUtils.getAddEventDtoRequest();
+        addEventDto.getDatesLocations().forEach(e -> e.setStartDate(ZonedDateTime.now(ZoneOffset.UTC)));
+        assertThrows(EventDtoValidationException.class, () -> validator.isValid(addEventDto, null));
+    }
+
+    @Test
+    void updateEventWithSameDates() {
+        UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDto();
+        updateEventDto.getDatesLocations().forEach(e -> e.setStartDate(ZonedDateTime.now(ZoneOffset.UTC)));
+        assertThrows(EventDtoValidationException.class, () -> validator.isValid(updateEventDto, null));
     }
 
     @Test

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -161,6 +161,8 @@ public final class ErrorMessage {
     public static final String NO_EVENT_LINK_OR_ADDRESS = "Invalid online-link or address";
     public static final String EVENT_START_DATE_AFTER_FINISH_DATE_OR_IN_PAST =
         "Start date must be in future and before finish date";
+    public static final String SAME_EVENT_DATES =
+        "User shouldn't be able to create event with the same event dates for two days within one event";
     public static final String FILTER_NOT_FOUND_BY_ID = "Filter not found";
     public static final String HAVE_ALREADY_SUBSCRIBED_ON_EVENT = "You have already subscribed on this event";
     public static final String EVENT_NOT_FOUND = "Event hasn't been found";


### PR DESCRIPTION
# GreenCity PR

## Summary Of Changes :fire:
**According to the user story https://github.com/ita-social-projects/GreenCity/issues/4231 from now prohibited possibility of creating an event with the same event dates for two days within one event**

## Issue Link :clipboard:
[_Link to the issue_](https://github.com/ita-social-projects/GreenCity/issues/6959)

## Added
_Added validation of duplicates start or finish event dates_

# PR Checklist Forms

- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers