### PR TITLE
Add endpoint that returns all habit assigns for a user that were created by another specific user

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -206,6 +206,7 @@ public class SecurityConfig {
                     "/shopping-list-items",
                     "/habit/assign/allForCurrentUser",
                     "/habit/assign/allMutualHabits/{userId}",
+                    "/habit/assign/myHabits/{userId}",
                     "/habit/assign/active/{date}",
                     "/habit/assign/{habitAssignId}/more",
                     "/habit/assign/activity/{from}/to/{to}",

--- a/core/src/main/java/greencity/controller/HabitAssignController.java
+++ b/core/src/main/java/greencity/controller/HabitAssignController.java
@@ -15,7 +15,7 @@ import greencity.dto.habit.HabitAssignVO;
 import greencity.dto.habit.HabitDto;
 import greencity.dto.habit.HabitVO;
 import greencity.dto.habit.HabitsDateEnrollmentDto;
-import greencity.dto.habit.MutualHabitAssignDto;
+import greencity.dto.habit.HabitAssignPreviewDto;
 import greencity.dto.habit.UserShoppingAndCustomShoppingListsDto;
 import greencity.dto.habitstatuscalendar.HabitStatusCalendarDto;
 import greencity.dto.user.UserVO;
@@ -233,15 +233,15 @@ public class HabitAssignController {
     }
 
     /**
-     * Finds all mutual in-progress and acquired {@link HabitAssignDto} for the
-     * current user and another specified user, with pagination.
+     * Finds all mutual in-progress and acquired {@link HabitAssignPreviewDto} for
+     * the current user and another specified user, with pagination.
      *
      * @param userId   the {@code User} id of the other user to find mutual habit
      *                 assignments with.
      * @param userVO   {@link UserVO} instance representing the current user.
      * @param pageable the {@link Pageable} object for pagination information.
      * @return a {@link ResponseEntity} containing a {@link PageableAdvancedDto}
-     *         with a list of {@link MutualHabitAssignDto} representing the found
+     *         with a list of {@link HabitAssignPreviewDto} representing the found
      *         mutual habit assignments and pagination information.
      */
     @Operation(summary = "Get all mutual (inprogress, acquired) assigned habits for current user with another user")
@@ -253,13 +253,43 @@ public class HabitAssignController {
             content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED)))
     })
     @GetMapping("/allMutualHabits/{userId}")
-    public ResponseEntity<PageableAdvancedDto<MutualHabitAssignDto>> getAllMutualHabitsWithUser(
+    public ResponseEntity<PageableAdvancedDto<HabitAssignPreviewDto>> getAllMutualHabitsWithUser(
         @PathVariable Long userId,
         @Parameter(hidden = true) @CurrentUser UserVO userVO,
         @Parameter(hidden = true) Pageable pageable) {
         return ResponseEntity.status(HttpStatus.OK)
             .body(habitAssignService
                 .getAllMutualHabitAssignsWithUserAndStatusNotCancelled(userId, userVO.getId(), pageable));
+    }
+
+    /**
+     * Finds all mutual in-progress and acquired {@link HabitAssignPreviewDto} for
+     * user made by current user, with pagination.
+     *
+     * @param userId   the {@code User} id of the other user to find habit
+     *                 assignments with.
+     * @param userVO   {@link UserVO} instance representing the current user.
+     * @param pageable the {@link Pageable} object for pagination information.
+     * @return a {@link ResponseEntity} containing a {@link PageableAdvancedDto}
+     *         with a list of {@link HabitAssignPreviewDto} representing the found
+     *         assignments and pagination information.
+     */
+    @Operation(summary = "Get all (inprogress, acquired) assigned habits for user made by current user")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST,
+            content = @Content(examples = @ExampleObject(HttpStatuses.BAD_REQUEST))),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED,
+            content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED)))
+    })
+    @GetMapping("/myHabits/{userId}")
+    public ResponseEntity<PageableAdvancedDto<HabitAssignPreviewDto>> getMyHabitsOfCurrentUser(
+        @PathVariable Long userId,
+        @Parameter(hidden = true) @CurrentUser UserVO userVO,
+        @Parameter(hidden = true) Pageable pageable) {
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(habitAssignService
+                .getMyHabitsOfCurrentUserAndStatusNotCancelled(userId, userVO.getId(), pageable));
     }
 
     /**

--- a/core/src/test/java/greencity/controller/HabitAssignControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitAssignControllerTest.java
@@ -193,6 +193,19 @@ class HabitAssignControllerTest {
     }
 
     @Test
+    void getMyHabitsOfCurrentUserTest() throws Exception {
+        long friendId = 2L;
+        when(userService.findByEmail(principal.getName())).thenReturn(userVO);
+        mockMvc.perform(get(habitLink + "/myHabits/{userId}", friendId)
+            .principal(principal))
+            .andExpect(status().isOk());
+
+        verify(userService).findByEmail(principal.getName());
+        verify(habitAssignService).getMyHabitsOfCurrentUserAndStatusNotCancelled(friendId, userVO.getId(),
+            PageRequest.of(0, 20));
+    }
+
+    @Test
     void deleteHabitAssignTest() throws Exception {
         Long habitAssignId = 1L;
 

--- a/dao/src/main/java/greencity/repository/HabitAssignRepo.java
+++ b/dao/src/main/java/greencity/repository/HabitAssignRepo.java
@@ -339,6 +339,19 @@ public interface HabitAssignRepo extends JpaRepository<HabitAssign, Long>,
             and (ha.status = 'INPROGRESS' OR ha.status = 'ACQUIRED') AND ha.habit.id IN
             (SELECT ha1.habit.id FROM HabitAssign ha1 where ha1.user.id = :currentUserId
             AND (ha1.status = 'INPROGRESS' OR ha1.status = 'ACQUIRED'))
+            ORDER BY ha.createDate
         """)
-    Page<HabitAssign> findAllBy(Long userId, Long currentUserId, Pageable pageable);
+    Page<HabitAssign> findAllMutual(Long userId, Long currentUserId, Pageable pageable);
+
+    @Query("""
+            SELECT ha FROM HabitAssign ha
+            left join fetch ha.habit h
+            left join fetch h.habitTranslations ht
+            left join fetch ht.language l
+            WHERE ha.user.id = :userId
+            and (ha.status = 'INPROGRESS' OR ha.status = 'ACQUIRED') AND ha.habit.id IN
+            (SELECT h1.id FROM Habit h1 WHERE h1.userId = :currentUserId)
+            ORDER BY ha.createDate
+        """)
+    Page<HabitAssign> findAllOfCurrentUser(Long userId, Long currentUserId, Pageable pageable);
 }

--- a/service-api/src/main/java/greencity/dto/habit/HabitAssignPreviewDto.java
+++ b/service-api/src/main/java/greencity/dto/habit/HabitAssignPreviewDto.java
@@ -16,9 +16,9 @@ import lombok.ToString;
 @EqualsAndHashCode
 @Builder
 @ToString
-public class MutualHabitAssignDto {
+public class HabitAssignPreviewDto {
     private Integer duration;
-    private MutualHabitDto habit;
+    private HabitPreviewDto habit;
     private Long id;
     private HabitAssignStatus status;
     private Long userId;

--- a/service-api/src/main/java/greencity/dto/habit/HabitPreviewDto.java
+++ b/service-api/src/main/java/greencity/dto/habit/HabitPreviewDto.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Data
 @Builder
-public class MutualHabitDto {
+public class HabitPreviewDto {
     private Long id;
     private String image;
     private HabitTranslationDto habitTranslation;

--- a/service-api/src/main/java/greencity/service/HabitAssignService.java
+++ b/service-api/src/main/java/greencity/service/HabitAssignService.java
@@ -9,7 +9,7 @@ import greencity.dto.habit.HabitAssignUserDurationDto;
 import greencity.dto.habit.HabitDto;
 import greencity.dto.habit.HabitVO;
 import greencity.dto.habit.HabitsDateEnrollmentDto;
-import greencity.dto.habit.MutualHabitAssignDto;
+import greencity.dto.habit.HabitAssignPreviewDto;
 import greencity.dto.habit.UserShoppingAndCustomShoppingListsDto;
 import greencity.dto.user.UserVO;
 import greencity.enums.HabitAssignStatus;
@@ -129,9 +129,26 @@ public interface HabitAssignService {
      *                      assignments with.
      * @param pageable      the {@link Pageable} object for pagination information.
      * @return a {@link PageableAdvancedDto} containing a list of
-     *         {@link MutualHabitAssignDto}.
+     *         {@link HabitAssignPreviewDto}.
      */
-    PageableAdvancedDto<MutualHabitAssignDto> getAllMutualHabitAssignsWithUserAndStatusNotCancelled(
+    PageableAdvancedDto<HabitAssignPreviewDto> getAllMutualHabitAssignsWithUserAndStatusNotCancelled(
+        Long userId, Long currentUserId, Pageable pageable);
+
+    /**
+     * Retrieves all mutual, non-cancelled {@code HabitAssign} entities shared
+     * between a specified {@code User} and the current user, with support for
+     * pagination.
+     *
+     * @param userId        the ID of the {@code User} whose mutual
+     *                      {@code HabitAssign} entities are to be retrieved.
+     * @param currentUserId the ID of the current user to find mutual habit
+     *                      assignments with.
+     * @param pageable      the {@link Pageable} object containing pagination
+     *                      information.
+     * @return a {@link PageableAdvancedDto} containing a list of
+     *         {@link HabitAssignPreviewDto}.
+     */
+    PageableAdvancedDto<HabitAssignPreviewDto> getMyHabitsOfCurrentUserAndStatusNotCancelled(
         Long userId, Long currentUserId, Pageable pageable);
 
     /**

--- a/service/src/main/java/greencity/mapping/HabitAssignPreviewDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/HabitAssignPreviewDtoMapper.java
@@ -1,7 +1,7 @@
 package greencity.mapping;
 
-import greencity.dto.habit.MutualHabitAssignDto;
-import greencity.dto.habit.MutualHabitDto;
+import greencity.dto.habit.HabitAssignPreviewDto;
+import greencity.dto.habit.HabitPreviewDto;
 import greencity.dto.habittranslation.HabitTranslationDto;
 import greencity.entity.Habit;
 import greencity.entity.HabitAssign;
@@ -12,17 +12,17 @@ import org.springframework.stereotype.Component;
 
 /**
  * Class that used by {@link ModelMapper} to map {@link HabitAssign} into
- * {@link MutualHabitAssignDto}.
+ * {@link HabitAssignPreviewDto}.
  */
 @Component
-public class MutualHabitAssignDtoMapper extends AbstractConverter<HabitAssign, MutualHabitAssignDto> {
+public class HabitAssignPreviewDtoMapper extends AbstractConverter<HabitAssign, HabitAssignPreviewDto> {
     /**
-     * Method convert {@link HabitAssign} to {@link MutualHabitAssignDto}.
+     * Method convert {@link HabitAssign} to {@link HabitAssignPreviewDto}.
      *
-     * @return {@link MutualHabitAssignDto}
+     * @return {@link HabitAssignPreviewDto}
      */
     @Override
-    protected MutualHabitAssignDto convert(HabitAssign habitAssign) {
+    protected HabitAssignPreviewDto convert(HabitAssign habitAssign) {
         Habit habit = habitAssign.getHabit();
         HabitTranslation habitTranslationUa = habit.getHabitTranslations().stream()
             .filter(translation -> translation.getLanguage().getCode().equalsIgnoreCase("ua"))
@@ -30,7 +30,7 @@ public class MutualHabitAssignDtoMapper extends AbstractConverter<HabitAssign, M
         HabitTranslation habitTranslation = habit.getHabitTranslations().stream()
             .filter(translation -> !translation.getLanguage().getCode().equalsIgnoreCase("en"))
             .findFirst().orElse(null);
-        MutualHabitDto mutualHabitDto = null;
+        HabitPreviewDto habitPreviewDto = null;
         if (habitTranslation != null && habitTranslationUa != null) {
             HabitTranslationDto habitTranslationDto = HabitTranslationDto.builder()
                 .name(habitTranslation.getName())
@@ -40,19 +40,19 @@ public class MutualHabitAssignDtoMapper extends AbstractConverter<HabitAssign, M
                 .description(habitTranslation.getDescription())
                 .descriptionUa(habitTranslationUa.getDescription())
                 .build();
-            mutualHabitDto = MutualHabitDto.builder()
+            habitPreviewDto = HabitPreviewDto.builder()
                 .id(habit.getId())
                 .image(habit.getImage())
                 .habitTranslation(habitTranslationDto)
                 .build();
         }
-        return MutualHabitAssignDto.builder()
+        return HabitAssignPreviewDto.builder()
             .id(habitAssign.getId())
             .status(habitAssign.getStatus())
             .userId(habitAssign.getUser().getId())
             .duration(habitAssign.getDuration())
             .workingDays(habitAssign.getWorkingDays())
-            .habit(mutualHabitDto)
+            .habit(habitPreviewDto)
             .build();
     }
 }

--- a/service/src/test/java/greencity/mapping/HabitAssignPreviewDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/HabitAssignPreviewDtoMapperTest.java
@@ -1,8 +1,8 @@
 package greencity.mapping;
 
 import greencity.ModelUtils;
-import greencity.dto.habit.MutualHabitAssignDto;
-import greencity.dto.habit.MutualHabitDto;
+import greencity.dto.habit.HabitAssignPreviewDto;
+import greencity.dto.habit.HabitPreviewDto;
 import greencity.dto.habittranslation.HabitTranslationDto;
 import greencity.entity.Habit;
 import greencity.entity.HabitAssign;
@@ -17,9 +17,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
-class MutualHabitAssignDtoMapperTest {
+class HabitAssignPreviewDtoMapperTest {
     @InjectMocks
-    private MutualHabitAssignDtoMapper mutualHabitAssignDtoMapper;
+    private HabitAssignPreviewDtoMapper habitAssignPreviewDtoMapper;
 
     @Test
     void convertTest() {
@@ -54,21 +54,21 @@ class MutualHabitAssignDtoMapperTest {
             .description(habitTranslation.getDescription())
             .descriptionUa(habitTranslationUa.getDescription())
             .build();
-        MutualHabitDto mutualHabitDto = MutualHabitDto.builder()
+        HabitPreviewDto habitPreviewDto = HabitPreviewDto.builder()
             .id(habit.getId())
             .image(habit.getImage())
             .habitTranslation(habitTranslationDto)
             .build();
-        MutualHabitAssignDto expected = MutualHabitAssignDto.builder()
+        HabitAssignPreviewDto expected = HabitAssignPreviewDto.builder()
             .id(habitAssign.getId())
             .status(habitAssign.getStatus())
             .userId(habitAssign.getUser().getId())
             .duration(habitAssign.getDuration())
             .workingDays(habitAssign.getWorkingDays())
-            .habit(mutualHabitDto)
+            .habit(habitPreviewDto)
             .build();
 
-        MutualHabitAssignDto actual = mutualHabitAssignDtoMapper.convert(habitAssign);
+        HabitAssignPreviewDto actual = habitAssignPreviewDtoMapper.convert(habitAssign);
 
         assertEquals(expected, actual);
     }

--- a/service/src/test/java/greencity/service/HabitAssignServiceImplTest.java
+++ b/service/src/test/java/greencity/service/HabitAssignServiceImplTest.java
@@ -14,7 +14,7 @@ import greencity.dto.habit.HabitAssignVO;
 import greencity.dto.habit.HabitDto;
 import greencity.dto.habit.HabitVO;
 import greencity.dto.habit.HabitsDateEnrollmentDto;
-import greencity.dto.habit.MutualHabitAssignDto;
+import greencity.dto.habit.HabitAssignPreviewDto;
 import greencity.dto.habit.UserShoppingAndCustomShoppingListsDto;
 import greencity.dto.habitstatuscalendar.HabitStatusCalendarVO;
 import greencity.dto.shoppinglistitem.BulkSaveCustomShoppingListItemDto;
@@ -865,7 +865,7 @@ class HabitAssignServiceImplTest {
         Pageable pageable = PageRequest.of(0, 6);
         List<HabitAssign> habitAssignList = List.of(habitAssign);
         Page<HabitAssign> returnedPage = new PageImpl<>(habitAssignList, pageable, habitAssignList.size());
-        MutualHabitAssignDto mutualHabitAssignDto = MutualHabitAssignDto.builder()
+        HabitAssignPreviewDto habitAssignPreviewDto = HabitAssignPreviewDto.builder()
             .id(habitAssign.getId())
             .status(habitAssign.getStatus())
             .userId(habitAssign.getUser().getId())
@@ -887,19 +887,63 @@ class HabitAssignServiceImplTest {
                 .description("descriptionUa")
                 .language(Language.builder().id(1L).code("en").build())
                 .build()));
-        PageableAdvancedDto<MutualHabitAssignDto> expected =
-            new PageableAdvancedDto<>(List.of(mutualHabitAssignDto), returnedPage.getTotalElements(),
+        PageableAdvancedDto<HabitAssignPreviewDto> expected =
+            new PageableAdvancedDto<>(List.of(habitAssignPreviewDto), returnedPage.getTotalElements(),
                 returnedPage.getPageable().getPageNumber(), returnedPage.getTotalPages(), returnedPage.getNumber(),
                 returnedPage.hasPrevious(), returnedPage.hasNext(), returnedPage.isFirst(), returnedPage.isLast());
 
-        when(habitAssignRepo.findAllBy(userId, currentUserId, pageable)).thenReturn(returnedPage);
-        when(modelMapper.map(habitAssign, MutualHabitAssignDto.class)).thenReturn(mutualHabitAssignDto);
+        when(habitAssignRepo.findAllMutual(userId, currentUserId, pageable)).thenReturn(returnedPage);
+        when(modelMapper.map(habitAssign, HabitAssignPreviewDto.class)).thenReturn(habitAssignPreviewDto);
 
         var actual =
             habitAssignService.getAllMutualHabitAssignsWithUserAndStatusNotCancelled(userId, currentUserId, pageable);
 
-        verify(habitAssignRepo).findAllBy(userId, currentUserId, pageable);
-        verify(modelMapper).map(habitAssign, MutualHabitAssignDto.class);
+        verify(habitAssignRepo).findAllMutual(userId, currentUserId, pageable);
+        verify(modelMapper).map(habitAssign, HabitAssignPreviewDto.class);
+        assertArrayEquals(expected.getPage().toArray(), actual.getPage().toArray());
+    }
+
+    @Test
+    void getMyHabitsOfCurrentUserAndStatusNotCancelledTest() {
+        Long userId = 1L, currentUserId = 2L;
+        Pageable pageable = PageRequest.of(0, 6);
+        List<HabitAssign> habitAssignList = List.of(habitAssign);
+        Page<HabitAssign> returnedPage = new PageImpl<>(habitAssignList, pageable, habitAssignList.size());
+        HabitAssignPreviewDto habitAssignPreviewDto = HabitAssignPreviewDto.builder()
+            .id(habitAssign.getId())
+            .status(habitAssign.getStatus())
+            .userId(habitAssign.getUser().getId())
+            .duration(habitAssign.getDuration())
+            .workingDays(habitAssign.getWorkingDays())
+            .build();
+        habitAssign.getHabit().setHabitTranslations(List.of(
+            HabitTranslation.builder()
+                .id(1L)
+                .name("name")
+                .habitItem("habitItem")
+                .description("description")
+                .language(Language.builder().id(1L).code("ua").build())
+                .build(),
+            HabitTranslation.builder()
+                .id(2L)
+                .name("nameUa")
+                .habitItem("habitItemUa")
+                .description("descriptionUa")
+                .language(Language.builder().id(1L).code("en").build())
+                .build()));
+        PageableAdvancedDto<HabitAssignPreviewDto> expected =
+            new PageableAdvancedDto<>(List.of(habitAssignPreviewDto), returnedPage.getTotalElements(),
+                returnedPage.getPageable().getPageNumber(), returnedPage.getTotalPages(), returnedPage.getNumber(),
+                returnedPage.hasPrevious(), returnedPage.hasNext(), returnedPage.isFirst(), returnedPage.isLast());
+
+        when(habitAssignRepo.findAllOfCurrentUser(userId, currentUserId, pageable)).thenReturn(returnedPage);
+        when(modelMapper.map(habitAssign, HabitAssignPreviewDto.class)).thenReturn(habitAssignPreviewDto);
+
+        var actual =
+            habitAssignService.getMyHabitsOfCurrentUserAndStatusNotCancelled(userId, currentUserId, pageable);
+
+        verify(habitAssignRepo).findAllOfCurrentUser(userId, currentUserId, pageable);
+        verify(modelMapper).map(habitAssign, HabitAssignPreviewDto.class);
         assertArrayEquals(expected.getPage().toArray(), actual.getPage().toArray());
     }
 


### PR DESCRIPTION
## Task
[#7191](https://github.com/ita-social-projects/GreenCity/issues/7191)

## Changes
Added new endpoint in HabitAssignController that returns page of all habit assigns made by current user. Also to avoid confusion renamed MutualHabitAssignDto to HabitAssignPreviewDto.