### PR TITLE
Commit with changeset for add new and drop previous user_action table constraint

### DIFF
--- a/dao/src/main/java/greencity/entity/UserAction.java
+++ b/dao/src/main/java/greencity/entity/UserAction.java
@@ -23,7 +23,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Table(name = "user_actions",
-    uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "achievement_category_id"}))
+    uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "achievement_category_id", "habit_id"}))
 @Builder
 @EqualsAndHashCode
 public class UserAction {

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -195,5 +195,6 @@
     <include file="db/changelog/logs/ch-delete-from-positions_authorities_mapping-authority-for-admin-position-Kizerov.xml"/>
     <include file="db/changelog/logs/ch-delete-from-positions_authorities_mapping-authority-for-service-manager-position-Kizerov.xml"/>
     <include file="db/changelog/logs/ch-add-unique-constraint-to-user_id-and-achievement_category_id-to-user_action_table.xml"/>
+    <include file="db/changelog/logs/ch-add-unique-constraint-to-include-habit_id-column-in-user_action-table-Sotnik.xml"/>
 </databaseChangeLog>
 

--- a/dao/src/main/resources/db/changelog/logs/ch-add-unique-constraint-to-include-habit_id-column-in-user_action-table-Sotnik.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-add-unique-constraint-to-include-habit_id-column-in-user_action-table-Sotnik.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="ch-add-unique-constraint-to-include-habit_id-column-in-user_action-table-Sotnik.xml" author="Olena Sotnik">
+        <dropUniqueConstraint tableName="user_actions"
+                              constraintName="user_actions_user_id_achievement_category_id_key"/>
+        <addUniqueConstraint tableName="user_actions"
+                             columnNames="user_id, achievement_category_id, habit_id"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
# GreenCity PR
Fix of habit enrollment by addition of new UniqueConstraint to user_action table in DB including 3 columns: "user_id, achievement_category_id, habit_id " and deleting previous including only 2 columns: "user_id, achievement_category_id", that made not possible to create few rows for different habits in db;

## Summary Of Changes :fire:
-created new file with changeset to add and delete constraints in user_action table
-modified db.changelog-master.xml
-modified entity UserAction to include habit-id column to  UniqueConstraint

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [ ] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers