### PR TITLE
refactor service method to return unassigned habits when needed

### DIFF
--- a/core/src/main/java/greencity/controller/HabitController.java
+++ b/core/src/main/java/greencity/controller/HabitController.java
@@ -128,9 +128,11 @@ public class HabitController {
     /**
      * Method finds all habits by tags and language code.
      *
-     * @param locale   {@link Locale} with needed language code.
-     * @param pageable {@link Pageable} instance.
-     * @param tags     {@link List} of {@link String}
+     * @param locale          {@link Locale} with needed language code.
+     * @param pageable        {@link Pageable} instance.
+     * @param tags            {@link List} of {@link String}
+     * @param excludeAssigned {@link boolean} flag to determine whether to exclude
+     *                        habits already assigned to the current user.
      * @return Pageable of {@link HabitDto}.
      */
     @Operation(summary = "Find all habits by tags and language code.")
@@ -142,11 +144,14 @@ public class HabitController {
     @GetMapping("/tags/search")
     @ApiPageableWithLocale
     public ResponseEntity<PageableDto<HabitDto>> getAllByTagsAndLanguageCode(
+        @Parameter(hidden = true) @CurrentUser UserVO userVO,
         @Parameter(hidden = true) @ValidLanguage Locale locale,
         @RequestParam List<String> tags,
+        @RequestParam boolean excludeAssigned,
         @Parameter(hidden = true) Pageable pageable) {
         return ResponseEntity.status(HttpStatus.OK).body(
-            habitService.getAllByTagsAndLanguageCode(pageable, tags, locale.getLanguage()));
+            habitService.getAllByTagsAndLanguageCode(pageable, tags, locale.getLanguage(), excludeAssigned,
+                userVO.getId()));
     }
 
     /**

--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -29,7 +29,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import static greencity.ModelUtils.getPrincipal;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
@@ -92,12 +92,13 @@ class HabitControllerTest {
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
         Locale locale = Locale.of("en");
         List<String> tags = Arrays.asList("News", "Education");
+        boolean excludeAssigned = false;
 
         mockMvc.perform(get(habitLink + "/tags/search?page=" + pageNumber +
-            "&lang=" + locale.getLanguage() + "&tags=News,Education")
+            "&lang=" + locale.getLanguage() + "&tags=News,Education" + "&excludeAssigned=" + excludeAssigned)
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
-        verify(habitService).getAllByTagsAndLanguageCode(pageable, tags, locale.getLanguage());
+        verify(habitService).getAllByTagsAndLanguageCode(pageable, tags, locale.getLanguage(), excludeAssigned, null);
     }
 
     @Test

--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -29,7 +29,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import static greencity.ModelUtils.getPrincipal;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;

--- a/service-api/src/main/java/greencity/service/HabitService.java
+++ b/service-api/src/main/java/greencity/service/HabitService.java
@@ -43,14 +43,19 @@ public interface HabitService {
     /**
      * Method that find all habit's translations by language code and tags.
      *
-     * @param pageable     {@link Pageable}
-     * @param tags         {@link List} of {@link String} tags
-     * @param languageCode language code {@link String}
+     * @param pageable        {@link Pageable}
+     * @param tags            {@link List} of {@link String} tags
+     * @param languageCode    language code {@link String}
+     * @param excludeAssigned {@link boolean} flag to determine whether to exclude
+     *                        habits already assigned to the specified user.
+     * @param userId          {@link Long} representing the ID of the user for whom
+     *                        assigned habits should be excluded (if applicable).
      *
      * @return {@link PageableDto} of {@link HabitDto}.
      * @author Markiyan Derevetskyi
      */
-    PageableDto<HabitDto> getAllByTagsAndLanguageCode(Pageable pageable, List<String> tags, String languageCode);
+    PageableDto<HabitDto> getAllByTagsAndLanguageCode(Pageable pageable, List<String> tags, String languageCode,
+        boolean excludeAssigned, Long userId);
 
     /**
      * Method that return all PageableDto of HabitDto by tags, isCustomHabit,

--- a/service/src/main/java/greencity/service/HabitServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitServiceImpl.java
@@ -138,10 +138,13 @@ public class HabitServiceImpl implements HabitService {
      */
     @Override
     public PageableDto<HabitDto> getAllByTagsAndLanguageCode(Pageable pageable, List<String> tags,
-        String languageCode) {
+        String languageCode, boolean excludeAssigned, Long userId) {
         List<String> lowerCaseTags = tags.stream().map(String::toLowerCase).collect(Collectors.toList());
-        Page<HabitTranslation> habitTranslationsPage =
-            habitTranslationRepo.findAllByTagsAndLanguageCode(pageable, lowerCaseTags, languageCode);
+        Page<HabitTranslation> habitTranslationsPage = (excludeAssigned)
+            ? habitTranslationRepo.findUnassignedHabitTranslationsByLanguageAndTags(pageable, lowerCaseTags,
+                languageCode, userId)
+            : habitTranslationRepo.findAllByTagsAndLanguageCode(pageable, lowerCaseTags, languageCode);
+
         return buildPageableDto(habitTranslationsPage);
     }
 

--- a/service/src/test/java/greencity/service/HabitServiceImplTest.java
+++ b/service/src/test/java/greencity/service/HabitServiceImplTest.java
@@ -250,11 +250,13 @@ class HabitServiceImplTest {
     }
 
     @Test
-    void getAllByTagsAndLanguageCode() {
+    void getAllByTagsAndLanguageCodeWithoutExcluded() {
         Pageable pageable = PageRequest.of(0, 2);
         String tag = "ECO_NEWS";
         List<String> tags = Collections.singletonList(tag);
         List<String> lowerCaseTags = Collections.singletonList(tag.toLowerCase());
+        boolean excludeAssigned = false;
+        Long userId = 1L;
         HabitTranslation habitTranslation = ModelUtils.getHabitTranslation();
         HabitDto habitDto = ModelUtils.getHabitDto();
         Page<HabitTranslation> habitTranslationPage =
@@ -266,7 +268,32 @@ class HabitServiceImplTest {
         when(habitAssignRepo.findAmountOfUsersAcquired(anyLong())).thenReturn(5L);
         when(habitTranslationRepo.findAllByTagsAndLanguageCode(pageable, lowerCaseTags, "en"))
             .thenReturn(habitTranslationPage);
-        assertEquals(pageableDto, habitService.getAllByTagsAndLanguageCode(pageable, tags, "en"));
+        assertEquals(pageableDto,
+            habitService.getAllByTagsAndLanguageCode(pageable, tags, "en", excludeAssigned, userId));
+    }
+
+    @Test
+    void getAllByTagsAndLanguageCodeWithExcluded() {
+        Pageable pageable = PageRequest.of(0, 2);
+        String tag = "ECO_NEWS";
+        List<String> tags = Collections.singletonList(tag);
+        List<String> lowerCaseTags = Collections.singletonList(tag.toLowerCase());
+        boolean excludeAssigned = true;
+        Long userId = 1L;
+        HabitTranslation habitTranslation = ModelUtils.getHabitTranslation();
+        HabitDto habitDto = ModelUtils.getHabitDto();
+        Page<HabitTranslation> habitTranslationPage =
+            new PageImpl<>(Collections.singletonList(habitTranslation), pageable, 10);
+        List<HabitDto> habitDtoList = Collections.singletonList(habitDto);
+        PageableDto pageableDto = new PageableDto(habitDtoList, habitTranslationPage.getTotalElements(),
+            habitTranslationPage.getPageable().getPageNumber(), habitTranslationPage.getTotalPages());
+        when(modelMapper.map(habitTranslation, HabitDto.class)).thenReturn(habitDto);
+        when(habitAssignRepo.findAmountOfUsersAcquired(anyLong())).thenReturn(5L);
+        when(habitTranslationRepo.findUnassignedHabitTranslationsByLanguageAndTags(pageable, lowerCaseTags, "en",
+            userId))
+            .thenReturn(habitTranslationPage);
+        assertEquals(pageableDto,
+            habitService.getAllByTagsAndLanguageCode(pageable, tags, "en", excludeAssigned, userId));
     }
 
     private static Stream<Arguments> getAllByDifferentParametersArguments() {


### PR DESCRIPTION
# GreenCityPR

## Summary Of Changes :fire:
Summary of changes…

## Added
-a new repository method findUnassignedHabitTranslationsByLanguageAndTags to handle the exclusion of assigned habits.
-unit tests

## Changed
-Refactored the HabitService interface and HabitServiceImpl class to include the excludeAssigned flag and user ID in the getAllByTagsAndLanguageCode method.
-Implemented logic to either fetch all habits or only unassigned habits based on the excludeAssigned flag.
-unit tests

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
