### PR TITLE
Changed notification logic when user likes eco news

### DIFF
--- a/service-api/src/main/java/greencity/service/UserNotificationService.java
+++ b/service-api/src/main/java/greencity/service/UserNotificationService.java
@@ -177,4 +177,12 @@ public interface UserNotificationService {
      * @param notificationId id of notification, that should be marked
      */
     void viewNotification(Long notificationId);
+
+    /**
+     * Checks for any unread notifications for the specified user.
+     *
+     * @param userId the ID of the user whose unread notifications are to be
+     *               checked.
+     */
+    void checkUnreadNotification(Long userId);
 }

--- a/service/src/main/java/greencity/service/UserNotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/UserNotificationServiceImpl.java
@@ -350,4 +350,15 @@ public class UserNotificationServiceImpl implements UserNotificationService {
     private void sendNotification(Long userId) {
         messagingTemplate.convertAndSend(TOPIC + userId + NOTIFICATION, true);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void checkUnreadNotification(Long userId) {
+        long unreadNotifications = notificationRepo.countByTargetUserIdAndViewedIsFalse(userId);
+        if (unreadNotifications == 0) {
+            messagingTemplate.convertAndSend(TOPIC + userId + NOTIFICATION, false);
+        }
+    }
 }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -452,6 +452,18 @@ public class ModelUtils {
             .build();
     }
 
+    public static UserVO getAuthorVO() {
+        return UserVO.builder()
+            .id(2L)
+            .email(TestConst.EMAIL)
+            .name(TestConst.NAME)
+            .role(Role.ROLE_USER)
+            .lastActivityTime(localDateTime)
+            .verifyEmail(new VerifyEmailVO())
+            .dateOfRegistration(localDateTime)
+            .build();
+    }
+
     public static UserManagementVO getUserManagementVO() {
         return UserManagementVO.builder()
             .id(1L)

--- a/service/src/test/java/greencity/service/EcoNewsServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EcoNewsServiceImplTest.java
@@ -23,9 +23,14 @@ import greencity.dto.user.UserVO;
 import greencity.entity.EcoNews;
 import greencity.entity.Tag;
 import greencity.entity.User;
+import greencity.entity.VerifyEmail;
 import greencity.enums.NotificationType;
 import greencity.enums.RatingCalculationEnum;
 import greencity.enums.TagType;
+import greencity.enums.AchievementAction;
+import greencity.enums.AchievementCategoryType;
+import greencity.enums.Role;
+import greencity.enums.UserStatus;
 import greencity.exception.exceptions.BadRequestException;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.exception.exceptions.NotSavedException;
@@ -45,6 +50,7 @@ import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalDateTime;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -874,5 +880,79 @@ class EcoNewsServiceImplTest {
         // then
         assertEquals(1, usersWhoDislikedPost.size());
         assertTrue(usersWhoDislikedPost.contains(user1VO));
+    }
+
+    @Test
+    void testLikeAddLike() {
+        UserVO actionUser = ModelUtils.getUserVO();
+        UserVO targetUser = ModelUtils.getAuthorVO();
+        EcoNewsVO ecoNewsVO = ModelUtils.getEcoNewsVO();
+        ecoNewsVO.setAuthor(targetUser);
+        ecoNewsVO.setUsersLikedNews(new HashSet<>());
+        EcoNews ecoNews = ModelUtils.getEcoNews();
+        ecoNews.setAuthor(User.builder()
+            .id(targetUser.getId())
+            .build());
+
+        when(ecoNewsRepo.save(any(EcoNews.class))).thenReturn(ecoNews);
+        when(ecoNewsRepo.findById(anyLong())).thenReturn(Optional.of(ecoNews));
+        when(modelMapper.map(any(EcoNews.class), eq(EcoNewsVO.class))).thenReturn(ecoNewsVO);
+        when(userService.findById(anyLong())).thenReturn(targetUser);
+
+        ecoNewsService.like(actionUser, ecoNewsVO.getId());
+
+        assertTrue(ecoNewsVO.getUsersLikedNews().contains(actionUser));
+        verify(userNotificationService, times(1)).createNotification(
+            targetUser, actionUser, NotificationType.ECONEWS_LIKE, ecoNewsVO.getId(), ecoNewsVO.getTitle());
+        verify(achievementCalculation, times(1)).calculateAchievement(actionUser,
+            AchievementCategoryType.LIKE_COMMENT_OR_REPLY, AchievementAction.ASSIGN);
+        verify(ratingCalculation, times(1))
+            .ratingCalculation(RatingCalculationEnum.LIKE_COMMENT_OR_REPLY, actionUser);
+    }
+
+    @Test
+    void testLikeUndoLike() {
+        User author = ModelUtils.getUser();
+        User action = User.builder()
+            .id(2L)
+            .email(TestConst.EMAIL)
+            .name(TestConst.NAME)
+            .role(Role.ROLE_USER)
+            .userStatus(UserStatus.ACTIVATED)
+            .lastActivityTime(LocalDateTime.now())
+            .verifyEmail(new VerifyEmail())
+            .dateOfRegistration(LocalDateTime.now())
+            .subscribedEvents(new HashSet<>())
+            .favoriteEvents(new HashSet<>())
+            .build();
+
+        ModelMapper mapper = new ModelMapper();
+        UserVO userVO = mapper.map(action, UserVO.class);
+        UserVO targetUser = mapper.map(author, UserVO.class);
+        UserVO actionUser = mapper.map(action, UserVO.class);
+
+        EcoNews news = EcoNews.builder()
+            .id(1L)
+            .author(author)
+            .usersLikedNews(new HashSet<>(Set.of(action)))
+            .build();
+        EcoNewsVO ecoNewsVO = mapper.map(news, EcoNewsVO.class);
+
+        ecoNewsVO.setUsersLikedNews(new HashSet<>(ecoNewsVO.getUsersLikedNews()));
+
+        when(ecoNewsRepo.findById(anyLong())).thenReturn(Optional.of(news));
+        when(modelMapper.map(any(EcoNews.class), eq(EcoNewsVO.class))).thenReturn(ecoNewsVO);
+
+        ecoNewsService.like(userVO, news.getId());
+
+        assertFalse(ecoNewsVO.getUsersLikedNews().contains(actionUser));
+
+        verify(userNotificationService, times(1))
+            .removeActionUserFromNotification(targetUser, actionUser, ecoNewsVO.getId(), NotificationType.ECONEWS_LIKE);
+        verify(userNotificationService, times(1)).checkUnreadNotification(author.getId());
+        verify(achievementCalculation, times(1))
+            .calculateAchievement(actionUser, AchievementCategoryType.LIKE_COMMENT_OR_REPLY, AchievementAction.DELETE);
+        verify(ratingCalculation, times(1))
+            .ratingCalculation(RatingCalculationEnum.UNDO_LIKE_COMMENT_OR_REPLY, actionUser);
     }
 }

--- a/service/src/test/java/greencity/service/UserNotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/UserNotificationServiceImplTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class UserNotificationServiceImplTest {
@@ -340,5 +341,25 @@ class UserNotificationServiceImplTest {
         verify(notificationRepo).countByTargetUserIdAndViewedIsFalse(userId);
         verify(messagingTemplate).convertAndSend(TOPIC + userId + NOTIFICATION, false);
         verify(notificationRepo).markNotificationAsViewed(notificationId);
+    }
+
+    @Test
+    void testCheckUnreadNotificationWhenUnreadExists() {
+        Long userId = 1L;
+        when(notificationRepo.countByTargetUserIdAndViewedIsFalse(userId)).thenReturn(3L);
+
+        userNotificationService.checkUnreadNotification(userId);
+
+        verify(messagingTemplate, never()).convertAndSend(TOPIC + userId + NOTIFICATION, false);
+    }
+
+    @Test
+    void testCheckUnreadNotificationWhenNoUnreadExists() {
+        Long userId = 2L;
+        when(notificationRepo.countByTargetUserIdAndViewedIsFalse(userId)).thenReturn(0L);
+
+        userNotificationService.checkUnreadNotification(userId);
+
+        verify(messagingTemplate, times(1)).convertAndSend(TOPIC + userId + NOTIFICATION, false);
     }
 }


### PR DESCRIPTION
# GreenCity PR

## Summary Of Changes :fire:
- removed email notification when user likes eco news.
- added logic to send new notification via websocket.
- added tests.

# Issue Link

[#6910
](https://github.com/ita-social-projects/GreenCity/issues/6910)

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers