### PR TITLE
Update event fix to avoid receiving imagesToDelete

### DIFF
--- a/core/src/main/java/greencity/constant/SwaggerExampleModel.java
+++ b/core/src/main/java/greencity/constant/SwaggerExampleModel.java
@@ -106,7 +106,6 @@ public final class SwaggerExampleModel {
         + "\t],\n"
         + "\t\"titleImage\":\"string\",\n"
         + "\t\"additionalImages\":[\"string\"],\n"
-        + "\t\"imagesToDelete\":[\"string\"],\n"
         + "\t\"tags\":[\"Social\"],\n"
         + "\t\"isOpen\":true\n"
         + "}";

--- a/dao/src/main/java/greencity/repository/EventRepo.java
+++ b/dao/src/main/java/greencity/repository/EventRepo.java
@@ -452,4 +452,19 @@ public interface EventRepo extends JpaRepository<Event, Long>, JpaSpecificationE
         GROUP BY e.id, tt.name, edl.city_en, et.tag_id, l.code, u.id, edl.id, uf.friend_id, ea.user_id, ef.user_id;
         """)
     List<Tuple> loadEventPreviewDataByIds(List<Long> ids, Long userId);
+
+    /**
+     * Method returns all images of events by event id.
+     *
+     * @param eventId {@link Long} event id.
+     * @return List of {@link String} links of event images.
+     *
+     * @author Olena Sotnik
+     */
+    @Query(nativeQuery = true,
+        value = "SELECT eim.link FROM events AS e "
+            + "JOIN events_images AS eim "
+            + "ON e.id = eim.event_id "
+            + "WHERE e.id = :eventId")
+    List<String> findAllImagesLinksByEventId(Long eventId);
 }

--- a/service-api/src/main/java/greencity/dto/event/UpdateEventDto.java
+++ b/service-api/src/main/java/greencity/dto/event/UpdateEventDto.java
@@ -38,8 +38,6 @@ public class UpdateEventDto {
 
     private List<String> additionalImages;
 
-    private List<String> imagesToDelete;
-
     private List<String> tags;
 
     @JsonProperty(value = "open")

--- a/service-api/src/main/java/greencity/dto/event/UpdateEventRequestDto.java
+++ b/service-api/src/main/java/greencity/dto/event/UpdateEventRequestDto.java
@@ -40,8 +40,6 @@ public class UpdateEventRequestDto {
 
     private List<String> additionalImages;
 
-    private List<String> imagesToDelete;
-
     private List<String> tags;
 
     @JsonProperty(value = "open")

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -56,7 +56,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.multipart.MultipartFile;
-
 import static greencity.ModelUtils.TEST_USER_VO;
 import static greencity.ModelUtils.getPrincipal;
 import static greencity.enums.EventType.OFFLINE;
@@ -330,7 +329,7 @@ class EventServiceImplTest {
             event.getAdditionalImages().getFirst().getLink());
         assertEquals(event.getTitleImage(), expectedEvent.getTitleImage());
 
-        eventToUpdateDto.setImagesToDelete(List.of("New addition image"));
+        when(eventRepo.findAllImagesLinksByEventId(anyLong())).thenReturn(List.of("New addition image"));
         doNothing().when(fileService).delete(any());
 
         method.invoke(eventService, event, eventToUpdateDto, null);
@@ -361,7 +360,8 @@ class EventServiceImplTest {
         assertEquals(expectedEvent.getAdditionalImages().getFirst().getLink(),
             event.getAdditionalImages().getFirst().getLink());
 
-        eventToUpdateDto.setImagesToDelete(null);
+        when(eventRepo.findAllImagesLinksByEventId(anyLong())).thenReturn(new ArrayList<>());
+        doNothing().when(fileService).delete(any());
         eventToUpdateDto.setTitleImage("url");
         eventToUpdateDto.setAdditionalImages(List.of("Add img 1", "Add img 2"));
         expectedEvent.setTitleImage("url");
@@ -389,6 +389,8 @@ class EventServiceImplTest {
     void updateTitleImage() {
         EventDto eventDto = ModelUtils.getEventDto();
         UpdateEventRequestDto eventToUpdateDto = ModelUtils.getUpdateEventRequestDto();
+        // UpdateEventDto eventToUpdateDto = ModelUtils.getUpdateEventDto();
+        eventToUpdateDto.setAdditionalImages(new ArrayList<>());
         Event event = ModelUtils.getEvent();
         List<Long> eventIds = List.of(event.getId());
         User user = ModelUtils.getUser();
@@ -1435,14 +1437,16 @@ class EventServiceImplTest {
     @Test
     void testCheckTitleImageInImagesToDelete_TitleImageInImagesToDelete_AdditionalImagesNotEmpty() throws Exception {
         UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDto();
-        updateEventDto.setImagesToDelete(List.of("titleImage"));
         updateEventDto.setTitleImage("titleImage");
         updateEventDto.setAdditionalImages(List.of("newTitleImage", "additionalImage"));
 
-        Method method =
-            EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
+        List<String> imagesToDelete = List.of("titleImage");
+        when(eventRepo.findAllImagesLinksByEventId(updateEventDto.getId())).thenReturn(imagesToDelete);
+
+        Method method = EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete",
+            UpdateEventDto.class, List.class);
         method.setAccessible(true);
-        method.invoke(eventService, updateEventDto);
+        method.invoke(eventService, updateEventDto, imagesToDelete);
 
         assertEquals("newTitleImage", updateEventDto.getTitleImage());
         assertEquals(1, updateEventDto.getAdditionalImages().size());
@@ -1452,14 +1456,16 @@ class EventServiceImplTest {
     @Test
     void testCheckTitleImageInImagesToDelete_TitleImageInImagesToDelete_AdditionalImagesEmpty() throws Exception {
         UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDto();
-        updateEventDto.setImagesToDelete(List.of("titleImage"));
         updateEventDto.setTitleImage("titleImage");
         updateEventDto.setAdditionalImages(Collections.emptyList());
 
-        Method method =
-            EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
+        List<String> imagesToDelete = List.of("titleImage");
+        when(eventRepo.findAllImagesLinksByEventId(updateEventDto.getId())).thenReturn(imagesToDelete);
+
+        Method method = EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete",
+            UpdateEventDto.class, List.class);
         method.setAccessible(true);
-        method.invoke(eventService, updateEventDto);
+        method.invoke(eventService, updateEventDto, imagesToDelete);
 
         assertNull(updateEventDto.getTitleImage());
     }
@@ -1467,14 +1473,16 @@ class EventServiceImplTest {
     @Test
     void testCheckTitleImageInImagesToDelete_TitleImageNotInImagesToDelete() throws Exception {
         UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDto();
-        updateEventDto.setImagesToDelete(List.of("anotherImage"));
         updateEventDto.setTitleImage("titleImage");
         updateEventDto.setAdditionalImages(List.of("additionalImage"));
 
-        Method method =
-            EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
+        List<String> imagesToDelete = List.of("additionalImage");
+        when(eventRepo.findAllImagesLinksByEventId(updateEventDto.getId())).thenReturn(imagesToDelete);
+
+        Method method = EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete",
+            UpdateEventDto.class, List.class);
         method.setAccessible(true);
-        method.invoke(eventService, updateEventDto);
+        method.invoke(eventService, updateEventDto, imagesToDelete);
 
         assertEquals("titleImage", updateEventDto.getTitleImage());
         assertEquals(1, updateEventDto.getAdditionalImages().size());
@@ -1484,14 +1492,16 @@ class EventServiceImplTest {
     @Test
     void testCheckTitleImageInImagesToDelete_NoTitleImage() throws Exception {
         UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDto();
-        updateEventDto.setImagesToDelete(List.of("titleImage"));
         updateEventDto.setTitleImage(null);
         updateEventDto.setAdditionalImages(List.of("additionalImage"));
 
-        Method method =
-            EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
+        List<String> imagesToDelete = List.of("titleImage");
+        when(eventRepo.findAllImagesLinksByEventId(updateEventDto.getId())).thenReturn(imagesToDelete);
+
+        Method method = EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete",
+            UpdateEventDto.class, List.class);
         method.setAccessible(true);
-        method.invoke(eventService, updateEventDto);
+        method.invoke(eventService, updateEventDto, imagesToDelete);
 
         assertNull(updateEventDto.getTitleImage());
     }
@@ -1499,14 +1509,15 @@ class EventServiceImplTest {
     @Test
     void testCheckTitleImageInImagesToDelete_NoImagesToDelete() throws Exception {
         UpdateEventDto updateEventDto = ModelUtils.getUpdateEventDto();
-        updateEventDto.setImagesToDelete(null);
         updateEventDto.setTitleImage("titleImage");
         updateEventDto.setAdditionalImages(List.of("additionalImage"));
 
-        Method method =
-            EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete", UpdateEventDto.class);
+        when(eventRepo.findAllImagesLinksByEventId(updateEventDto.getId())).thenReturn(null);
+
+        Method method = EventServiceImpl.class.getDeclaredMethod("checkTitleImageInImagesToDelete",
+            UpdateEventDto.class, List.class);
         method.setAccessible(true);
-        method.invoke(eventService, updateEventDto);
+        method.invoke(eventService, updateEventDto, null);
 
         assertEquals("titleImage", updateEventDto.getTitleImage());
         assertEquals(1, updateEventDto.getAdditionalImages().size());

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -389,7 +389,6 @@ class EventServiceImplTest {
     void updateTitleImage() {
         EventDto eventDto = ModelUtils.getEventDto();
         UpdateEventRequestDto eventToUpdateDto = ModelUtils.getUpdateEventRequestDto();
-        // UpdateEventDto eventToUpdateDto = ModelUtils.getUpdateEventDto();
         eventToUpdateDto.setAdditionalImages(new ArrayList<>());
         Event event = ModelUtils.getEvent();
         List<Long> eventIds = List.of(event.getId());


### PR DESCRIPTION
# GreenCity PR
Update implementation of images deleting during update of event

## Summary Of Changes :fire:
-Removed field 'imagesToDelete' in UpdateEventDto and in UpdateEventRequestDto
-Updated method update Event in EventServiceImpl
-Updated tests in EventServiceImplTest
-Removed field 'imagesToDelete' in SwaggerModel for this endpoint
-Added method findAllImagesLinksByEventId() in EventRepo

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [ ] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers