### PR TITLE
Fix authorities for admin and service manager position

### DIFF
--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -191,5 +191,7 @@
     <include file="db/changelog/logs/ch-add-column-user_actions-Spodaryk.xml"/>
     <include file="db/changelog/logs/ch-update-users-set-new-main-email-Midianyi.xml"/>
     <include file="db/changelog/logs/ch-add-new-column-to-habits-is-deleted-Sotnik.xml"/>
+    <include file="db/changelog/logs/ch-delete-from-positions_authorities_mapping-authority-for-admin-position-Kizerov.xml"/>
+    <include file="db/changelog/logs/ch-delete-from-positions_authorities_mapping-authority-for-service-manager-position-Kizerov.xml"/>
 </databaseChangeLog>
 

--- a/dao/src/main/resources/db/changelog/logs/ch-delete-from-positions_authorities_mapping-authority-for-admin-position-Kizerov.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-delete-from-positions_authorities_mapping-authority-for-admin-position-Kizerov.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="delete-authorities-positions_authorities_mapping" author="Kizerov Dmytro">
+        <delete tableName="positions_authorities_mapping">
+            <where>position_id = 7 AND authorities_id = 18</where>
+        </delete>
+    </changeSet>
+</databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-delete-from-positions_authorities_mapping-authority-for-service-manager-position-Kizerov.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-delete-from-positions_authorities_mapping-authority-for-service-manager-position-Kizerov.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="delete-authorities-positions_authorities_mapping" author="Kizerov Dmytro">
+        <delete tableName="positions_authorities_mapping">
+            <where>position_id = 1 AND authorities_id = 28</where>
+        </delete>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
# GreenCity PR
https://github.com/ita-social-projects/GreenCity/issues/6403
![Capture](https://github.com/ita-social-projects/GreenCity/assets/113462277/19f42f4f-b08c-4cbe-be5c-abb7e4fa2c13)
https://github.com/ita-social-projects/GreenCity/issues/6402
![CaptureService](https://github.com/ita-social-projects/GreenCity/assets/113462277/19651051-d386-4f71-b7db-5749198ebb06)

## Summary Of Changes :fire:
Delete authorities for admin and service manager from DB

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers