### PR TITLE
Fixed ints and longs are assigned max values in Swagger example models.

### DIFF
--- a/core/src/main/java/greencity/config/SwaggerConfig.java
+++ b/core/src/main/java/greencity/config/SwaggerConfig.java
@@ -36,9 +36,9 @@ public class SwaggerConfig {
                     .bearerFormat("JWT")))
             .info(new Info().title("Greencity API")
                 .summary("Api Documentation")
-                .version("3.1.0")
+                .version("3.0.3")
                 .license(new License().name("Apache 2.0").identifier("Apache-2.0")
                     .url("https://www.apache.org/licenses/LICENSE-2.0.html")))
-            .openapi("3.1.0");
+            .openapi("3.0.3");
     }
 }


### PR DESCRIPTION
# GreenCity PR
## Summary of Changes
Fixed that integers and longs are assigned max values in Swager example models.

## Issue Link
[#7068](https://github.com/ita-social-projects/GreenCity/issues/7068)

## Changed
- Swwager version from 3.1.0 to 3.0.3

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers