### PR TITLE
Fixed removal of title image

### DIFF
--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -670,9 +670,10 @@ public class EventServiceImpl implements EventService {
         String titleImage = updateEventDto.getTitleImage();
 
         if (imagesToDelete != null && titleImage != null && imagesToDelete.contains(titleImage)) {
-            List<String> additionalImages = updateEventDto.getAdditionalImages();
+            List<String> additionalImages = new ArrayList<>(updateEventDto.getAdditionalImages());
             if (additionalImages != null && !additionalImages.isEmpty()) {
-                updateEventDto.setTitleImage(updateEventDto.getAdditionalImages().removeFirst());
+                updateEventDto.setTitleImage(additionalImages.removeFirst());
+                updateEventDto.setAdditionalImages(additionalImages);
             } else {
                 updateEventDto.setTitleImage(null);
             }

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -665,11 +665,14 @@ public class EventServiceImpl implements EventService {
         }
     }
 
-    private void checkTitleImageInImagesToDelete (UpdateEventDto updateEventDto){
-        if (updateEventDto.getImagesToDelete().contains(updateEventDto.getTitleImage())) {
-            if (!updateEventDto.getAdditionalImages().isEmpty()){
-                updateEventDto.setTitleImage(updateEventDto.getAdditionalImages().getFirst());
-                updateEventDto.getAdditionalImages().removeFirst();
+    private void checkTitleImageInImagesToDelete(UpdateEventDto updateEventDto) {
+        List<String> imagesToDelete = updateEventDto.getImagesToDelete();
+        String titleImage = updateEventDto.getTitleImage();
+
+        if (imagesToDelete != null && titleImage != null && imagesToDelete.contains(titleImage)) {
+            List<String> additionalImages = updateEventDto.getAdditionalImages();
+            if (additionalImages != null && !additionalImages.isEmpty()) {
+                updateEventDto.setTitleImage(updateEventDto.getAdditionalImages().removeFirst());
             } else {
                 updateEventDto.setTitleImage(null);
             }

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -651,15 +651,8 @@ public class EventServiceImpl implements EventService {
     }
 
     private void updateImages(Event toUpdate, UpdateEventDto updateEventDto, MultipartFile[] images) {
-        if (updateEventDto.getImagesToDelete().contains(updateEventDto.getTitleImage())) {
-            if (updateEventDto.getAdditionalImages() != null){
-                updateEventDto.setTitleImage(updateEventDto.getAdditionalImages().getFirst());
-                updateEventDto.getAdditionalImages().removeFirst();
-            }else {
-                updateEventDto.setTitleImage(null);
-            }
-        }
         eventRepo.deleteEventAdditionalImagesByEventId(updateEventDto.getId());
+        checkTitleImageInImagesToDelete(updateEventDto);
         if (ArrayUtils.isEmpty(images) && updateEventDto.getImagesToDelete() == null) {
             changeOldImagesWithoutRemovingAndAdding(toUpdate, updateEventDto);
         } else if (images == null || images.length == 0) {
@@ -669,6 +662,17 @@ public class EventServiceImpl implements EventService {
         } else {
             deleteImagesFromServer(updateEventDto.getImagesToDelete());
             addNewImages(toUpdate, updateEventDto, images);
+        }
+    }
+
+    private void checkTitleImageInImagesToDelete (UpdateEventDto updateEventDto){
+        if (updateEventDto.getImagesToDelete().contains(updateEventDto.getTitleImage())) {
+            if (!updateEventDto.getAdditionalImages().isEmpty()){
+                updateEventDto.setTitleImage(updateEventDto.getAdditionalImages().getFirst());
+                updateEventDto.getAdditionalImages().removeFirst();
+            } else {
+                updateEventDto.setTitleImage(null);
+            }
         }
     }
 

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -618,6 +618,7 @@ public class EventServiceImpl implements EventService {
     }
 
     private void enhanceWithNewData(Event toUpdate, UpdateEventDto updateEventDto, MultipartFile[] images) {
+
         if (updateEventDto.getTitle() != null) {
             toUpdate.setTitle(updateEventDto.getTitle());
         }
@@ -651,6 +652,9 @@ public class EventServiceImpl implements EventService {
     }
 
     private void updateImages(Event toUpdate, UpdateEventDto updateEventDto, MultipartFile[] images) {
+        if (updateEventDto.getImagesToDelete().contains(updateEventDto.getTitleImage())) {
+            updateEventDto.setTitleImage(null);
+        }
         eventRepo.deleteEventAdditionalImagesByEventId(updateEventDto.getId());
         if (ArrayUtils.isEmpty(images) && updateEventDto.getImagesToDelete() == null) {
             changeOldImagesWithoutRemovingAndAdding(toUpdate, updateEventDto);

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -618,7 +618,6 @@ public class EventServiceImpl implements EventService {
     }
 
     private void enhanceWithNewData(Event toUpdate, UpdateEventDto updateEventDto, MultipartFile[] images) {
-
         if (updateEventDto.getTitle() != null) {
             toUpdate.setTitle(updateEventDto.getTitle());
         }
@@ -653,7 +652,12 @@ public class EventServiceImpl implements EventService {
 
     private void updateImages(Event toUpdate, UpdateEventDto updateEventDto, MultipartFile[] images) {
         if (updateEventDto.getImagesToDelete().contains(updateEventDto.getTitleImage())) {
-            updateEventDto.setTitleImage(null);
+            if (updateEventDto.getAdditionalImages() != null){
+                updateEventDto.setTitleImage(updateEventDto.getAdditionalImages().getFirst());
+                updateEventDto.getAdditionalImages().removeFirst();
+            }else {
+                updateEventDto.setTitleImage(null);
+            }
         }
         eventRepo.deleteEventAdditionalImagesByEventId(updateEventDto.getId());
         if (ArrayUtils.isEmpty(images) && updateEventDto.getImagesToDelete() == null) {

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -5,15 +5,9 @@ import greencity.TestConst;
 import greencity.achievement.AchievementCalculation;
 import greencity.client.RestClient;
 import greencity.constant.AppConstant;
+import greencity.constant.ErrorMessage;
 import greencity.dto.PageableAdvancedDto;
-import greencity.dto.event.AddEventDtoRequest;
-import greencity.dto.event.AddressDto;
-import greencity.dto.event.EventAttenderDto;
-import greencity.dto.event.EventAuthorDto;
-import greencity.dto.event.EventDto;
-import greencity.dto.event.EventPreviewDto;
-import greencity.dto.event.UpdateEventDto;
-import greencity.dto.event.UpdateEventRequestDto;
+import greencity.dto.event.*;
 import greencity.dto.filter.FilterEventDto;
 import greencity.dto.tag.TagVO;
 import greencity.dto.user.UserVO;
@@ -35,6 +29,7 @@ import greencity.repository.EventRepo;
 import greencity.repository.UserRepo;
 import jakarta.persistence.Tuple;
 import jakarta.persistence.TupleElement;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.Principal;
 import java.util.ArrayList;
@@ -1516,5 +1511,22 @@ class EventServiceImplTest {
         assertEquals("titleImage", updateEventDto.getTitleImage());
         assertEquals(1, updateEventDto.getAdditionalImages().size());
         assertEquals("additionalImage", updateEventDto.getAdditionalImages().getFirst());
+    }
+
+    @Test
+    void testCheckingEqualityDateTimeInEventDateLocationDto() throws Exception {
+        List<EventDateLocationDto> eventDateLocationDtos = ModelUtils.getEventDateLocationDtoWithSameDateTime();
+
+        Method method =
+            EventServiceImpl.class.getDeclaredMethod("checkingEqualityDateTimeInEventDateLocationDto", List.class);
+        method.setAccessible(true);
+
+        InvocationTargetException exception = assertThrows(InvocationTargetException.class, () -> {
+            method.invoke(eventService, eventDateLocationDtos);
+        });
+
+        Throwable cause = exception.getCause();
+        assertTrue(cause instanceof IllegalArgumentException);
+        assertEquals(ErrorMessage.SAME_START_TIME_AND_FINISH_TIME_IN_EVENT_DATE, cause.getMessage());
     }
 }

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -1444,7 +1444,8 @@ class EventServiceImplTest {
         updateEventDto.setTitleImage("titleImage");
         updateEventDto.setAdditionalImages(List.of("newTitleImage", "additionalImage"));
 
-        Method method = EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
+        Method method =
+            EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
         method.setAccessible(true);
         method.invoke(eventService, updateEventDto);
 
@@ -1460,7 +1461,8 @@ class EventServiceImplTest {
         updateEventDto.setTitleImage("titleImage");
         updateEventDto.setAdditionalImages(Collections.emptyList());
 
-        Method method = EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
+        Method method =
+            EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
         method.setAccessible(true);
         method.invoke(eventService, updateEventDto);
 
@@ -1474,7 +1476,8 @@ class EventServiceImplTest {
         updateEventDto.setTitleImage("titleImage");
         updateEventDto.setAdditionalImages(List.of("additionalImage"));
 
-        Method method = EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
+        Method method =
+            EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
         method.setAccessible(true);
         method.invoke(eventService, updateEventDto);
 
@@ -1490,7 +1493,8 @@ class EventServiceImplTest {
         updateEventDto.setTitleImage(null);
         updateEventDto.setAdditionalImages(List.of("additionalImage"));
 
-        Method method = EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
+        Method method =
+            EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
         method.setAccessible(true);
         method.invoke(eventService, updateEventDto);
 
@@ -1504,7 +1508,8 @@ class EventServiceImplTest {
         updateEventDto.setTitleImage("titleImage");
         updateEventDto.setAdditionalImages(List.of("additionalImage"));
 
-        Method method = EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
+        Method method =
+            EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
         method.setAccessible(true);
         method.invoke(eventService, updateEventDto);
 

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -1436,4 +1436,80 @@ class EventServiceImplTest {
         assertEquals(100L, actual);
         verify(eventRepo).getAmountOfOrganizedAndAttendedEventsByUserId(anyLong());
     }
+
+    @Test
+    void testCheckTitleImageInImagesToDelete_TitleImageInImagesToDelete_AdditionalImagesNotEmpty() throws Exception {
+        UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDto();
+        updateEventDto.setImagesToDelete(List.of("titleImage"));
+        updateEventDto.setTitleImage("titleImage");
+        updateEventDto.setAdditionalImages(List.of("newTitleImage", "additionalImage"));
+
+        Method method = EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
+        method.setAccessible(true);
+        method.invoke(eventService, updateEventDto);
+
+        assertEquals("newTitleImage", updateEventDto.getTitleImage());
+        assertEquals(1, updateEventDto.getAdditionalImages().size());
+        assertEquals("additionalImage", updateEventDto.getAdditionalImages().getFirst());
+    }
+
+    @Test
+    void testCheckTitleImageInImagesToDelete_TitleImageInImagesToDelete_AdditionalImagesEmpty() throws Exception {
+        UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDto();
+        updateEventDto.setImagesToDelete(List.of("titleImage"));
+        updateEventDto.setTitleImage("titleImage");
+        updateEventDto.setAdditionalImages(Collections.emptyList());
+
+        Method method = EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
+        method.setAccessible(true);
+        method.invoke(eventService, updateEventDto);
+
+        assertNull(updateEventDto.getTitleImage());
+    }
+
+    @Test
+    void testCheckTitleImageInImagesToDelete_TitleImageNotInImagesToDelete() throws Exception {
+        UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDto();
+        updateEventDto.setImagesToDelete(List.of("anotherImage"));
+        updateEventDto.setTitleImage("titleImage");
+        updateEventDto.setAdditionalImages(List.of("additionalImage"));
+
+        Method method = EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
+        method.setAccessible(true);
+        method.invoke(eventService, updateEventDto);
+
+        assertEquals("titleImage", updateEventDto.getTitleImage());
+        assertEquals(1, updateEventDto.getAdditionalImages().size());
+        assertEquals("additionalImage", updateEventDto.getAdditionalImages().getFirst());
+    }
+
+    @Test
+    void testCheckTitleImageInImagesToDelete_NoTitleImage() throws Exception {
+        UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDto();
+        updateEventDto.setImagesToDelete(List.of("titleImage"));
+        updateEventDto.setTitleImage(null);
+        updateEventDto.setAdditionalImages(List.of("additionalImage"));
+
+        Method method = EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
+        method.setAccessible(true);
+        method.invoke(eventService, updateEventDto);
+
+        assertNull(updateEventDto.getTitleImage());
+    }
+
+    @Test
+    void testCheckTitleImageInImagesToDelete_NoImagesToDelete() throws Exception {
+        UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDto();
+        updateEventDto.setImagesToDelete(null);
+        updateEventDto.setTitleImage("titleImage");
+        updateEventDto.setAdditionalImages(List.of("additionalImage"));
+
+        Method method = EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
+        method.setAccessible(true);
+        method.invoke(eventService, updateEventDto);
+
+        assertEquals("titleImage", updateEventDto.getTitleImage());
+        assertEquals(1, updateEventDto.getAdditionalImages().size());
+        assertEquals("additionalImage", updateEventDto.getAdditionalImages().getFirst());
+    }
 }

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -1511,8 +1511,8 @@ class EventServiceImplTest {
         assertEquals("titleImage", updateEventDto.getTitleImage());
         assertEquals(1, updateEventDto.getAdditionalImages().size());
         assertEquals("additionalImage", updateEventDto.getAdditionalImages().getFirst());
-     }
-      
+    }
+
     @Test
     void testCheckingEqualityDateTimeInEventDateLocationDto() throws Exception {
         List<EventDateLocationDto> eventDateLocationDtos = ModelUtils.getEventDateLocationDtoWithSameDateTime();


### PR DESCRIPTION
## Summary Of Changes :fire:
- Fixed removing title image. Now when deleting a title image, not only the file in the cloud is deleted, but also the link to it in the TitleImage. Instead, the first image from additionalImages is inserted into TitleImage.

## Issue Link
[#7215](https://github.com/ita-social-projects/GreenCity/issues/7215)