### PR TITLE
title field of event cannot be null or empty during update

### DIFF
--- a/service-api/src/main/java/greencity/dto/event/UpdateEventDto.java
+++ b/service-api/src/main/java/greencity/dto/event/UpdateEventDto.java
@@ -1,6 +1,8 @@
 package greencity.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -16,6 +18,8 @@ public class UpdateEventDto {
     @NotNull
     private Long id;
 
+    @NotEmpty
+    @NotBlank
     @Size(min = 1, max = 70)
     private String title;
 


### PR DESCRIPTION
# GreenCity PR
Now User will recieve HTTP code 400 in case of leaving empty "title" field of the event or enter null or enter spaces during update.
After having discussion with Team Lead - true and false values are acceptable in "title" field of the event.

## Summary Of Changes :fire:
User will recieve HTTP code 400 in case of leaving empty "title" field of the event or enter null or enter spaces during update.

## Issue Link :clipboard:
_&lt;[Link to the issue](https://github.com/ita-social-projects/GreenCity/issues/6948)&gt;_

## Changed
_Field "title" of UpdateEventDto class has been updated_

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers