### PR TITLE
Add endpoint to return all habit assigns of non current user

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -206,6 +206,7 @@ public class SecurityConfig {
                     "/shopping-list-items",
                     "/habit/assign/allForCurrentUser",
                     "/habit/assign/allMutualHabits/{userId}",
+                    "/habit/assign/allUser/{userId}",
                     "/habit/assign/myHabits/{userId}",
                     "/habit/assign/active/{date}",
                     "/habit/assign/{habitAssignId}/more",

--- a/core/src/main/java/greencity/controller/HabitAssignController.java
+++ b/core/src/main/java/greencity/controller/HabitAssignController.java
@@ -233,6 +233,34 @@ public class HabitAssignController {
     }
 
     /**
+     * Method for finding all inprogress, acquired {@link HabitAssignDto}'s for user
+     * by id.
+     *
+     * @param userId   the {@code User} id of the other user to find habit
+     *                 assignments with.
+     * @param pageable the {@link Pageable} object for pagination information.
+     * @return list of {@link HabitAssignDto}.
+     */
+    @Operation(summary = "Get (inprogress, acquired) assigned habits for user by id")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK, content = @Content(
+            array = @ArraySchema(schema = @Schema(implementation = HabitAssignDto.class)))),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST,
+            content = @Content(examples = @ExampleObject(HttpStatuses.BAD_REQUEST))),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED,
+            content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED)))
+    })
+    @ApiLocale
+    @GetMapping("/allUser/{userId}")
+    public ResponseEntity<PageableAdvancedDto<HabitAssignPreviewDto>> getUserHabitAssignsByIdAndAcquired(
+        @PathVariable Long userId,
+        @Parameter(hidden = true) Pageable pageable) {
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(habitAssignService
+                .getAllByUserIdAndStatusNotCancelled(userId, pageable));
+    }
+
+    /**
      * Finds all mutual in-progress and acquired {@link HabitAssignPreviewDto} for
      * the current user and another specified user, with pagination.
      *

--- a/core/src/test/java/greencity/controller/HabitAssignControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitAssignControllerTest.java
@@ -206,6 +206,16 @@ class HabitAssignControllerTest {
     }
 
     @Test
+    void getUserHabitAssignsByIdAndAcquiredTest() throws Exception {
+        long friendId = 2L;
+        mockMvc.perform(get(habitLink + "/allUser/{userId}", friendId)
+            .principal(principal))
+            .andExpect(status().isOk());
+
+        verify(habitAssignService).getAllByUserIdAndStatusNotCancelled(friendId, PageRequest.of(0, 20));
+    }
+
+    @Test
     void deleteHabitAssignTest() throws Exception {
         Long habitAssignId = 1L;
 

--- a/dao/src/main/java/greencity/repository/HabitAssignRepo.java
+++ b/dao/src/main/java/greencity/repository/HabitAssignRepo.java
@@ -46,6 +46,28 @@ public interface HabitAssignRepo extends JpaRepository<HabitAssign, Long>,
     List<HabitAssign> findAllByUserId(@Param("userId") Long userId);
 
     /**
+     * Retrieves a paginated list of {@code HabitAssign} entities for a specified
+     * user that are in progress or acquired. This method includes fetching
+     * associated {@code Habit}, {@code HabitTranslations}, and {@code Language}
+     * entities.
+     *
+     * @param userId   the ID of the {@code User} whose {@code HabitAssign} entities
+     *                 are to be retrieved.
+     * @param pageable the {@link Pageable} object containing pagination
+     *                 information.
+     * @return a {@link Page} of {@code HabitAssign} entities.
+     */
+    @Query("""
+            SELECT ha FROM HabitAssign ha
+            left join fetch ha.habit h
+            left join fetch h.habitTranslations ht
+            left join fetch ht.language l
+            WHERE ha.user.id = :userId and (ha.status = 'INPROGRESS' OR ha.status = 'ACQUIRED')
+            ORDER BY ha.createDate
+        """)
+    Page<HabitAssign> findAllByUserId(Long userId, Pageable pageable);
+
+    /**
      * Method to find all {@link HabitAssign} by {@link Habit} id (not canceled and
      * not expired).
      *
@@ -343,6 +365,20 @@ public interface HabitAssignRepo extends JpaRepository<HabitAssign, Long>,
         """)
     Page<HabitAssign> findAllMutual(Long userId, Long currentUserId, Pageable pageable);
 
+    /**
+     * Retrieves a paginated list of {@code HabitAssign} entities for a specified
+     * user that are in progress or acquired, and are shared with the current user.
+     * This method includes fetching associated {@code Habit},
+     * {@code HabitTranslations}, and {@code Language} entities.
+     *
+     * @param userId        the ID of the {@code User} whose {@code HabitAssign}
+     *                      entities are to be retrieved.
+     * @param currentUserId the ID of the current user to find mutual habit
+     *                      assignments with.
+     * @param pageable      the {@link Pageable} object containing pagination
+     *                      information.
+     * @return a {@link Page} of {@code HabitAssign} entities.
+     */
     @Query("""
             SELECT ha FROM HabitAssign ha
             left join fetch ha.habit h

--- a/service-api/src/main/java/greencity/service/HabitAssignService.java
+++ b/service-api/src/main/java/greencity/service/HabitAssignService.java
@@ -124,7 +124,8 @@ public interface HabitAssignService {
      *
      * @param userId   {@code User} id.
      * @param pageable the {@link Pageable} object for pagination information.
-     * @return a {@link PageableAdvancedDto} containing a list of {@link HabitAssignPreviewDto}.
+     * @return a {@link PageableAdvancedDto} containing a list of
+     *         {@link HabitAssignPreviewDto}.
      */
     PageableAdvancedDto<HabitAssignPreviewDto> getAllByUserIdAndStatusNotCancelled(Long userId, Pageable pageable);
 

--- a/service-api/src/main/java/greencity/service/HabitAssignService.java
+++ b/service-api/src/main/java/greencity/service/HabitAssignService.java
@@ -120,11 +120,18 @@ public interface HabitAssignService {
     List<HabitAssignDto> getAllHabitAssignsByUserIdAndStatusNotCancelled(Long userId, String language);
 
     /**
-     * Finds all mutual non-cancelled {@code HabitAssign} entities between a given
-     * {@code User} and the current user, with pagination support.
+     * Method to find all (not cancelled) id and acquired status.
      *
-     * @param userId        the {@code User} id to find mutual {@code HabitAssign}
-     *                      entities for.
+     * @param userId   {@code User} id.
+     * @param pageable the {@link Pageable} object for pagination information.
+     * @return a {@link PageableAdvancedDto} containing a list of {@link HabitAssignPreviewDto}.
+     */
+    PageableAdvancedDto<HabitAssignPreviewDto> getAllByUserIdAndStatusNotCancelled(Long userId, Pageable pageable);
+
+    /**
+     * Finds all mutual non-cancelled {@link HabitAssignPreviewDto}.
+     *
+     * @param userId        the {@code User} id
      * @param currentUserId the id of the current user to find mutual habit
      *                      assignments with.
      * @param pageable      the {@link Pageable} object for pagination information.
@@ -135,14 +142,11 @@ public interface HabitAssignService {
         Long userId, Long currentUserId, Pageable pageable);
 
     /**
-     * Retrieves all mutual, non-cancelled {@code HabitAssign} entities shared
-     * between a specified {@code User} and the current user, with support for
-     * pagination.
+     * Retrieves all non-cancelled {@link HabitAssignPreviewDto} for user that made
+     * by current user.
      *
-     * @param userId        the ID of the {@code User} whose mutual
-     *                      {@code HabitAssign} entities are to be retrieved.
-     * @param currentUserId the ID of the current user to find mutual habit
-     *                      assignments with.
+     * @param userId        the {@code User} id
+     * @param currentUserId the ID of the current user that is an author of habits.
      * @param pageable      the {@link Pageable} object containing pagination
      *                      information.
      * @return a {@link PageableAdvancedDto} containing a list of

--- a/service/src/main/java/greencity/service/HabitAssignServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitAssignServiceImpl.java
@@ -628,6 +628,16 @@ public class HabitAssignServiceImpl implements HabitAssignService {
      * {@inheritDoc}
      */
     @Override
+    public PageableAdvancedDto<HabitAssignPreviewDto> getAllByUserIdAndStatusNotCancelled(Long userId,
+        Pageable pageable) {
+        Page<HabitAssign> returnedPage = habitAssignRepo.findAllByUserId(userId, pageable);
+        return mapHabitAssignPageToPageableAdvancedDtoOfMutualHabitAssignDto(returnedPage);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public Long getNumberHabitAssignsByHabitIdAndStatus(Long habitId, HabitAssignStatus status) {
         List<HabitAssign> habitAssigns =
             habitAssignRepo.findAllHabitAssignsByStatusAndHabitId(status, habitId);

--- a/service/src/test/java/greencity/service/HabitAssignServiceImplTest.java
+++ b/service/src/test/java/greencity/service/HabitAssignServiceImplTest.java
@@ -948,6 +948,50 @@ class HabitAssignServiceImplTest {
     }
 
     @Test
+    void getAllByUserIdAndStatusNotCancelledTest() {
+        Long userId = 1L;
+        Pageable pageable = PageRequest.of(0, 6);
+        List<HabitAssign> habitAssignList = List.of(habitAssign);
+        Page<HabitAssign> returnedPage = new PageImpl<>(habitAssignList, pageable, habitAssignList.size());
+        HabitAssignPreviewDto habitAssignPreviewDto = HabitAssignPreviewDto.builder()
+            .id(habitAssign.getId())
+            .status(habitAssign.getStatus())
+            .userId(habitAssign.getUser().getId())
+            .duration(habitAssign.getDuration())
+            .workingDays(habitAssign.getWorkingDays())
+            .build();
+        habitAssign.getHabit().setHabitTranslations(List.of(
+            HabitTranslation.builder()
+                .id(1L)
+                .name("name")
+                .habitItem("habitItem")
+                .description("description")
+                .language(Language.builder().id(1L).code("ua").build())
+                .build(),
+            HabitTranslation.builder()
+                .id(2L)
+                .name("nameUa")
+                .habitItem("habitItemUa")
+                .description("descriptionUa")
+                .language(Language.builder().id(1L).code("en").build())
+                .build()));
+        PageableAdvancedDto<HabitAssignPreviewDto> expected =
+            new PageableAdvancedDto<>(List.of(habitAssignPreviewDto), returnedPage.getTotalElements(),
+                returnedPage.getPageable().getPageNumber(), returnedPage.getTotalPages(), returnedPage.getNumber(),
+                returnedPage.hasPrevious(), returnedPage.hasNext(), returnedPage.isFirst(), returnedPage.isLast());
+
+        when(habitAssignRepo.findAllByUserId(userId, pageable)).thenReturn(returnedPage);
+        when(modelMapper.map(habitAssign, HabitAssignPreviewDto.class)).thenReturn(habitAssignPreviewDto);
+
+        var actual =
+            habitAssignService.getAllByUserIdAndStatusNotCancelled(userId, pageable);
+
+        verify(habitAssignRepo).findAllByUserId(userId, pageable);
+        verify(modelMapper).map(habitAssign, HabitAssignPreviewDto.class);
+        assertArrayEquals(expected.getPage().toArray(), actual.getPage().toArray());
+    }
+
+    @Test
     void getUserShoppingAndCustomShoppingLists() {
         Long habitAssignId = 2L;
         Long userId = 3L;


### PR DESCRIPTION
## Task
[#7190](https://github.com/ita-social-projects/GreenCity/issues/7190)

## Changes
Added new endpoint in HabitAssignController that returns page of all habit assign previews for user by id and tests both for controllers and service.