### PR TITLE
sorting by creation date implemented

### DIFF
--- a/service/src/main/java/greencity/service/EcoNewsServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsServiceImpl.java
@@ -232,11 +232,14 @@ public class EcoNewsServiceImpl implements EcoNewsService {
 
     @Override
     public PageableAdvancedDto<EcoNewsGenericDto> findByFilters(Pageable page, List<String> tags, String title) {
-        return CollectionUtils.isEmpty(tags) && StringUtils.isEmpty(title) ?
-                buildPageableAdvancedGeneticDto(ecoNewsRepo.findAll(PageRequest.of(page.getPageNumber(), page.getPageSize(),
-                       Sort.by(Sort.Direction.DESC, "creationDate")))) :
-                buildPageableAdvancedGeneticDto(ecoNewsRepo.findAll((root, query, criteriaBuilder) -> getPredicate(root, criteriaBuilder, tags, title),
-                        PageRequest.of(page.getPageNumber(), page.getPageSize(), Sort.by(Sort.Direction.DESC, "creationDate"))));
+        return CollectionUtils.isEmpty(tags) && StringUtils.isEmpty(title)
+            ? buildPageableAdvancedGeneticDto(ecoNewsRepo.findAll(
+                PageRequest.of(page.getPageNumber(), page.getPageSize(),
+                    Sort.by(Sort.Direction.DESC, "creationDate"))))
+            : buildPageableAdvancedGeneticDto(ecoNewsRepo.findAll(
+                (root, query, criteriaBuilder) -> getPredicate(root, criteriaBuilder, tags, title),
+                PageRequest.of(page.getPageNumber(), page.getPageSize(),
+                    Sort.by(Sort.Direction.DESC, "creationDate"))));
     }
 
     private PageableAdvancedDto<EcoNewsDto> buildPageableAdvancedDto(Page<EcoNews> ecoNewsPage) {

--- a/service/src/main/java/greencity/service/EcoNewsServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsServiceImpl.java
@@ -59,6 +59,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.apache.commons.lang3.StringUtils;
@@ -231,9 +232,11 @@ public class EcoNewsServiceImpl implements EcoNewsService {
 
     @Override
     public PageableAdvancedDto<EcoNewsGenericDto> findByFilters(Pageable page, List<String> tags, String title) {
-        return buildPageableAdvancedGeneticDto(
-            ecoNewsRepo.findAll((root, query, criteriaBuilder) -> getPredicate(root, criteriaBuilder, tags, title),
-                page));
+        return CollectionUtils.isEmpty(tags) && StringUtils.isEmpty(title) ?
+                buildPageableAdvancedGeneticDto(ecoNewsRepo.findAll(PageRequest.of(page.getPageNumber(), page.getPageSize(),
+                       Sort.by(Sort.Direction.DESC, "creationDate")))) :
+                buildPageableAdvancedGeneticDto(ecoNewsRepo.findAll((root, query, criteriaBuilder) -> getPredicate(root, criteriaBuilder, tags, title),
+                        PageRequest.of(page.getPageNumber(), page.getPageSize(), Sort.by(Sort.Direction.DESC, "creationDate"))));
     }
 
     private PageableAdvancedDto<EcoNewsDto> buildPageableAdvancedDto(Page<EcoNews> ecoNewsPage) {

--- a/service/src/test/java/greencity/service/EcoNewsServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EcoNewsServiceImplTest.java
@@ -799,6 +799,16 @@ class EcoNewsServiceImplTest {
     }
 
     @Test
+    void findByFilters_ReturnsCorrectResult_WhenTagsAndTitleAreEmpty() {
+        Pageable pageable = PageRequest.of(0, 2);
+        List<EcoNews> ecoNews = Collections.singletonList(ModelUtils.getEcoNews());
+        Page<EcoNews> page = new PageImpl<>(ecoNews, pageable, ecoNews.size());
+        when(ecoNewsRepo.findAll(any(Pageable.class))).thenReturn(page);
+        ecoNewsService.findByFilters(pageable, null, null);
+        verify(ecoNewsRepo, times(1)).findAll(any(Pageable.class));
+    }
+
+    @Test
     void getContentAndSourceForEcoNewsById() {
         EcoNews ecoNews = ModelUtils.getEcoNews();
         when(ecoNewsRepo.findById(1L)).thenReturn(Optional.of(ecoNews));


### PR DESCRIPTION
# GreenCity PR

Currently, EcoNews are represented incorrectly: they are sorted by ID in the table. They should be sorted by creation date (from newest to oldest). (issue #7100 )

# Changed

Checking for input data for filtering. If it is empty, retrieve the newest EcoNews. Otherwise, the filtering remains the same, with the addition of sorting by creation date for the filtered EcoNews.

Test provided with postman:

![pic2](https://github.com/ita-social-projects/GreenCity/assets/73854494/cfd20132-d3fd-4ba5-906f-ee280ca1164a)


# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers