### PR TITLE
Commit with fix of calculateAchivement in deleteHabitAssign()

### DIFF
--- a/service/src/main/java/greencity/service/HabitAssignServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitAssignServiceImpl.java
@@ -991,7 +991,7 @@ public class HabitAssignServiceImpl implements HabitAssignService {
             ratingCalculation.ratingCalculation(RatingCalculationEnum.UNDO_DAYS_OF_HABIT_IN_PROGRESS,
                 userVO);
             achievementCalculation.calculateAchievement(userVO,
-                AchievementCategoryType.HABIT, AchievementAction.DELETE);
+                AchievementCategoryType.HABIT, AchievementAction.DELETE, habitAssign.getHabit().getId());
         }
         userShoppingListItemRepo.deleteShoppingListItemsByHabitAssignId(habitAssign.getId());
         customShoppingListItemRepo.deleteCustomShoppingListItemsByHabitId(habitAssign.getHabit().getId());


### PR DESCRIPTION
# GreenCity PR
SQL exception is produced due to query multiple results instead of 1 for search of UserAction.
As for habits should be used overloaded method calculateAchievent () with habitId, as there is without it foe other categories of userActions.

## Summary Of Changes :fire:
-updated method deleteHabitAssign() to use overladed method calculateAchievent() with habitId;

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [ ] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers