### PR TITLE
Commit with [POST]place/filter fix

### DIFF
--- a/dao/src/main/java/greencity/constant/RepoConstants.java
+++ b/dao/src/main/java/greencity/constant/RepoConstants.java
@@ -14,6 +14,7 @@ public final class RepoConstants {
     public static final String REGISTRATION_DATE = "dateOfRegistration";
     public static final String CATEGORY = "category";
     public static final String STATUS = "userStatus";
+    public static final String PLACE_STATUS = "status";
     public static final String ROLE = "role";
     public static final String ADDRESS = "address";
     public static final String VALUE = "value";

--- a/dao/src/main/java/greencity/repository/PlaceRepo.java
+++ b/dao/src/main/java/greencity/repository/PlaceRepo.java
@@ -107,7 +107,7 @@ public interface PlaceRepo extends JpaRepository<Place, Long>, JpaSpecificationE
      * @return - places with searching category
      */
     @Query(nativeQuery = true,
-        value = "SELECT * FROM places p "
+        value = "SELECT p.* FROM places p "
             + "join categories c on c.id = p.category_id "
             + "WHERE c.name IN (:category) "
             + "or c.name_ua IN (:category)")

--- a/dao/src/main/java/greencity/repository/options/PlaceFilter.java
+++ b/dao/src/main/java/greencity/repository/options/PlaceFilter.java
@@ -70,7 +70,7 @@ public class PlaceFilter implements Specification<Place> {
         if (status == null) {
             status = PlaceStatus.APPROVED;
         }
-        return cb.equal(r.get(RepoConstants.STATUS), status);
+        return cb.equal(r.get(RepoConstants.PLACE_STATUS), status);
     }
 
     /**


### PR DESCRIPTION
# GreenCity PR
[POST] place/filter produces error "Could not resolve attribute 'userStatus' of 'greencity.entity.Place'"
 when page is opened. 

## Summary Of Changes :fire:
-added new const to root for PlaceStatus status field, it used to use const with value "userStatus" instead "status"
-updated repository native query, as it produced errors after migration.

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers