### PR TITLE
Commit with fix of Query as result might be multiple

### DIFF
--- a/dao/src/main/java/greencity/repository/HabitRepo.java
+++ b/dao/src/main/java/greencity/repository/HabitRepo.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -60,16 +61,13 @@ public interface HabitRepo extends JpaRepository<Habit, Long>, JpaSpecificationE
      *
      * @param userId  {@link Long} userId of user who owns habit.
      * @param habitId {@link Long} habitId.
-     * @return {@link Optional} of {@link HabitAssign} by owner of current habit.
+     * @return {@link List} of {@link HabitAssign} of current habit's owner.
      *
      * @author Olena Sotnik
      */
-    @Query(value = "SELECT ha.id "
-        + "FROM habits AS h "
-        + "INNER JOIN habit_assign ha "
-        + "ON ha.habit_id = h.id "
+    @Query(value = "SELECT DISTINCT ha.id "
+        + "FROM habit_assign AS ha "
         + "WHERE ha.habit_id =:habitId "
-        + "AND h.user_id =:userId", nativeQuery = true)
-    Optional<Long> findHabitAssignByHabitIdAndHabitOwnerId(@Param("habitId") Long habitId,
-        @Param("userId") Long userId);
+        + "AND ha.user_id =:userId", nativeQuery = true)
+    List<Long> findHabitAssignByHabitIdAndHabitOwnerId(@Param("habitId") Long habitId, @Param("userId") Long userId);
 }

--- a/service/src/main/java/greencity/service/HabitServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitServiceImpl.java
@@ -527,7 +527,7 @@ public class HabitServiceImpl implements HabitService {
         if (!userId.equals(habit.getUserId())) {
             throw new UserHasNoPermissionToAccessException(ErrorMessage.USER_HAS_NO_PERMISSION);
         }
-        Optional<Long> habitAssignId = habitRepo.findHabitAssignByHabitIdAndHabitOwnerId(habit.getId(), userId);
-        habitAssignId.ifPresent(haId -> habitAssignService.deleteHabitAssign(haId, userId));
+        habitRepo.findHabitAssignByHabitIdAndHabitOwnerId(habit.getId(), userId)
+            .forEach(haId -> habitAssignService.deleteHabitAssign(haId, userId));
     }
 }

--- a/service/src/test/java/greencity/service/HabitServiceImplTest.java
+++ b/service/src/test/java/greencity/service/HabitServiceImplTest.java
@@ -1189,7 +1189,7 @@ class HabitServiceImplTest {
             .thenReturn(Optional.of(toDelete));
         when(userRepo.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
         when(habitRepo.findHabitAssignByHabitIdAndHabitOwnerId(customHabitId, 1L))
-            .thenReturn(Optional.of(habitAssign.getId()));
+            .thenReturn(List.of(habitAssign.getId()));
 
         habitService.deleteCustomHabit(customHabitId, user.getEmail());
 


### PR DESCRIPTION
# GreenCity PR
Method findHabitAssignByHabitIdAndHabitOwnerId() in HabitRepo might produce multiple results, so return value should be of collection type.

## Summary Of Changes :fire:
- Updated method findHabitAssignByHabitIdAndHabitOwnerId in HabitRepo to return List<Long> habitAssignsIds;
- Updated method unAssignOwnerFromCustomHabit in HabitServiceImpl due to new return value from repository method;
- Updated tests; 

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers