### PR TITLE
Changed logic of email notifications

### DIFF
--- a/dao/src/main/java/greencity/repository/NotificationRepo.java
+++ b/dao/src/main/java/greencity/repository/NotificationRepo.java
@@ -44,7 +44,7 @@ public interface NotificationRepo extends JpaRepository<Notification, Long>, Jpa
      * @return last Notifications for user, where viewed is false
      */
     Page<Notification> findByTargetUserIdAndProjectNameInAndNotificationTypeInOrderByTimeDesc(Long targetUserId,
-                                                                                              ProjectName[] projectNames, NotificationType[] notificationTypes, Pageable pageable);
+        ProjectName[] projectNames, NotificationType[] notificationTypes, Pageable pageable);
 
     /**
      * Checks if there are any unread notifications for the specified user.
@@ -93,7 +93,7 @@ public interface NotificationRepo extends JpaRepository<Notification, Long>, Jpa
      * @return {@link Notification} with specific NotificationType and id of object
      */
     Notification findNotificationByTargetUserIdAndNotificationTypeAndTargetId(Long targetUserId,
-                                                                              NotificationType notificationType, Long targetId);
+        NotificationType notificationType, Long targetId);
 
     /**
      * Method to find specific not viewed Notification.
@@ -104,7 +104,7 @@ public interface NotificationRepo extends JpaRepository<Notification, Long>, Jpa
      * @return {@link Notification} with specific NotificationType and id of object
      */
     Optional<Notification> findNotificationByTargetUserIdAndNotificationTypeAndTargetIdAndViewedIsFalse(
-            Long targetUserId, NotificationType notificationType, Long targetId);
+        Long targetUserId, NotificationType notificationType, Long targetId);
 
     /**
      * Method to delete specific Notification.
@@ -125,10 +125,14 @@ public interface NotificationRepo extends JpaRepository<Notification, Long>, Jpa
     long countByTargetUserIdAndViewedIsFalse(Long userId);
 
     /**
-     * Method to return all unread notifications by specific type
+     * Method to return all unread notifications by specific type.
+     *
      * @param notificationType type of notification
      * @return List of unread notification that have specific type
      */
-    @Query("SELECT n FROM Notification n JOIN FETCH n.targetUser JOIN FETCH n.actionUsers WHERE n.notificationType = :notificationType AND n.viewed = false")
+    @Query("SELECT n FROM Notification n "
+        + "JOIN FETCH n.targetUser "
+        + "JOIN FETCH n.actionUsers "
+        + "WHERE n.notificationType = :notificationType AND n.viewed = false")
     List<Notification> findAllByNotificationTypeAndViewedIsFalse(NotificationType notificationType);
 }

--- a/dao/src/main/java/greencity/repository/NotificationRepo.java
+++ b/dao/src/main/java/greencity/repository/NotificationRepo.java
@@ -44,7 +44,7 @@ public interface NotificationRepo extends JpaRepository<Notification, Long>, Jpa
      * @return last Notifications for user, where viewed is false
      */
     Page<Notification> findByTargetUserIdAndProjectNameInAndNotificationTypeInOrderByTimeDesc(Long targetUserId,
-        ProjectName[] projectNames, NotificationType[] notificationTypes, Pageable pageable);
+                                                                                              ProjectName[] projectNames, NotificationType[] notificationTypes, Pageable pageable);
 
     /**
      * Checks if there are any unread notifications for the specified user.
@@ -93,7 +93,7 @@ public interface NotificationRepo extends JpaRepository<Notification, Long>, Jpa
      * @return {@link Notification} with specific NotificationType and id of object
      */
     Notification findNotificationByTargetUserIdAndNotificationTypeAndTargetId(Long targetUserId,
-        NotificationType notificationType, Long targetId);
+                                                                              NotificationType notificationType, Long targetId);
 
     /**
      * Method to find specific not viewed Notification.
@@ -104,7 +104,7 @@ public interface NotificationRepo extends JpaRepository<Notification, Long>, Jpa
      * @return {@link Notification} with specific NotificationType and id of object
      */
     Optional<Notification> findNotificationByTargetUserIdAndNotificationTypeAndTargetIdAndViewedIsFalse(
-        Long targetUserId, NotificationType notificationType, Long targetId);
+            Long targetUserId, NotificationType notificationType, Long targetId);
 
     /**
      * Method to delete specific Notification.
@@ -123,4 +123,12 @@ public interface NotificationRepo extends JpaRepository<Notification, Long>, Jpa
      * @return the number of unread notifications for the specified user
      */
     long countByTargetUserIdAndViewedIsFalse(Long userId);
+
+    /**
+     * Method to return all unread notifications by specific type
+     * @param notificationType type of notification
+     * @return List of unread notification that have specific type
+     */
+    @Query("SELECT n FROM Notification n JOIN FETCH n.targetUser JOIN FETCH n.actionUsers WHERE n.notificationType = :notificationType AND n.viewed = false")
+    List<Notification> findAllByNotificationTypeAndViewedIsFalse(NotificationType notificationType);
 }

--- a/service-api/src/main/java/greencity/client/RestClient.java
+++ b/service-api/src/main/java/greencity/client/RestClient.java
@@ -17,7 +17,6 @@ import greencity.message.ScheduledEmailMessage;
 import greencity.message.SendChangePlaceStatusEmailMessage;
 import greencity.message.SendHabitNotification;
 import greencity.message.SendReportEmailMessage;
-import greencity.message.UserReceivedCommentMessage;
 import greencity.message.UserTaggedInCommentMessage;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -71,10 +70,10 @@ public class RestClient {
      *                                   GreenCityUser.
      */
     public RestClient(RestTemplate restTemplate,
-                      @Value("${greencityuser.server.address}") String greenCityUserServerAddress,
-                      HttpServletRequest httpServletRequest,
-                      JwtTool jwtTool,
-                      @Value("${spring.liquibase.parameters.service-email}") String systemEmail) {
+        @Value("${greencityuser.server.address}") String greenCityUserServerAddress,
+        HttpServletRequest httpServletRequest,
+        JwtTool jwtTool,
+        @Value("${spring.liquibase.parameters.service-email}") String systemEmail) {
         this.restTemplate = restTemplate;
         this.greenCityUserServerAddress = greenCityUserServerAddress;
         this.httpServletRequest = httpServletRequest;
@@ -92,10 +91,10 @@ public class RestClient {
     public List<UserVO> findAllByEmailNotification(EmailNotification emailNotification) {
         HttpEntity<String> entity = new HttpEntity<>(new HttpHeaders());
         ResponseEntity<List<UserVO>> exchange = restTemplate.exchange(greenCityUserServerAddress
-                        + RestTemplateLinks.USER_FIND_ALL_BY_EMAIL_NOTIFICATION
-                        + RestTemplateLinks.EMAIL_NOTIFICATION + emailNotification,
-                HttpMethod.GET, entity, new ParameterizedTypeReference<>() {
-                });
+            + RestTemplateLinks.USER_FIND_ALL_BY_EMAIL_NOTIFICATION
+            + RestTemplateLinks.EMAIL_NOTIFICATION + emailNotification,
+            HttpMethod.GET, entity, new ParameterizedTypeReference<>() {
+            });
         return exchange.getBody();
     }
 
@@ -108,9 +107,9 @@ public class RestClient {
     public List<String> findAllUsersCities() {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         ResponseEntity<List<String>> exchange = restTemplate.exchange(greenCityUserServerAddress
-                        + RestTemplateLinks.FIND_ALL_USERS_CITIES,
-                HttpMethod.GET, entity, new ParameterizedTypeReference<>() {
-                });
+            + RestTemplateLinks.FIND_ALL_USERS_CITIES,
+            HttpMethod.GET, entity, new ParameterizedTypeReference<>() {
+            });
         return exchange.getBody();
     }
 
@@ -123,9 +122,9 @@ public class RestClient {
     public Map<Integer, Long> findAllRegistrationMonthsMap() {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         ResponseEntity<Map<Integer, Long>> exchange = restTemplate.exchange(greenCityUserServerAddress
-                        + RestTemplateLinks.FIND_ALL_REGISTRATION_MONTHS_MAP,
-                HttpMethod.GET, entity, new ParameterizedTypeReference<>() {
-                });
+            + RestTemplateLinks.FIND_ALL_REGISTRATION_MONTHS_MAP,
+            HttpMethod.GET, entity, new ParameterizedTypeReference<>() {
+            });
         return exchange.getBody();
     }
 
@@ -138,9 +137,9 @@ public class RestClient {
     public UserVO findByEmail(String email) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         UriComponentsBuilder url = UriComponentsBuilder.fromHttpUrl(greenCityUserServerAddress
-                + RestTemplateLinks.USER_FIND_BY_EMAIL).queryParam("email", email);
+            + RestTemplateLinks.USER_FIND_BY_EMAIL).queryParam("email", email);
         return restTemplate.exchange(url.toUriString(), HttpMethod.GET,
-                entity, UserVO.class).getBody();
+            entity, UserVO.class).getBody();
     }
 
     /**
@@ -153,8 +152,8 @@ public class RestClient {
     public UserVO findById(Long id) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         return restTemplate.exchange(greenCityUserServerAddress
-                        + RestTemplateLinks.USER_FIND_BY_ID + RestTemplateLinks.ID + id, HttpMethod.GET, entity, UserVO.class)
-                .getBody();
+            + RestTemplateLinks.USER_FIND_BY_ID + RestTemplateLinks.ID + id, HttpMethod.GET, entity, UserVO.class)
+            .getBody();
     }
 
     /**
@@ -167,8 +166,8 @@ public class RestClient {
     public UserVOAchievement findUserForAchievement(Long id) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         return restTemplate.exchange(greenCityUserServerAddress
-                        + RestTemplateLinks.USER_FIND_BY_ID_FOR_ACHIEVEMENT + RestTemplateLinks.ID + id,
-                HttpMethod.GET, entity, UserVOAchievement.class).getBody();
+            + RestTemplateLinks.USER_FIND_BY_ID_FOR_ACHIEVEMENT + RestTemplateLinks.ID + id,
+            HttpMethod.GET, entity, UserVOAchievement.class).getBody();
     }
 
     /**
@@ -188,14 +187,14 @@ public class RestClient {
         }
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         return restTemplate.exchange(greenCityUserServerAddress
-                        + RestTemplateLinks.USER_FIND_USER_FOR_MANAGEMENT + RestTemplateLinks.PAGE + pageable
-                        .getPageNumber()
-                        + RestTemplateLinks.SIZE + pageable
-                        .getPageSize()
-                        + RestTemplateLinks.SORT + orderUrl,
-                HttpMethod.GET, entity,
-                new ParameterizedTypeReference<PageableAdvancedDto<UserManagementDto>>() {
-                }).getBody();
+            + RestTemplateLinks.USER_FIND_USER_FOR_MANAGEMENT + RestTemplateLinks.PAGE + pageable
+                .getPageNumber()
+            + RestTemplateLinks.SIZE + pageable
+                .getPageSize()
+            + RestTemplateLinks.SORT + orderUrl,
+            HttpMethod.GET, entity,
+            new ParameterizedTypeReference<PageableAdvancedDto<UserManagementDto>>() {
+            }).getBody();
     }
 
     /**
@@ -209,13 +208,13 @@ public class RestClient {
     public PageableAdvancedDto<UserManagementDto> searchBy(Pageable pageable, String query) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         UriComponentsBuilder url = UriComponentsBuilder.fromHttpUrl(greenCityUserServerAddress
-                        + RestTemplateLinks.SEARCH_BY)
-                .queryParam("page", pageable.getPageNumber())
-                .queryParam("size", pageable.getPageSize())
-                .queryParam("query", query);
+            + RestTemplateLinks.SEARCH_BY)
+            .queryParam("page", pageable.getPageNumber())
+            .queryParam("size", pageable.getPageSize())
+            .queryParam("query", query);
         return restTemplate.exchange(url.toUriString(), HttpMethod.GET, entity,
-                new ParameterizedTypeReference<PageableAdvancedDto<UserManagementDto>>() {
-                }).getBody();
+            new ParameterizedTypeReference<PageableAdvancedDto<UserManagementDto>>() {
+            }).getBody();
     }
 
     /**
@@ -230,18 +229,18 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<UserManagementUpdateDto> entity = new HttpEntity<>(updateDto, headers);
         restTemplate.exchange(greenCityUserServerAddress
-                + RestTemplateLinks.USER + "/" + userDto.getId(), HttpMethod.PUT, entity, Object.class);
+            + RestTemplateLinks.USER + "/" + userDto.getId(), HttpMethod.PUT, entity, Object.class);
         log.info("User with id {} has been updated", userDto.getId());
     }
 
     private UserManagementUpdateDto managementDtoToUpdateDto(UserManagementDto userDto) {
         return UserManagementUpdateDto.builder()
-                .name(userDto.getName())
-                .email(userDto.getEmail())
-                .userCredo(userDto.getUserCredo())
-                .role(userDto.getRole())
-                .userStatus(userDto.getUserStatus())
-                .build();
+            .name(userDto.getName())
+            .email(userDto.getEmail())
+            .userCredo(userDto.getUserCredo())
+            .role(userDto.getRole())
+            .userStatus(userDto.getUserStatus())
+            .build();
     }
 
     /**
@@ -252,7 +251,7 @@ public class RestClient {
      */
     public void updateRole(Long id, Role role) {
         String url = greenCityUserServerAddress
-                + RestTemplateLinks.USER + "/" + id + "/role";
+            + RestTemplateLinks.USER + "/" + id + "/role";
         HttpHeaders headers = setHeader();
         headers.setContentType(MediaType.APPLICATION_JSON);
         UserRoleDto userRoleDto = new UserRoleDto(role);
@@ -269,7 +268,7 @@ public class RestClient {
     public List<UserVO> findAll() {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         ResponseEntity<UserVO[]> exchange = restTemplate.exchange(greenCityUserServerAddress
-                + RestTemplateLinks.USER_FIND_ALL, HttpMethod.GET, entity, UserVO[].class);
+            + RestTemplateLinks.USER_FIND_ALL, HttpMethod.GET, entity, UserVO[].class);
         UserVO[] responseDtos = exchange.getBody();
         assert responseDtos != null;
         return Arrays.asList(responseDtos);
@@ -284,8 +283,8 @@ public class RestClient {
     public List<UserManagementDto> findUserFriendsByUserId(Long id) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         ResponseEntity<UserManagementDto[]> exchange = restTemplate.exchange(greenCityUserServerAddress
-                        + RestTemplateLinks.USER + "/" + id + RestTemplateLinks.FRIENDS, HttpMethod.GET, entity,
-                UserManagementDto[].class);
+            + RestTemplateLinks.USER + "/" + id + RestTemplateLinks.FRIENDS, HttpMethod.GET, entity,
+            UserManagementDto[].class);
         UserManagementDto[] responseDtos = exchange.getBody();
         assert responseDtos != null;
         return Arrays.asList(responseDtos);
@@ -301,9 +300,9 @@ public class RestClient {
     public Optional<UserVO> findNotDeactivatedByEmail(String email) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         UserVO body = restTemplate.exchange(greenCityUserServerAddress
-                        + RestTemplateLinks.USER_FIND_NOT_DEACTIVATED_BY_EMAIL + RestTemplateLinks.EMAIL
-                        + email, HttpMethod.GET, entity, UserVO.class)
-                .getBody();
+            + RestTemplateLinks.USER_FIND_NOT_DEACTIVATED_BY_EMAIL + RestTemplateLinks.EMAIL
+            + email, HttpMethod.GET, entity, UserVO.class)
+            .getBody();
         assert body != null;
         return Optional.of(body);
     }
@@ -317,7 +316,7 @@ public class RestClient {
     public Long findIdByEmail(String email) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         UriComponentsBuilder url = UriComponentsBuilder.fromHttpUrl(greenCityUserServerAddress
-                + RestTemplateLinks.USER_FIND_ID_BY_EMAIL).queryParam("email", email);
+            + RestTemplateLinks.USER_FIND_ID_BY_EMAIL).queryParam("email", email);
         return restTemplate.exchange(url.toUriString(), HttpMethod.GET, entity, Long.class).getBody();
     }
 
@@ -334,7 +333,7 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<List<String>> entity = new HttpEntity<>(userReasons, headers);
         restTemplate.exchange(greenCityUserServerAddress + RestTemplateLinks.USER_DEACTIVATE
-                + RestTemplateLinks.ID + userId, HttpMethod.PUT, entity, Object.class);
+            + RestTemplateLinks.ID + userId, HttpMethod.PUT, entity, Object.class);
         log.info("User with id {} has been deactivated", userId);
     }
 
@@ -348,7 +347,7 @@ public class RestClient {
     public String getUserLang(Long userId) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         String body = restTemplate.exchange(greenCityUserServerAddress + RestTemplateLinks.USER_LANG
-                + RestTemplateLinks.ID + userId, HttpMethod.GET, entity, String.class).getBody();
+            + RestTemplateLinks.ID + userId, HttpMethod.GET, entity, String.class).getBody();
         assert body != null;
         return body;
     }
@@ -362,7 +361,7 @@ public class RestClient {
     public void setActivatedStatus(Long userId) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         restTemplate.exchange(greenCityUserServerAddress + RestTemplateLinks.USER_ACTIVATE
-                + RestTemplateLinks.ID + userId, HttpMethod.PUT, entity, Object.class);
+            + RestTemplateLinks.ID + userId, HttpMethod.PUT, entity, Object.class);
     }
 
     /**
@@ -378,8 +377,8 @@ public class RestClient {
     public List<String> getDeactivationReason(Long userId, String adminLang) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         String[] reasonDtos = restTemplate.exchange(greenCityUserServerAddress + RestTemplateLinks.USER_REASONS
-                + RestTemplateLinks.ID + userId
-                + RestTemplateLinks.ADMIN_LANG + adminLang, HttpMethod.GET, entity, String[].class).getBody();
+            + RestTemplateLinks.ID + userId
+            + RestTemplateLinks.ADMIN_LANG + adminLang, HttpMethod.GET, entity, String[].class).getBody();
         assert reasonDtos != null;
         return Arrays.asList(reasonDtos);
     }
@@ -399,8 +398,8 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<String> entity = new HttpEntity<>(json, headers);
         restTemplate.exchange(greenCityUserServerAddress
-                + RestTemplateLinks.USER_DEACTIVATE
-                + RestTemplateLinks.ID + listId, HttpMethod.PUT, entity, Long[].class);
+            + RestTemplateLinks.USER_DEACTIVATE
+            + RestTemplateLinks.ID + listId, HttpMethod.PUT, entity, Long[].class);
     }
 
     /**
@@ -414,7 +413,7 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<UserManagementDto> entity = new HttpEntity<>(userDto, headers);
         restTemplate.exchange(greenCityUserServerAddress
-                + RestTemplateLinks.OWN_SECURITY_REGISTER, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.OWN_SECURITY_REGISTER, HttpMethod.POST, entity, Object.class);
     }
 
     /**
@@ -428,7 +427,7 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<EcoNewsForSendEmailDto> entity = new HttpEntity<>(message, headers);
         restTemplate.exchange(greenCityUserServerAddress
-                + RestTemplateLinks.ADD_ECO_NEWS, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.ADD_ECO_NEWS, HttpMethod.POST, entity, Object.class);
     }
 
     /**
@@ -443,7 +442,7 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<EventCommentForSendEmailDto> entity = new HttpEntity<>(message, headers);
         restTemplate.exchange(greenCityUserServerAddress
-                + RestTemplateLinks.ADD_EVENT_COMMENT, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.ADD_EVENT_COMMENT, HttpMethod.POST, entity, Object.class);
     }
 
     /**
@@ -458,7 +457,7 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<SendReportEmailMessage> entity = new HttpEntity<>(reportEmailMessage, headers);
         restTemplate.exchange(greenCityUserServerAddress
-                + RestTemplateLinks.SEND_REPORT, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.SEND_REPORT, HttpMethod.POST, entity, Object.class);
     }
 
     /**
@@ -470,7 +469,7 @@ public class RestClient {
     public void scheduleDeleteDeactivatedUsers() {
         HttpEntity<String> entity = new HttpEntity<>(new HttpHeaders());
         restTemplate.exchange(greenCityUserServerAddress + RestTemplateLinks.DELETE_DEACTIVATED_USERS,
-                HttpMethod.POST, entity, Object.class);
+            HttpMethod.POST, entity, Object.class);
     }
 
     /**
@@ -485,9 +484,9 @@ public class RestClient {
         HttpHeaders headers = setHeader();
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<SendChangePlaceStatusEmailMessage> entity =
-                new HttpEntity<>(changePlaceStatusEmailMessage, headers);
+            new HttpEntity<>(changePlaceStatusEmailMessage, headers);
         restTemplate.exchange(greenCityUserServerAddress
-                + RestTemplateLinks.CHANGE_PLACE_STATUS, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.CHANGE_PLACE_STATUS, HttpMethod.POST, entity, Object.class);
     }
 
     /**
@@ -502,7 +501,7 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<SendHabitNotification> entity = new HttpEntity<>(sendHabitNotification, headers);
         restTemplate.exchange(greenCityUserServerAddress
-                + RestTemplateLinks.SEND_HABIT_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.SEND_HABIT_NOTIFICATION, HttpMethod.POST, entity, Object.class);
     }
 
     /**
@@ -525,13 +524,13 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<UserManagementViewDto> entity = new HttpEntity<>(userViewDto, headers);
         return restTemplate.exchange(
-                greenCityUserServerAddress + RestTemplateLinks.USER_SEARCH + RestTemplateLinks.PAGE
-                        + pageable.getPageNumber()
-                        + RestTemplateLinks.SIZE + pageable.getPageSize()
-                        + RestTemplateLinks.SORT + orderUrl,
-                HttpMethod.POST, entity,
-                new ParameterizedTypeReference<PageableAdvancedDto<UserManagementVO>>() {
-                }).getBody();
+            greenCityUserServerAddress + RestTemplateLinks.USER_SEARCH + RestTemplateLinks.PAGE
+                + pageable.getPageNumber()
+                + RestTemplateLinks.SIZE + pageable.getPageSize()
+                + RestTemplateLinks.SORT + orderUrl,
+            HttpMethod.POST, entity,
+            new ParameterizedTypeReference<PageableAdvancedDto<UserManagementVO>>() {
+            }).getBody();
     }
 
     /**
@@ -559,9 +558,9 @@ public class RestClient {
 
     private String getTokenFromCookies(Cookie[] cookies) {
         String token = Arrays.stream(cookies)
-                .filter(c -> c.getName().equals("accessToken"))
-                .findFirst()
-                .map(Cookie::getValue).orElse(null);
+            .filter(c -> c.getName().equals("accessToken"))
+            .findFirst()
+            .map(Cookie::getValue).orElse(null);
         return token == null ? null : "Bearer " + token;
     }
 
@@ -575,7 +574,7 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<GeneralEmailMessage> entity = new HttpEntity<>(notification, headers);
         restTemplate.exchange(greenCityUserServerAddress
-                + RestTemplateLinks.SEND_GENERAL_EMAIL_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.SEND_GENERAL_EMAIL_NOTIFICATION, HttpMethod.POST, entity, Object.class);
         log.info("Email notification has been sent to {}", notification.getEmail());
     }
 
@@ -589,7 +588,7 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<HabitAssignNotificationMessage> entity = new HttpEntity<>(message, headers);
         restTemplate.exchange(greenCityUserServerAddress
-                + RestTemplateLinks.SEND_HABIT_ASSIGN_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.SEND_HABIT_ASSIGN_NOTIFICATION, HttpMethod.POST, entity, Object.class);
     }
 
     /**
@@ -602,7 +601,7 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<UserTaggedInCommentMessage> entity = new HttpEntity<>(message, headers);
         restTemplate.exchange(greenCityUserServerAddress
-                + RestTemplateLinks.SEND_USERS_MENTION_IN_COMMENT_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.SEND_USERS_MENTION_IN_COMMENT_NOTIFICATION, HttpMethod.POST, entity, Object.class);
     }
 
     /**
@@ -610,13 +609,13 @@ public class RestClient {
      *
      * @param message {@link ScheduledEmailMessage}.
      */
-    public void sendScheduledEmailNotification(ScheduledEmailMessage message){
+    public void sendScheduledEmailNotification(ScheduledEmailMessage message) {
         String accessToken = "Bearer " + jwtTool.createAccessToken(systemEmail, Role.ROLE_ADMIN);
         HttpHeaders headers = new HttpHeaders();
         headers.set(AUTHORIZATION, accessToken);
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<ScheduledEmailMessage> entity = new HttpEntity<>(message, headers);
         restTemplate.exchange(greenCityUserServerAddress
-                + RestTemplateLinks.SEND_SCHEDULED_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.SEND_SCHEDULED_NOTIFICATION, HttpMethod.POST, entity, Object.class);
     }
 }

--- a/service-api/src/main/java/greencity/client/RestClient.java
+++ b/service-api/src/main/java/greencity/client/RestClient.java
@@ -1,5 +1,6 @@
 package greencity.client;
 
+import greencity.constant.AppConstant;
 import greencity.dto.user.UserManagementDto;
 import greencity.dto.user.UserManagementUpdateDto;
 import greencity.dto.user.UserManagementVO;
@@ -54,6 +55,7 @@ public class RestClient {
     private final HttpServletRequest httpServletRequest;
     private final JwtTool jwtTool;
     private final String systemEmail;
+
 
     /**
      * Constructs a new instance of the RestClient class.
@@ -548,7 +550,7 @@ public class RestClient {
         }
 
         if (!StringUtils.hasLength(accessToken)) {
-            accessToken = "Bearer " + jwtTool.createAccessToken(systemEmail, Role.ROLE_ADMIN);
+            accessToken = AppConstant.TOKEN_PREFIX + jwtTool.createAccessToken(systemEmail, Role.ROLE_ADMIN);
         }
 
         HttpHeaders headers = new HttpHeaders();
@@ -561,7 +563,7 @@ public class RestClient {
             .filter(c -> c.getName().equals("accessToken"))
             .findFirst()
             .map(Cookie::getValue).orElse(null);
-        return token == null ? null : "Bearer " + token;
+        return token == null ? null : AppConstant.TOKEN_PREFIX + token;
     }
 
     /**
@@ -610,7 +612,7 @@ public class RestClient {
      * @param message {@link ScheduledEmailMessage}.
      */
     public void sendScheduledEmailNotification(ScheduledEmailMessage message) {
-        String accessToken = "Bearer " + jwtTool.createAccessToken(systemEmail, Role.ROLE_ADMIN);
+        String accessToken = AppConstant.TOKEN_PREFIX + jwtTool.createAccessToken(systemEmail, Role.ROLE_ADMIN);
         HttpHeaders headers = new HttpHeaders();
         headers.set(AUTHORIZATION, accessToken);
         headers.setContentType(MediaType.APPLICATION_JSON);

--- a/service-api/src/main/java/greencity/client/RestClient.java
+++ b/service-api/src/main/java/greencity/client/RestClient.java
@@ -56,7 +56,6 @@ public class RestClient {
     private final JwtTool jwtTool;
     private final String systemEmail;
 
-
     /**
      * Constructs a new instance of the RestClient class.
      *

--- a/service-api/src/main/java/greencity/client/RestClient.java
+++ b/service-api/src/main/java/greencity/client/RestClient.java
@@ -13,11 +13,11 @@ import java.util.Map;
 import java.util.Optional;
 import greencity.message.GeneralEmailMessage;
 import greencity.message.HabitAssignNotificationMessage;
+import greencity.message.ScheduledEmailMessage;
 import greencity.message.SendChangePlaceStatusEmailMessage;
 import greencity.message.SendHabitNotification;
 import greencity.message.SendReportEmailMessage;
 import greencity.message.UserReceivedCommentMessage;
-import greencity.message.UserReceivedCommentReplyMessage;
 import greencity.message.UserTaggedInCommentMessage;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -71,10 +71,10 @@ public class RestClient {
      *                                   GreenCityUser.
      */
     public RestClient(RestTemplate restTemplate,
-        @Value("${greencityuser.server.address}") String greenCityUserServerAddress,
-        HttpServletRequest httpServletRequest,
-        JwtTool jwtTool,
-        @Value("${spring.liquibase.parameters.service-email}") String systemEmail) {
+                      @Value("${greencityuser.server.address}") String greenCityUserServerAddress,
+                      HttpServletRequest httpServletRequest,
+                      JwtTool jwtTool,
+                      @Value("${spring.liquibase.parameters.service-email}") String systemEmail) {
         this.restTemplate = restTemplate;
         this.greenCityUserServerAddress = greenCityUserServerAddress;
         this.httpServletRequest = httpServletRequest;
@@ -92,10 +92,10 @@ public class RestClient {
     public List<UserVO> findAllByEmailNotification(EmailNotification emailNotification) {
         HttpEntity<String> entity = new HttpEntity<>(new HttpHeaders());
         ResponseEntity<List<UserVO>> exchange = restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.USER_FIND_ALL_BY_EMAIL_NOTIFICATION
-            + RestTemplateLinks.EMAIL_NOTIFICATION + emailNotification,
-            HttpMethod.GET, entity, new ParameterizedTypeReference<>() {
-            });
+                        + RestTemplateLinks.USER_FIND_ALL_BY_EMAIL_NOTIFICATION
+                        + RestTemplateLinks.EMAIL_NOTIFICATION + emailNotification,
+                HttpMethod.GET, entity, new ParameterizedTypeReference<>() {
+                });
         return exchange.getBody();
     }
 
@@ -108,9 +108,9 @@ public class RestClient {
     public List<String> findAllUsersCities() {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         ResponseEntity<List<String>> exchange = restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.FIND_ALL_USERS_CITIES,
-            HttpMethod.GET, entity, new ParameterizedTypeReference<>() {
-            });
+                        + RestTemplateLinks.FIND_ALL_USERS_CITIES,
+                HttpMethod.GET, entity, new ParameterizedTypeReference<>() {
+                });
         return exchange.getBody();
     }
 
@@ -123,9 +123,9 @@ public class RestClient {
     public Map<Integer, Long> findAllRegistrationMonthsMap() {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         ResponseEntity<Map<Integer, Long>> exchange = restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.FIND_ALL_REGISTRATION_MONTHS_MAP,
-            HttpMethod.GET, entity, new ParameterizedTypeReference<>() {
-            });
+                        + RestTemplateLinks.FIND_ALL_REGISTRATION_MONTHS_MAP,
+                HttpMethod.GET, entity, new ParameterizedTypeReference<>() {
+                });
         return exchange.getBody();
     }
 
@@ -138,9 +138,9 @@ public class RestClient {
     public UserVO findByEmail(String email) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         UriComponentsBuilder url = UriComponentsBuilder.fromHttpUrl(greenCityUserServerAddress
-            + RestTemplateLinks.USER_FIND_BY_EMAIL).queryParam("email", email);
+                + RestTemplateLinks.USER_FIND_BY_EMAIL).queryParam("email", email);
         return restTemplate.exchange(url.toUriString(), HttpMethod.GET,
-            entity, UserVO.class).getBody();
+                entity, UserVO.class).getBody();
     }
 
     /**
@@ -153,8 +153,8 @@ public class RestClient {
     public UserVO findById(Long id) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         return restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.USER_FIND_BY_ID + RestTemplateLinks.ID + id, HttpMethod.GET, entity, UserVO.class)
-            .getBody();
+                        + RestTemplateLinks.USER_FIND_BY_ID + RestTemplateLinks.ID + id, HttpMethod.GET, entity, UserVO.class)
+                .getBody();
     }
 
     /**
@@ -167,8 +167,8 @@ public class RestClient {
     public UserVOAchievement findUserForAchievement(Long id) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         return restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.USER_FIND_BY_ID_FOR_ACHIEVEMENT + RestTemplateLinks.ID + id,
-            HttpMethod.GET, entity, UserVOAchievement.class).getBody();
+                        + RestTemplateLinks.USER_FIND_BY_ID_FOR_ACHIEVEMENT + RestTemplateLinks.ID + id,
+                HttpMethod.GET, entity, UserVOAchievement.class).getBody();
     }
 
     /**
@@ -188,14 +188,14 @@ public class RestClient {
         }
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         return restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.USER_FIND_USER_FOR_MANAGEMENT + RestTemplateLinks.PAGE + pageable
-                .getPageNumber()
-            + RestTemplateLinks.SIZE + pageable
-                .getPageSize()
-            + RestTemplateLinks.SORT + orderUrl,
-            HttpMethod.GET, entity,
-            new ParameterizedTypeReference<PageableAdvancedDto<UserManagementDto>>() {
-            }).getBody();
+                        + RestTemplateLinks.USER_FIND_USER_FOR_MANAGEMENT + RestTemplateLinks.PAGE + pageable
+                        .getPageNumber()
+                        + RestTemplateLinks.SIZE + pageable
+                        .getPageSize()
+                        + RestTemplateLinks.SORT + orderUrl,
+                HttpMethod.GET, entity,
+                new ParameterizedTypeReference<PageableAdvancedDto<UserManagementDto>>() {
+                }).getBody();
     }
 
     /**
@@ -209,13 +209,13 @@ public class RestClient {
     public PageableAdvancedDto<UserManagementDto> searchBy(Pageable pageable, String query) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         UriComponentsBuilder url = UriComponentsBuilder.fromHttpUrl(greenCityUserServerAddress
-            + RestTemplateLinks.SEARCH_BY)
-            .queryParam("page", pageable.getPageNumber())
-            .queryParam("size", pageable.getPageSize())
-            .queryParam("query", query);
+                        + RestTemplateLinks.SEARCH_BY)
+                .queryParam("page", pageable.getPageNumber())
+                .queryParam("size", pageable.getPageSize())
+                .queryParam("query", query);
         return restTemplate.exchange(url.toUriString(), HttpMethod.GET, entity,
-            new ParameterizedTypeReference<PageableAdvancedDto<UserManagementDto>>() {
-            }).getBody();
+                new ParameterizedTypeReference<PageableAdvancedDto<UserManagementDto>>() {
+                }).getBody();
     }
 
     /**
@@ -230,18 +230,18 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<UserManagementUpdateDto> entity = new HttpEntity<>(updateDto, headers);
         restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.USER + "/" + userDto.getId(), HttpMethod.PUT, entity, Object.class);
+                + RestTemplateLinks.USER + "/" + userDto.getId(), HttpMethod.PUT, entity, Object.class);
         log.info("User with id {} has been updated", userDto.getId());
     }
 
     private UserManagementUpdateDto managementDtoToUpdateDto(UserManagementDto userDto) {
         return UserManagementUpdateDto.builder()
-            .name(userDto.getName())
-            .email(userDto.getEmail())
-            .userCredo(userDto.getUserCredo())
-            .role(userDto.getRole())
-            .userStatus(userDto.getUserStatus())
-            .build();
+                .name(userDto.getName())
+                .email(userDto.getEmail())
+                .userCredo(userDto.getUserCredo())
+                .role(userDto.getRole())
+                .userStatus(userDto.getUserStatus())
+                .build();
     }
 
     /**
@@ -252,7 +252,7 @@ public class RestClient {
      */
     public void updateRole(Long id, Role role) {
         String url = greenCityUserServerAddress
-            + RestTemplateLinks.USER + "/" + id + "/role";
+                + RestTemplateLinks.USER + "/" + id + "/role";
         HttpHeaders headers = setHeader();
         headers.setContentType(MediaType.APPLICATION_JSON);
         UserRoleDto userRoleDto = new UserRoleDto(role);
@@ -269,7 +269,7 @@ public class RestClient {
     public List<UserVO> findAll() {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         ResponseEntity<UserVO[]> exchange = restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.USER_FIND_ALL, HttpMethod.GET, entity, UserVO[].class);
+                + RestTemplateLinks.USER_FIND_ALL, HttpMethod.GET, entity, UserVO[].class);
         UserVO[] responseDtos = exchange.getBody();
         assert responseDtos != null;
         return Arrays.asList(responseDtos);
@@ -284,8 +284,8 @@ public class RestClient {
     public List<UserManagementDto> findUserFriendsByUserId(Long id) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         ResponseEntity<UserManagementDto[]> exchange = restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.USER + "/" + id + RestTemplateLinks.FRIENDS, HttpMethod.GET, entity,
-            UserManagementDto[].class);
+                        + RestTemplateLinks.USER + "/" + id + RestTemplateLinks.FRIENDS, HttpMethod.GET, entity,
+                UserManagementDto[].class);
         UserManagementDto[] responseDtos = exchange.getBody();
         assert responseDtos != null;
         return Arrays.asList(responseDtos);
@@ -301,9 +301,9 @@ public class RestClient {
     public Optional<UserVO> findNotDeactivatedByEmail(String email) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         UserVO body = restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.USER_FIND_NOT_DEACTIVATED_BY_EMAIL + RestTemplateLinks.EMAIL
-            + email, HttpMethod.GET, entity, UserVO.class)
-            .getBody();
+                        + RestTemplateLinks.USER_FIND_NOT_DEACTIVATED_BY_EMAIL + RestTemplateLinks.EMAIL
+                        + email, HttpMethod.GET, entity, UserVO.class)
+                .getBody();
         assert body != null;
         return Optional.of(body);
     }
@@ -317,7 +317,7 @@ public class RestClient {
     public Long findIdByEmail(String email) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         UriComponentsBuilder url = UriComponentsBuilder.fromHttpUrl(greenCityUserServerAddress
-            + RestTemplateLinks.USER_FIND_ID_BY_EMAIL).queryParam("email", email);
+                + RestTemplateLinks.USER_FIND_ID_BY_EMAIL).queryParam("email", email);
         return restTemplate.exchange(url.toUriString(), HttpMethod.GET, entity, Long.class).getBody();
     }
 
@@ -334,7 +334,7 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<List<String>> entity = new HttpEntity<>(userReasons, headers);
         restTemplate.exchange(greenCityUserServerAddress + RestTemplateLinks.USER_DEACTIVATE
-            + RestTemplateLinks.ID + userId, HttpMethod.PUT, entity, Object.class);
+                + RestTemplateLinks.ID + userId, HttpMethod.PUT, entity, Object.class);
         log.info("User with id {} has been deactivated", userId);
     }
 
@@ -348,7 +348,7 @@ public class RestClient {
     public String getUserLang(Long userId) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         String body = restTemplate.exchange(greenCityUserServerAddress + RestTemplateLinks.USER_LANG
-            + RestTemplateLinks.ID + userId, HttpMethod.GET, entity, String.class).getBody();
+                + RestTemplateLinks.ID + userId, HttpMethod.GET, entity, String.class).getBody();
         assert body != null;
         return body;
     }
@@ -362,7 +362,7 @@ public class RestClient {
     public void setActivatedStatus(Long userId) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         restTemplate.exchange(greenCityUserServerAddress + RestTemplateLinks.USER_ACTIVATE
-            + RestTemplateLinks.ID + userId, HttpMethod.PUT, entity, Object.class);
+                + RestTemplateLinks.ID + userId, HttpMethod.PUT, entity, Object.class);
     }
 
     /**
@@ -378,8 +378,8 @@ public class RestClient {
     public List<String> getDeactivationReason(Long userId, String adminLang) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         String[] reasonDtos = restTemplate.exchange(greenCityUserServerAddress + RestTemplateLinks.USER_REASONS
-            + RestTemplateLinks.ID + userId
-            + RestTemplateLinks.ADMIN_LANG + adminLang, HttpMethod.GET, entity, String[].class).getBody();
+                + RestTemplateLinks.ID + userId
+                + RestTemplateLinks.ADMIN_LANG + adminLang, HttpMethod.GET, entity, String[].class).getBody();
         assert reasonDtos != null;
         return Arrays.asList(reasonDtos);
     }
@@ -399,8 +399,8 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<String> entity = new HttpEntity<>(json, headers);
         restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.USER_DEACTIVATE
-            + RestTemplateLinks.ID + listId, HttpMethod.PUT, entity, Long[].class);
+                + RestTemplateLinks.USER_DEACTIVATE
+                + RestTemplateLinks.ID + listId, HttpMethod.PUT, entity, Long[].class);
     }
 
     /**
@@ -414,7 +414,7 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<UserManagementDto> entity = new HttpEntity<>(userDto, headers);
         restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.OWN_SECURITY_REGISTER, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.OWN_SECURITY_REGISTER, HttpMethod.POST, entity, Object.class);
     }
 
     /**
@@ -428,7 +428,7 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<EcoNewsForSendEmailDto> entity = new HttpEntity<>(message, headers);
         restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.ADD_ECO_NEWS, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.ADD_ECO_NEWS, HttpMethod.POST, entity, Object.class);
     }
 
     /**
@@ -443,7 +443,7 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<EventCommentForSendEmailDto> entity = new HttpEntity<>(message, headers);
         restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.ADD_EVENT_COMMENT, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.ADD_EVENT_COMMENT, HttpMethod.POST, entity, Object.class);
     }
 
     /**
@@ -458,7 +458,7 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<SendReportEmailMessage> entity = new HttpEntity<>(reportEmailMessage, headers);
         restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.SEND_REPORT, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.SEND_REPORT, HttpMethod.POST, entity, Object.class);
     }
 
     /**
@@ -470,7 +470,7 @@ public class RestClient {
     public void scheduleDeleteDeactivatedUsers() {
         HttpEntity<String> entity = new HttpEntity<>(new HttpHeaders());
         restTemplate.exchange(greenCityUserServerAddress + RestTemplateLinks.DELETE_DEACTIVATED_USERS,
-            HttpMethod.POST, entity, Object.class);
+                HttpMethod.POST, entity, Object.class);
     }
 
     /**
@@ -485,9 +485,9 @@ public class RestClient {
         HttpHeaders headers = setHeader();
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<SendChangePlaceStatusEmailMessage> entity =
-            new HttpEntity<>(changePlaceStatusEmailMessage, headers);
+                new HttpEntity<>(changePlaceStatusEmailMessage, headers);
         restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.CHANGE_PLACE_STATUS, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.CHANGE_PLACE_STATUS, HttpMethod.POST, entity, Object.class);
     }
 
     /**
@@ -502,7 +502,7 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<SendHabitNotification> entity = new HttpEntity<>(sendHabitNotification, headers);
         restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.SEND_HABIT_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.SEND_HABIT_NOTIFICATION, HttpMethod.POST, entity, Object.class);
     }
 
     /**
@@ -525,13 +525,13 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<UserManagementViewDto> entity = new HttpEntity<>(userViewDto, headers);
         return restTemplate.exchange(
-            greenCityUserServerAddress + RestTemplateLinks.USER_SEARCH + RestTemplateLinks.PAGE
-                + pageable.getPageNumber()
-                + RestTemplateLinks.SIZE + pageable.getPageSize()
-                + RestTemplateLinks.SORT + orderUrl,
-            HttpMethod.POST, entity,
-            new ParameterizedTypeReference<PageableAdvancedDto<UserManagementVO>>() {
-            }).getBody();
+                greenCityUserServerAddress + RestTemplateLinks.USER_SEARCH + RestTemplateLinks.PAGE
+                        + pageable.getPageNumber()
+                        + RestTemplateLinks.SIZE + pageable.getPageSize()
+                        + RestTemplateLinks.SORT + orderUrl,
+                HttpMethod.POST, entity,
+                new ParameterizedTypeReference<PageableAdvancedDto<UserManagementVO>>() {
+                }).getBody();
     }
 
     /**
@@ -559,9 +559,9 @@ public class RestClient {
 
     private String getTokenFromCookies(Cookie[] cookies) {
         String token = Arrays.stream(cookies)
-            .filter(c -> c.getName().equals("accessToken"))
-            .findFirst()
-            .map(Cookie::getValue).orElse(null);
+                .filter(c -> c.getName().equals("accessToken"))
+                .findFirst()
+                .map(Cookie::getValue).orElse(null);
         return token == null ? null : "Bearer " + token;
     }
 
@@ -575,7 +575,7 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<GeneralEmailMessage> entity = new HttpEntity<>(notification, headers);
         restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.SEND_GENERAL_EMAIL_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.SEND_GENERAL_EMAIL_NOTIFICATION, HttpMethod.POST, entity, Object.class);
         log.info("Email notification has been sent to {}", notification.getEmail());
     }
 
@@ -589,7 +589,7 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<HabitAssignNotificationMessage> entity = new HttpEntity<>(message, headers);
         restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.SEND_HABIT_ASSIGN_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.SEND_HABIT_ASSIGN_NOTIFICATION, HttpMethod.POST, entity, Object.class);
     }
 
     /**
@@ -602,32 +602,21 @@ public class RestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<UserTaggedInCommentMessage> entity = new HttpEntity<>(message, headers);
         restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.SEND_USERS_MENTION_IN_COMMENT_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.SEND_USERS_MENTION_IN_COMMENT_NOTIFICATION, HttpMethod.POST, entity, Object.class);
     }
 
     /**
-     * Method sends email notification when user has received comment.
+     * Method sends scheduled email notification.
      *
-     * @param message {@link UserReceivedCommentMessage}.
+     * @param message {@link ScheduledEmailMessage}.
      */
-    public void sendUserReceivedCommentNotification(UserReceivedCommentMessage message) {
-        HttpHeaders headers = setHeader();
+    public void sendScheduledEmailNotification(ScheduledEmailMessage message){
+        String accessToken = "Bearer " + jwtTool.createAccessToken(systemEmail, Role.ROLE_ADMIN);
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(AUTHORIZATION, accessToken);
         headers.setContentType(MediaType.APPLICATION_JSON);
-        HttpEntity<UserReceivedCommentMessage> entity = new HttpEntity<>(message, headers);
+        HttpEntity<ScheduledEmailMessage> entity = new HttpEntity<>(message, headers);
         restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.SEND_USER_RECEIVED_COMMENT_NOTIFICATION, HttpMethod.POST, entity, Object.class);
-    }
-
-    /**
-     * Method sends email notification when user has received reply to the comment.
-     *
-     * @param message {@link UserReceivedCommentMessage}.
-     */
-    public void sendUserReceivedCommentReplyNotification(UserReceivedCommentReplyMessage message) {
-        HttpHeaders headers = setHeader();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        HttpEntity<UserReceivedCommentReplyMessage> entity = new HttpEntity<>(message, headers);
-        restTemplate.exchange(greenCityUserServerAddress
-            + RestTemplateLinks.SEND_USER_RECEIVED_COMMENT_REPLY_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.SEND_SCHEDULED_NOTIFICATION, HttpMethod.POST, entity, Object.class);
     }
 }

--- a/service-api/src/main/java/greencity/constant/AppConstant.java
+++ b/service-api/src/main/java/greencity/constant/AppConstant.java
@@ -23,4 +23,5 @@ public class AppConstant {
     public static final String DEFAULT_HABIT_IMAGE = "img/habit-default.png";
     public static final String DEFAULT_EVENT_IMAGES = "img/habits/default-habit-image.png";
     public static final String SELF_ACHIEVEMENT_CATEGORY = "ACHIEVEMENT";
+    public static final String TOKEN_PREFIX = "Bearer ";
 }

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -129,7 +129,7 @@ public class ErrorMessage {
     public static final String COMMENT_NOT_FOUND_BY_PARENT_COMMENT_ID =
         "The comment with entered parent_comment_id doesn't exist";
     public static final String COMMENT_PROPERTY_TYPE_NOT_FOUND = "For type comment not found this property :";
-    public static final String CANNOT_REPLY_THE_REPLY = "You can't reply on reply";
+    public static final String CANNOT_REPLY_THE_REPLY = "Can not make a reply to a reply";
     public static final String NOT_A_CURRENT_USER = "You can't perform actions with the data of other user";
     public static final String FAVORITE_PLACE_ALREADY_EXISTS =
         "Favorite place already exist for this placeId: %d and user with email: %s";
@@ -189,6 +189,4 @@ public class ErrorMessage {
         "No friends are assigned on current habit with id: ";
     public static final String INVALID_TIME_RANGE = "Start date and end date must be greater than end date";
     public static final String NOT_FOUND_IN_CURRENT_TIME_RANGE = "Not found backups in current time range";
-    public static final String COMMENT_NOT_FOUND_BY_ID = "Comment doesn't exist by this id: ";
-    public static final String EMPTY_HABIT_ASSIGN_LIST = "Habit Assigns list cannot be empty";
 }

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -129,7 +129,7 @@ public class ErrorMessage {
     public static final String COMMENT_NOT_FOUND_BY_PARENT_COMMENT_ID =
         "The comment with entered parent_comment_id doesn't exist";
     public static final String COMMENT_PROPERTY_TYPE_NOT_FOUND = "For type comment not found this property :";
-    public static final String CANNOT_REPLY_THE_REPLY = "Can not make a reply to a reply";
+    public static final String CANNOT_REPLY_THE_REPLY = "You can't reply on reply";
     public static final String NOT_A_CURRENT_USER = "You can't perform actions with the data of other user";
     public static final String FAVORITE_PLACE_ALREADY_EXISTS =
         "Favorite place already exist for this placeId: %d and user with email: %s";
@@ -189,4 +189,6 @@ public class ErrorMessage {
         "No friends are assigned on current habit with id: ";
     public static final String INVALID_TIME_RANGE = "Start date and end date must be greater than end date";
     public static final String NOT_FOUND_IN_CURRENT_TIME_RANGE = "Not found backups in current time range";
+    public static final String COMMENT_NOT_FOUND_BY_ID = "Comment doesn't exist by this id: ";
+    public static final String EMPTY_HABIT_ASSIGN_LIST = "Habit Assigns list cannot be empty";
 }

--- a/service-api/src/main/java/greencity/constant/LogMessage.java
+++ b/service-api/src/main/java/greencity/constant/LogMessage.java
@@ -24,12 +24,13 @@ public final class LogMessage {
     public static final String IN_AVERAGE_RATE = "in averageRate(), id: {}";
     public static final String PLACE_STATUS_NOT_DIFFERENT = "the place with id: {} already has status: {}";
     public static final String IN_DELETE_BY_PLACE_ID_AND_USER_EMAIL =
-        "in deleteByPlaceIdAndUserEmail(), place id: {} and status: {} ";
+            "in deleteByPlaceIdAndUserEmail(), place id: {} and status: {} ";
     public static final String IN_FIND_BY_PLACE_ID = "in findById(), placeId: {}";
     public static final String IN_GET_ACCESS_PLACE_AS_FAVORITE_PLACE =
-        "in getAccessPlaceAsFavoritePlace(), placeId: {}";
+            "in getAccessPlaceAsFavoritePlace(), placeId: {}";
     public static final String IN_GET_FAVORITE_PLACE_WITH_LOCATION =
-        "in getFavoritePlaceWithLocation(), place id: {} and email: {}";
+            "in getFavoritePlaceWithLocation(), place id: {} and email: {}";
+    public static final String IN_SEND_SCHEDULED_EMAIL = "in sendEmail(), time: {}, type: {}";
 
     private LogMessage() {
     }

--- a/service-api/src/main/java/greencity/constant/LogMessage.java
+++ b/service-api/src/main/java/greencity/constant/LogMessage.java
@@ -24,12 +24,12 @@ public final class LogMessage {
     public static final String IN_AVERAGE_RATE = "in averageRate(), id: {}";
     public static final String PLACE_STATUS_NOT_DIFFERENT = "the place with id: {} already has status: {}";
     public static final String IN_DELETE_BY_PLACE_ID_AND_USER_EMAIL =
-            "in deleteByPlaceIdAndUserEmail(), place id: {} and status: {} ";
+        "in deleteByPlaceIdAndUserEmail(), place id: {} and status: {} ";
     public static final String IN_FIND_BY_PLACE_ID = "in findById(), placeId: {}";
     public static final String IN_GET_ACCESS_PLACE_AS_FAVORITE_PLACE =
-            "in getAccessPlaceAsFavoritePlace(), placeId: {}";
+        "in getAccessPlaceAsFavoritePlace(), placeId: {}";
     public static final String IN_GET_FAVORITE_PLACE_WITH_LOCATION =
-            "in getFavoritePlaceWithLocation(), place id: {} and email: {}";
+        "in getFavoritePlaceWithLocation(), place id: {} and email: {}";
     public static final String IN_SEND_SCHEDULED_EMAIL = "in sendEmail(), time: {}, type: {}";
 
     private LogMessage() {

--- a/service-api/src/main/java/greencity/constant/RestTemplateLinks.java
+++ b/service-api/src/main/java/greencity/constant/RestTemplateLinks.java
@@ -37,12 +37,8 @@ public class RestTemplateLinks {
     public static final String SEND_GENERAL_EMAIL_NOTIFICATION = "/email/general/notification";
     public static final String SEND_HABIT_ASSIGN_NOTIFICATION = "/email/habitAssign/notification";
     public static final String SEND_USERS_MENTION_IN_COMMENT_NOTIFICATION = "/email/taggedUserInComment/notification";
-    public static final String SEND_USER_RECEIVED_COMMENT_NOTIFICATION = "/email/userReceivedComment/notification";
-    public static final String SEND_USER_RECEIVED_COMMENT_REPLY_NOTIFICATION =
-            "/email/userReceivedCommentReply/notification";
-    public static final String SEND_USER_RECEIVED_LIKE_NOTIFICATION = "/email/userReceivedLike/notification";
-    public static final String SEND_USER_RECEIVED_FRIEND_REQUEST_NOTIFICATION = "/email/userFriendRequest/notification";
     public static final String SEND_SCHEDULED_NOTIFICATION = "/email/scheduled/notification";
+
     private RestTemplateLinks() {
     }
 }

--- a/service-api/src/main/java/greencity/constant/RestTemplateLinks.java
+++ b/service-api/src/main/java/greencity/constant/RestTemplateLinks.java
@@ -39,8 +39,10 @@ public class RestTemplateLinks {
     public static final String SEND_USERS_MENTION_IN_COMMENT_NOTIFICATION = "/email/taggedUserInComment/notification";
     public static final String SEND_USER_RECEIVED_COMMENT_NOTIFICATION = "/email/userReceivedComment/notification";
     public static final String SEND_USER_RECEIVED_COMMENT_REPLY_NOTIFICATION =
-        "/email/userReceivedCommentReply/notification";
-
+            "/email/userReceivedCommentReply/notification";
+    public static final String SEND_USER_RECEIVED_LIKE_NOTIFICATION = "/email/userReceivedLike/notification";
+    public static final String SEND_USER_RECEIVED_FRIEND_REQUEST_NOTIFICATION = "/email/userFriendRequest/notification";
+    public static final String SEND_SCHEDULED_NOTIFICATION = "/email/scheduled/notification";
     private RestTemplateLinks() {
     }
 }

--- a/service-api/src/main/java/greencity/message/ScheduledEmailMessage.java
+++ b/service-api/src/main/java/greencity/message/ScheduledEmailMessage.java
@@ -1,0 +1,27 @@
+package greencity.message;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.io.Serializable;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ScheduledEmailMessage implements Serializable {
+    @NotEmpty(message = "Username cannot be empty")
+    private String username;
+    @NotEmpty(message = "Email cannot be empty")
+    private String email;
+    @NotEmpty(message = "Link cannot be empty")
+    private String baseLink;
+    @NotEmpty(message = "Subject cannot be empty")
+    private String subject;
+    @NotEmpty(message = "Body cannot be empty")
+    private String body;
+    @NotEmpty(message = "Language cannot be empty")
+    private String language;
+}

--- a/service-api/src/main/java/greencity/service/NotificationService.java
+++ b/service-api/src/main/java/greencity/service/NotificationService.java
@@ -1,17 +1,9 @@
 package greencity.service;
 
-import greencity.constant.AppConstant;
-import greencity.constant.LogMessage;
 import greencity.dto.place.PlaceVO;
-import greencity.enums.NotificationType;
 import greencity.message.GeneralEmailMessage;
 import greencity.message.HabitAssignNotificationMessage;
-import greencity.message.UserReceivedCommentMessage;
-import greencity.message.UserReceivedCommentReplyMessage;
 import greencity.message.UserTaggedInCommentMessage;
-import org.springframework.scheduling.annotation.Scheduled;
-
-import java.time.LocalDateTime;
 import java.util.Set;
 
 public interface NotificationService {
@@ -44,26 +36,26 @@ public interface NotificationService {
     void sendMonthlyReport();
 
     /**
-     * Method for sending scheduled email to user has unread notifications
-     * connected with likes. Sending is performed 2 times a day.
+     * Method for sending scheduled email to user has unread notifications connected
+     * with likes. Sending is performed 2 times a day.
      */
     void sendLikeScheduledEmail();
 
     /**
-     * Method for sending scheduled email to user has unread notifications
-     * connected with comments. Sending is performed 2 times a day.
+     * Method for sending scheduled email to user has unread notifications connected
+     * with comments. Sending is performed 2 times a day.
      */
     void sendCommentScheduledEmail();
 
     /**
-     * Method for sending scheduled email to user has unread notifications
-     * connected with comment replies. Sending is performed 2 times a day.
+     * Method for sending scheduled email to user has unread notifications connected
+     * with comment replies. Sending is performed 2 times a day.
      */
     void sendCommentReplyScheduledEmail();
 
     /**
-     * Method for sending scheduled email to user has unread notifications
-     * connected with friend requests. Sending is performed 2 times a day.
+     * Method for sending scheduled email to user has unread notifications connected
+     * with friend requests. Sending is performed 2 times a day.
      */
     void sendFriendRequestScheduledEmail();
 

--- a/service-api/src/main/java/greencity/service/NotificationService.java
+++ b/service-api/src/main/java/greencity/service/NotificationService.java
@@ -1,11 +1,17 @@
 package greencity.service;
 
+import greencity.constant.AppConstant;
+import greencity.constant.LogMessage;
 import greencity.dto.place.PlaceVO;
+import greencity.enums.NotificationType;
 import greencity.message.GeneralEmailMessage;
 import greencity.message.HabitAssignNotificationMessage;
 import greencity.message.UserReceivedCommentMessage;
 import greencity.message.UserReceivedCommentReplyMessage;
 import greencity.message.UserTaggedInCommentMessage;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.time.LocalDateTime;
 import java.util.Set;
 
 public interface NotificationService {
@@ -38,6 +44,30 @@ public interface NotificationService {
     void sendMonthlyReport();
 
     /**
+     * Method for sending scheduled email to user has unread notifications
+     * connected with likes. Sending is performed 2 times a day.
+     */
+    void sendLikeScheduledEmail();
+
+    /**
+     * Method for sending scheduled email to user has unread notifications
+     * connected with comments. Sending is performed 2 times a day.
+     */
+    void sendCommentScheduledEmail();
+
+    /**
+     * Method for sending scheduled email to user has unread notifications
+     * connected with comment replies. Sending is performed 2 times a day.
+     */
+    void sendCommentReplyScheduledEmail();
+
+    /**
+     * Method for sending scheduled email to user has unread notifications
+     * connected with friend requests. Sending is performed 2 times a day.
+     */
+    void sendFriendRequestScheduledEmail();
+
+    /**
      * method sends a general email notification to many Users.
      *
      * @param usersEmails {@link Set} to this users email will be sent.
@@ -68,18 +98,4 @@ public interface NotificationService {
      * @param message {@link UserTaggedInCommentMessage}.
      */
     void sendUsersTaggedInCommentEmailNotification(UserTaggedInCommentMessage message);
-
-    /**
-     * Method send a notification message when user received comment.
-     *
-     * @param message {@link UserReceivedCommentMessage}.
-     */
-    void sendUserReceivedCommentEmailNotification(UserReceivedCommentMessage message);
-
-    /**
-     * Method send a notification message when user received reply to the comment.
-     *
-     * @param message {@link UserReceivedCommentReplyMessage}.
-     */
-    void sendUserReceivedCommentReplyEmailNotification(UserReceivedCommentReplyMessage message);
 }

--- a/service-api/src/test/java/greencity/ModelUtils.java
+++ b/service-api/src/test/java/greencity/ModelUtils.java
@@ -18,7 +18,6 @@ import greencity.dto.user.PlaceAuthorDto;
 import greencity.dto.user.UserShoppingListItemResponseDto;
 import greencity.dto.user.UserVO;
 import greencity.dto.verifyemail.VerifyEmailVO;
-import greencity.enums.NotificationType;
 import greencity.enums.Role;
 import greencity.enums.ShoppingListItemStatus;
 import greencity.message.GeneralEmailMessage;

--- a/service-api/src/test/java/greencity/ModelUtils.java
+++ b/service-api/src/test/java/greencity/ModelUtils.java
@@ -18,9 +18,11 @@ import greencity.dto.user.PlaceAuthorDto;
 import greencity.dto.user.UserShoppingListItemResponseDto;
 import greencity.dto.user.UserVO;
 import greencity.dto.verifyemail.VerifyEmailVO;
+import greencity.enums.NotificationType;
 import greencity.enums.Role;
 import greencity.enums.ShoppingListItemStatus;
 import greencity.message.GeneralEmailMessage;
+import greencity.message.ScheduledEmailMessage;
 import greencity.message.SendChangePlaceStatusEmailMessage;
 import greencity.message.SendReportEmailMessage;
 import greencity.message.SendHabitNotification;
@@ -42,45 +44,45 @@ import java.util.Set;
 public class ModelUtils {
     public static UserVO getUserVO() {
         return UserVO.builder()
-            .id(1L)
-            .email(TestConst.EMAIL)
-            .name(TestConst.NAME)
-            .role(Role.ROLE_USER)
-            .lastActivityTime(LocalDateTime.now())
-            .verifyEmail(new VerifyEmailVO())
-            .dateOfRegistration(LocalDateTime.now())
-            .build();
+                .id(1L)
+                .email(TestConst.EMAIL)
+                .name(TestConst.NAME)
+                .role(Role.ROLE_USER)
+                .lastActivityTime(LocalDateTime.now())
+                .verifyEmail(new VerifyEmailVO())
+                .dateOfRegistration(LocalDateTime.now())
+                .build();
     }
 
     public static PlaceNotificationDto getPlaceNotificationDto() {
         return PlaceNotificationDto.builder()
-            .category(getCategoryDto())
-            .name("name")
-            .build();
+                .category(getCategoryDto())
+                .name("name")
+                .build();
     }
 
     private static PlaceAuthorDto getPlaceAuthorDto() {
         return PlaceAuthorDto.builder()
-            .id(1L)
-            .email("test@gmail.com")
-            .name("taras")
-            .build();
+                .id(1L)
+                .email("test@gmail.com")
+                .name("taras")
+                .build();
     }
 
     public static SendChangePlaceStatusEmailMessage getSendChangePlaceStatusEmailMessage() {
         return SendChangePlaceStatusEmailMessage.builder()
-            .placeStatus("status")
-            .authorEmail("test@gmail.com")
-            .placeName("placeName")
-            .authorFirstName("taras")
-            .build();
+                .placeStatus("status")
+                .authorEmail("test@gmail.com")
+                .placeName("placeName")
+                .authorFirstName("taras")
+                .build();
     }
 
     public static SendHabitNotification getSendHabitNotification() {
         return SendHabitNotification.builder()
-            .email("test@gmail.com")
-            .name("taras")
-            .build();
+                .email("test@gmail.com")
+                .name("taras")
+                .build();
     }
 
     public static HttpHeaders getHeaders() {
@@ -92,143 +94,143 @@ public class ModelUtils {
 
     public static CategoryDto getCategoryDto() {
         return CategoryDto.builder()
-            .name("name")
-            .parentCategoryId(1L)
-            .build();
+                .name("name")
+                .parentCategoryId(1L)
+                .build();
     }
 
     public static SendReportEmailMessage getSendReportEmailMessage() {
         return SendReportEmailMessage.builder()
-            .emailNotification("notification")
-            .categoriesDtoWithPlacesDtoMap(Collections.singletonMap(
-                getCategoryDto(), Collections.singletonList(getPlaceNotificationDto())))
-            .subscribers(Collections.singletonList(getPlaceAuthorDto()))
-            .build();
+                .emailNotification("notification")
+                .categoriesDtoWithPlacesDtoMap(Collections.singletonMap(
+                        getCategoryDto(), Collections.singletonList(getPlaceNotificationDto())))
+                .subscribers(Collections.singletonList(getPlaceAuthorDto()))
+                .build();
     }
 
     public static AddEcoNewsDtoResponse getAddEcoNewsDtoResponse() {
         return new AddEcoNewsDtoResponse(1L, "title",
-            "text", "shortInfo", EcoNewsAuthorDto.builder().id(1L).name(TestConst.NAME).build(),
-            ZonedDateTime.now(), TestConst.SITE, null,
-            Arrays.asList("Новини", "News", "Новины"));
+                "text", "shortInfo", EcoNewsAuthorDto.builder().id(1L).name(TestConst.NAME).build(),
+                ZonedDateTime.now(), TestConst.SITE, null,
+                Arrays.asList("Новини", "News", "Новины"));
     }
 
     public static EcoNewsForSendEmailDto getEcoNewsForSendEmailDto() {
         return EcoNewsForSendEmailDto.builder()
-            .unsubscribeToken("string")
-            .creationDate(ZonedDateTime.now())
-            .imagePath("string")
-            .author(ModelUtils.getPlaceAuthorDto())
-            .text("string")
-            .source("string")
-            .title("string")
-            .build();
+                .unsubscribeToken("string")
+                .creationDate(ZonedDateTime.now())
+                .imagePath("string")
+                .author(ModelUtils.getPlaceAuthorDto())
+                .text("string")
+                .source("string")
+                .title("string")
+                .build();
     }
 
     public static EventCommentForSendEmailDto getEventCommentForSendEmailDto() {
         return EventCommentForSendEmailDto.builder()
-            .id(1L)
-            .organizer(ModelUtils.getEventAuthorDto())
-            .createdDate(LocalDateTime.now())
-            .author(ModelUtils.getEventCommentAuthorDto())
-            .text("text")
-            .eventId(1L)
-            .build();
+                .id(1L)
+                .organizer(ModelUtils.getEventAuthorDto())
+                .createdDate(LocalDateTime.now())
+                .author(ModelUtils.getEventCommentAuthorDto())
+                .text("text")
+                .eventId(1L)
+                .build();
     }
 
     public static EventAuthorDto getEventAuthorDto() {
         return EventAuthorDto.builder()
-            .id(1L)
-            .name("Inna")
-            .organizerRating(1.0)
-            .build();
+                .id(1L)
+                .name("Inna")
+                .organizerRating(1.0)
+                .build();
     }
 
     public static EventCommentAuthorDto getEventCommentAuthorDto() {
         return EventCommentAuthorDto.builder()
-            .id(ModelUtils.getUserVO().getId())
-            .name(ModelUtils.getUserVO().getName().trim())
-            .userProfilePicturePath(ModelUtils.getUserVO().getProfilePicturePath())
-            .build();
+                .id(ModelUtils.getUserVO().getId())
+                .name(ModelUtils.getUserVO().getName().trim())
+                .userProfilePicturePath(ModelUtils.getUserVO().getProfilePicturePath())
+                .build();
     }
 
     public static TagUaEnDto tagUaEnDto = TagUaEnDto.builder().id(1L).nameUa("Сщціальний").nameEn("Social").build();
 
     public static EventDto getEventDtoWithTag() {
         return EventDto.builder()
-            .id(1L)
-            .countComments(2)
-            .likes(20)
-            .tags(List.of(tagUaEnDto))
-            .build();
+                .id(1L)
+                .countComments(2)
+                .likes(20)
+                .tags(List.of(tagUaEnDto))
+                .build();
     }
 
     public static EventDto getEventDtoWithoutTag() {
         return EventDto.builder()
-            .id(1L)
-            .countComments(2)
-            .likes(20)
-            .build();
+                .id(1L)
+                .countComments(2)
+                .likes(20)
+                .build();
     }
 
     public static UserShoppingListItemResponseDto getUserShoppingListItemResponseDto() {
         return UserShoppingListItemResponseDto.builder()
-            .id(1L)
-            .text("text")
-            .status(ShoppingListItemStatus.ACTIVE)
-            .build();
+                .id(1L)
+                .text("text")
+                .status(ShoppingListItemStatus.ACTIVE)
+                .build();
     }
 
     public static CustomShoppingListItemResponseDto getCustomShoppingListItemResponseDto() {
         return CustomShoppingListItemResponseDto.builder()
-            .id(1L)
-            .text("text")
-            .status(ShoppingListItemStatus.ACTIVE)
-            .build();
+                .id(1L)
+                .text("text")
+                .status(ShoppingListItemStatus.ACTIVE)
+                .build();
     }
 
     public static UserShoppingAndCustomShoppingListsDto getUserShoppingAndCustomShoppingListsDto() {
         return UserShoppingAndCustomShoppingListsDto.builder()
-            .userShoppingListItemDto(List.of(getUserShoppingListItemResponseDto()))
-            .customShoppingListItemDto(List.of(getCustomShoppingListItemResponseDto()))
-            .build();
+                .userShoppingListItemDto(List.of(getUserShoppingListItemResponseDto()))
+                .customShoppingListItemDto(List.of(getCustomShoppingListItemResponseDto()))
+                .build();
     }
 
     public static CustomHabitDtoRequest getAddCustomHabitDtoRequest() {
         return CustomHabitDtoRequest.builder()
-            .complexity(1)
-            .image("")
-            .defaultDuration(14)
-            .tagIds(Set.of(20L))
-            .build();
+                .complexity(1)
+                .image("")
+                .defaultDuration(14)
+                .tagIds(Set.of(20L))
+                .build();
     }
 
     public static CustomHabitDtoResponse getAddCustomHabitDtoResponse() {
         return CustomHabitDtoResponse.builder()
-            .id(1L)
-            .complexity(1)
-            .image("")
-            .defaultDuration(14)
-            .tagIds(Set.of(20L))
-            .build();
+                .id(1L)
+                .complexity(1)
+                .image("")
+                .defaultDuration(14)
+                .tagIds(Set.of(20L))
+                .build();
     }
 
     public static GeneralEmailMessage getGeneralEmailNotification() {
         return GeneralEmailMessage.builder()
-            .email("test@gmail.com")
-            .subject("Congratulations")
-            .message("You have successfully done something")
-            .build();
+                .email("test@gmail.com")
+                .subject("Congratulations")
+                .message("You have successfully done something")
+                .build();
     }
 
     public static HabitAssignNotificationMessage getHabitAssignNotificationMessage() {
         return HabitAssignNotificationMessage.builder()
-            .senderName("sender")
-            .receiverName("receiver")
-            .habitAssignId(1L)
-            .language("en")
-            .receiverEmail("receiver@email.com")
-            .build();
+                .senderName("sender")
+                .receiverName("receiver")
+                .habitAssignId(1L)
+                .language("en")
+                .receiverEmail("receiver@email.com")
+                .build();
     }
 
     public static URL getUrl() throws MalformedURLException {
@@ -237,35 +239,46 @@ public class ModelUtils {
 
     public static UserTaggedInCommentMessage getUserTaggedInCommentMessage() {
         return UserTaggedInCommentMessage.builder()
-            .baseLink("http://localhost:8060/events/1")
-            .taggerName("Denys")
-            .receiverName("Ivan")
-            .language("en")
-            .receiverEmail("Ivan@gmail.com")
-            .build();
+                .baseLink("http://localhost:8060/events/1")
+                .taggerName("Denys")
+                .receiverName("Ivan")
+                .language("en")
+                .receiverEmail("Ivan@gmail.com")
+                .build();
     }
 
     public static UserReceivedCommentMessage getUserReceivedCommentMessage() {
         return UserReceivedCommentMessage.builder()
-            .commentText("test")
-            .baseLink("http://localhost:8060/events/1")
-            .authorName("Denys")
-            .receiverName("Ivan")
-            .language("en")
-            .receiverEmail("Ivan@gmail.com")
-            .build();
+                .commentText("test")
+                .baseLink("http://localhost:8060/events/1")
+                .authorName("Denys")
+                .receiverName("Ivan")
+                .language("en")
+                .receiverEmail("Ivan@gmail.com")
+                .build();
     }
 
     public static UserReceivedCommentReplyMessage getUserReceivedCommentReplyMessage() {
         return UserReceivedCommentReplyMessage.builder()
-            .commentText("test")
-            .baseLink("http://localhost:8060/events/1")
-            .authorName("Denys")
-            .receiverName("Ivan")
-            .language("en")
-            .receiverEmail("Ivan@gmail.com")
-            .parentCommentText("parent comment")
-            .parentCommentAuthorName("Dmytro")
-            .build();
+                .commentText("test")
+                .baseLink("http://localhost:8060/events/1")
+                .authorName("Denys")
+                .receiverName("Ivan")
+                .language("en")
+                .receiverEmail("Ivan@gmail.com")
+                .parentCommentText("parent comment")
+                .parentCommentAuthorName("Dmytro")
+                .build();
+    }
+
+    public static ScheduledEmailMessage getScheduledEmailMessage() {
+        return ScheduledEmailMessage.builder()
+                .username("test")
+                .body("test")
+                .subject("test")
+                .language("en")
+                .baseLink("test")
+                .email("test@gmail.com")
+                .build();
     }
 }

--- a/service-api/src/test/java/greencity/ModelUtils.java
+++ b/service-api/src/test/java/greencity/ModelUtils.java
@@ -44,45 +44,45 @@ import java.util.Set;
 public class ModelUtils {
     public static UserVO getUserVO() {
         return UserVO.builder()
-                .id(1L)
-                .email(TestConst.EMAIL)
-                .name(TestConst.NAME)
-                .role(Role.ROLE_USER)
-                .lastActivityTime(LocalDateTime.now())
-                .verifyEmail(new VerifyEmailVO())
-                .dateOfRegistration(LocalDateTime.now())
-                .build();
+            .id(1L)
+            .email(TestConst.EMAIL)
+            .name(TestConst.NAME)
+            .role(Role.ROLE_USER)
+            .lastActivityTime(LocalDateTime.now())
+            .verifyEmail(new VerifyEmailVO())
+            .dateOfRegistration(LocalDateTime.now())
+            .build();
     }
 
     public static PlaceNotificationDto getPlaceNotificationDto() {
         return PlaceNotificationDto.builder()
-                .category(getCategoryDto())
-                .name("name")
-                .build();
+            .category(getCategoryDto())
+            .name("name")
+            .build();
     }
 
     private static PlaceAuthorDto getPlaceAuthorDto() {
         return PlaceAuthorDto.builder()
-                .id(1L)
-                .email("test@gmail.com")
-                .name("taras")
-                .build();
+            .id(1L)
+            .email("test@gmail.com")
+            .name("taras")
+            .build();
     }
 
     public static SendChangePlaceStatusEmailMessage getSendChangePlaceStatusEmailMessage() {
         return SendChangePlaceStatusEmailMessage.builder()
-                .placeStatus("status")
-                .authorEmail("test@gmail.com")
-                .placeName("placeName")
-                .authorFirstName("taras")
-                .build();
+            .placeStatus("status")
+            .authorEmail("test@gmail.com")
+            .placeName("placeName")
+            .authorFirstName("taras")
+            .build();
     }
 
     public static SendHabitNotification getSendHabitNotification() {
         return SendHabitNotification.builder()
-                .email("test@gmail.com")
-                .name("taras")
-                .build();
+            .email("test@gmail.com")
+            .name("taras")
+            .build();
     }
 
     public static HttpHeaders getHeaders() {
@@ -94,143 +94,143 @@ public class ModelUtils {
 
     public static CategoryDto getCategoryDto() {
         return CategoryDto.builder()
-                .name("name")
-                .parentCategoryId(1L)
-                .build();
+            .name("name")
+            .parentCategoryId(1L)
+            .build();
     }
 
     public static SendReportEmailMessage getSendReportEmailMessage() {
         return SendReportEmailMessage.builder()
-                .emailNotification("notification")
-                .categoriesDtoWithPlacesDtoMap(Collections.singletonMap(
-                        getCategoryDto(), Collections.singletonList(getPlaceNotificationDto())))
-                .subscribers(Collections.singletonList(getPlaceAuthorDto()))
-                .build();
+            .emailNotification("notification")
+            .categoriesDtoWithPlacesDtoMap(Collections.singletonMap(
+                getCategoryDto(), Collections.singletonList(getPlaceNotificationDto())))
+            .subscribers(Collections.singletonList(getPlaceAuthorDto()))
+            .build();
     }
 
     public static AddEcoNewsDtoResponse getAddEcoNewsDtoResponse() {
         return new AddEcoNewsDtoResponse(1L, "title",
-                "text", "shortInfo", EcoNewsAuthorDto.builder().id(1L).name(TestConst.NAME).build(),
-                ZonedDateTime.now(), TestConst.SITE, null,
-                Arrays.asList("Новини", "News", "Новины"));
+            "text", "shortInfo", EcoNewsAuthorDto.builder().id(1L).name(TestConst.NAME).build(),
+            ZonedDateTime.now(), TestConst.SITE, null,
+            Arrays.asList("Новини", "News", "Новины"));
     }
 
     public static EcoNewsForSendEmailDto getEcoNewsForSendEmailDto() {
         return EcoNewsForSendEmailDto.builder()
-                .unsubscribeToken("string")
-                .creationDate(ZonedDateTime.now())
-                .imagePath("string")
-                .author(ModelUtils.getPlaceAuthorDto())
-                .text("string")
-                .source("string")
-                .title("string")
-                .build();
+            .unsubscribeToken("string")
+            .creationDate(ZonedDateTime.now())
+            .imagePath("string")
+            .author(ModelUtils.getPlaceAuthorDto())
+            .text("string")
+            .source("string")
+            .title("string")
+            .build();
     }
 
     public static EventCommentForSendEmailDto getEventCommentForSendEmailDto() {
         return EventCommentForSendEmailDto.builder()
-                .id(1L)
-                .organizer(ModelUtils.getEventAuthorDto())
-                .createdDate(LocalDateTime.now())
-                .author(ModelUtils.getEventCommentAuthorDto())
-                .text("text")
-                .eventId(1L)
-                .build();
+            .id(1L)
+            .organizer(ModelUtils.getEventAuthorDto())
+            .createdDate(LocalDateTime.now())
+            .author(ModelUtils.getEventCommentAuthorDto())
+            .text("text")
+            .eventId(1L)
+            .build();
     }
 
     public static EventAuthorDto getEventAuthorDto() {
         return EventAuthorDto.builder()
-                .id(1L)
-                .name("Inna")
-                .organizerRating(1.0)
-                .build();
+            .id(1L)
+            .name("Inna")
+            .organizerRating(1.0)
+            .build();
     }
 
     public static EventCommentAuthorDto getEventCommentAuthorDto() {
         return EventCommentAuthorDto.builder()
-                .id(ModelUtils.getUserVO().getId())
-                .name(ModelUtils.getUserVO().getName().trim())
-                .userProfilePicturePath(ModelUtils.getUserVO().getProfilePicturePath())
-                .build();
+            .id(ModelUtils.getUserVO().getId())
+            .name(ModelUtils.getUserVO().getName().trim())
+            .userProfilePicturePath(ModelUtils.getUserVO().getProfilePicturePath())
+            .build();
     }
 
     public static TagUaEnDto tagUaEnDto = TagUaEnDto.builder().id(1L).nameUa("Сщціальний").nameEn("Social").build();
 
     public static EventDto getEventDtoWithTag() {
         return EventDto.builder()
-                .id(1L)
-                .countComments(2)
-                .likes(20)
-                .tags(List.of(tagUaEnDto))
-                .build();
+            .id(1L)
+            .countComments(2)
+            .likes(20)
+            .tags(List.of(tagUaEnDto))
+            .build();
     }
 
     public static EventDto getEventDtoWithoutTag() {
         return EventDto.builder()
-                .id(1L)
-                .countComments(2)
-                .likes(20)
-                .build();
+            .id(1L)
+            .countComments(2)
+            .likes(20)
+            .build();
     }
 
     public static UserShoppingListItemResponseDto getUserShoppingListItemResponseDto() {
         return UserShoppingListItemResponseDto.builder()
-                .id(1L)
-                .text("text")
-                .status(ShoppingListItemStatus.ACTIVE)
-                .build();
+            .id(1L)
+            .text("text")
+            .status(ShoppingListItemStatus.ACTIVE)
+            .build();
     }
 
     public static CustomShoppingListItemResponseDto getCustomShoppingListItemResponseDto() {
         return CustomShoppingListItemResponseDto.builder()
-                .id(1L)
-                .text("text")
-                .status(ShoppingListItemStatus.ACTIVE)
-                .build();
+            .id(1L)
+            .text("text")
+            .status(ShoppingListItemStatus.ACTIVE)
+            .build();
     }
 
     public static UserShoppingAndCustomShoppingListsDto getUserShoppingAndCustomShoppingListsDto() {
         return UserShoppingAndCustomShoppingListsDto.builder()
-                .userShoppingListItemDto(List.of(getUserShoppingListItemResponseDto()))
-                .customShoppingListItemDto(List.of(getCustomShoppingListItemResponseDto()))
-                .build();
+            .userShoppingListItemDto(List.of(getUserShoppingListItemResponseDto()))
+            .customShoppingListItemDto(List.of(getCustomShoppingListItemResponseDto()))
+            .build();
     }
 
     public static CustomHabitDtoRequest getAddCustomHabitDtoRequest() {
         return CustomHabitDtoRequest.builder()
-                .complexity(1)
-                .image("")
-                .defaultDuration(14)
-                .tagIds(Set.of(20L))
-                .build();
+            .complexity(1)
+            .image("")
+            .defaultDuration(14)
+            .tagIds(Set.of(20L))
+            .build();
     }
 
     public static CustomHabitDtoResponse getAddCustomHabitDtoResponse() {
         return CustomHabitDtoResponse.builder()
-                .id(1L)
-                .complexity(1)
-                .image("")
-                .defaultDuration(14)
-                .tagIds(Set.of(20L))
-                .build();
+            .id(1L)
+            .complexity(1)
+            .image("")
+            .defaultDuration(14)
+            .tagIds(Set.of(20L))
+            .build();
     }
 
     public static GeneralEmailMessage getGeneralEmailNotification() {
         return GeneralEmailMessage.builder()
-                .email("test@gmail.com")
-                .subject("Congratulations")
-                .message("You have successfully done something")
-                .build();
+            .email("test@gmail.com")
+            .subject("Congratulations")
+            .message("You have successfully done something")
+            .build();
     }
 
     public static HabitAssignNotificationMessage getHabitAssignNotificationMessage() {
         return HabitAssignNotificationMessage.builder()
-                .senderName("sender")
-                .receiverName("receiver")
-                .habitAssignId(1L)
-                .language("en")
-                .receiverEmail("receiver@email.com")
-                .build();
+            .senderName("sender")
+            .receiverName("receiver")
+            .habitAssignId(1L)
+            .language("en")
+            .receiverEmail("receiver@email.com")
+            .build();
     }
 
     public static URL getUrl() throws MalformedURLException {
@@ -239,46 +239,46 @@ public class ModelUtils {
 
     public static UserTaggedInCommentMessage getUserTaggedInCommentMessage() {
         return UserTaggedInCommentMessage.builder()
-                .baseLink("http://localhost:8060/events/1")
-                .taggerName("Denys")
-                .receiverName("Ivan")
-                .language("en")
-                .receiverEmail("Ivan@gmail.com")
-                .build();
+            .baseLink("http://localhost:8060/events/1")
+            .taggerName("Denys")
+            .receiverName("Ivan")
+            .language("en")
+            .receiverEmail("Ivan@gmail.com")
+            .build();
     }
 
     public static UserReceivedCommentMessage getUserReceivedCommentMessage() {
         return UserReceivedCommentMessage.builder()
-                .commentText("test")
-                .baseLink("http://localhost:8060/events/1")
-                .authorName("Denys")
-                .receiverName("Ivan")
-                .language("en")
-                .receiverEmail("Ivan@gmail.com")
-                .build();
+            .commentText("test")
+            .baseLink("http://localhost:8060/events/1")
+            .authorName("Denys")
+            .receiverName("Ivan")
+            .language("en")
+            .receiverEmail("Ivan@gmail.com")
+            .build();
     }
 
     public static UserReceivedCommentReplyMessage getUserReceivedCommentReplyMessage() {
         return UserReceivedCommentReplyMessage.builder()
-                .commentText("test")
-                .baseLink("http://localhost:8060/events/1")
-                .authorName("Denys")
-                .receiverName("Ivan")
-                .language("en")
-                .receiverEmail("Ivan@gmail.com")
-                .parentCommentText("parent comment")
-                .parentCommentAuthorName("Dmytro")
-                .build();
+            .commentText("test")
+            .baseLink("http://localhost:8060/events/1")
+            .authorName("Denys")
+            .receiverName("Ivan")
+            .language("en")
+            .receiverEmail("Ivan@gmail.com")
+            .parentCommentText("parent comment")
+            .parentCommentAuthorName("Dmytro")
+            .build();
     }
 
     public static ScheduledEmailMessage getScheduledEmailMessage() {
         return ScheduledEmailMessage.builder()
-                .username("test")
-                .body("test")
-                .subject("test")
-                .language("en")
-                .baseLink("test")
-                .email("test@gmail.com")
-                .build();
+            .username("test")
+            .body("test")
+            .subject("test")
+            .language("en")
+            .baseLink("test")
+            .email("test@gmail.com")
+            .build();
     }
 }

--- a/service-api/src/test/java/greencity/client/RestClientTest.java
+++ b/service-api/src/test/java/greencity/client/RestClientTest.java
@@ -15,7 +15,6 @@ import greencity.dto.achievement.UserVOAchievement;
 import greencity.dto.econews.EcoNewsForSendEmailDto;
 import greencity.dto.eventcomment.EventCommentForSendEmailDto;
 import greencity.enums.EmailNotification;
-import greencity.enums.NotificationType;
 import greencity.enums.Role;
 import greencity.message.GeneralEmailMessage;
 import greencity.message.ScheduledEmailMessage;
@@ -28,9 +27,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Map;
-
-import greencity.message.UserReceivedCommentMessage;
-import greencity.message.UserReceivedCommentReplyMessage;
 import greencity.message.UserTaggedInCommentMessage;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -88,8 +84,8 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.USER_FIND_BY_EMAIL
-                        + RestTemplateLinks.EMAIL + "taras@gmail.com", HttpMethod.GET,
-                entity, UserVO.class)).thenReturn(ResponseEntity.ok(userVO));
+            + RestTemplateLinks.EMAIL + "taras@gmail.com", HttpMethod.GET,
+            entity, UserVO.class)).thenReturn(ResponseEntity.ok(userVO));
 
         assertEquals(userVO, restClient.findByEmail("taras@gmail.com"));
     }
@@ -103,8 +99,8 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.USER_FIND_BY_ID + RestTemplateLinks.ID + 1L, HttpMethod.GET, entity, UserVO.class))
-                .thenReturn(ResponseEntity.ok(userVO));
+            + RestTemplateLinks.USER_FIND_BY_ID + RestTemplateLinks.ID + 1L, HttpMethod.GET, entity, UserVO.class))
+            .thenReturn(ResponseEntity.ok(userVO));
 
         assertEquals(userVO, restClient.findById(1L));
     }
@@ -118,8 +114,8 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                        + RestTemplateLinks.USER_FIND_BY_ID_FOR_ACHIEVEMENT + RestTemplateLinks.ID + 1L,
-                HttpMethod.GET, entity, UserVOAchievement.class)).thenReturn(ResponseEntity.ok(userVOAchievement));
+            + RestTemplateLinks.USER_FIND_BY_ID_FOR_ACHIEVEMENT + RestTemplateLinks.ID + 1L,
+            HttpMethod.GET, entity, UserVOAchievement.class)).thenReturn(ResponseEntity.ok(userVOAchievement));
 
         assertEquals(userVOAchievement, restClient.findUserForAchievement(1L));
     }
@@ -133,15 +129,15 @@ class RestClientTest {
         Pageable pageable = PageRequest.of(0, 10);
         List<UserManagementDto> ecoNewsDtos = Collections.singletonList(new UserManagementDto());
         PageableAdvancedDto<UserManagementDto> pageableAdvancedDto =
-                new PageableAdvancedDto<>(ecoNewsDtos, 2, 0, 3, 0, true, true, true, true);
+            new PageableAdvancedDto<>(ecoNewsDtos, 2, 0, 3, 0, true, true, true, true);
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                        + RestTemplateLinks.SEARCH_BY + RestTemplateLinks.PAGE + pageable.getPageNumber()
-                        + RestTemplateLinks.SIZE + pageable.getPageSize()
-                        + RestTemplateLinks.QUERY + query, HttpMethod.GET, entity,
-                new ParameterizedTypeReference<PageableAdvancedDto<UserManagementDto>>() {
-                })).thenReturn(ResponseEntity.ok(pageableAdvancedDto));
+            + RestTemplateLinks.SEARCH_BY + RestTemplateLinks.PAGE + pageable.getPageNumber()
+            + RestTemplateLinks.SIZE + pageable.getPageSize()
+            + RestTemplateLinks.QUERY + query, HttpMethod.GET, entity,
+            new ParameterizedTypeReference<PageableAdvancedDto<UserManagementDto>>() {
+            })).thenReturn(ResponseEntity.ok(pageableAdvancedDto));
 
         assertEquals(pageableAdvancedDto, restClient.searchBy(pageable, query));
     }
@@ -159,13 +155,13 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.USER + "/1", HttpMethod.PUT, entity, Object.class))
-                .thenReturn(ResponseEntity.ok(Object));
+            + RestTemplateLinks.USER + "/1", HttpMethod.PUT, entity, Object.class))
+            .thenReturn(ResponseEntity.ok(Object));
 
         restClient.updateUser(userManagementDto);
 
         assertEquals(ResponseEntity.ok(Object), restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.USER + "/1", HttpMethod.PUT, entity, Object.class));
+            + RestTemplateLinks.USER + "/1", HttpMethod.PUT, entity, Object.class));
     }
 
     @Test
@@ -173,7 +169,7 @@ class RestClientTest {
         Role newRole = Role.ROLE_MODERATOR;
         UserRoleDto userRoleDto = new UserRoleDto(newRole);
         String url = GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.USER + "/1/role";
+            + RestTemplateLinks.USER + "/1/role";
         HttpHeaders headers = new HttpHeaders();
         headers.set(AUTHORIZATION, ACCESS_TOKEN);
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -196,8 +192,8 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.USER_FIND_ALL, HttpMethod.GET, entity, UserVO[].class))
-                .thenReturn(ResponseEntity.of(Optional.of(userVOS)));
+            + RestTemplateLinks.USER_FIND_ALL, HttpMethod.GET, entity, UserVO[].class))
+            .thenReturn(ResponseEntity.of(Optional.of(userVOS)));
 
         assertEquals(Arrays.asList(userVOS), restClient.findAll());
     }
@@ -212,12 +208,12 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                        + RestTemplateLinks.USER + "/" + 1L + RestTemplateLinks.FRIENDS, HttpMethod.GET, entity,
-                UserManagementDto[].class)).thenReturn(ResponseEntity.ok(userManagementDtos));
+            + RestTemplateLinks.USER + "/" + 1L + RestTemplateLinks.FRIENDS, HttpMethod.GET, entity,
+            UserManagementDto[].class)).thenReturn(ResponseEntity.ok(userManagementDtos));
         restClient.findUserFriendsByUserId(1L);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.USER + "/"
-                + 1L + RestTemplateLinks.FRIENDS, HttpMethod.GET, entity, UserManagementDto[].class);
+            + 1L + RestTemplateLinks.FRIENDS, HttpMethod.GET, entity, UserManagementDto[].class);
     }
 
     @Test
@@ -230,8 +226,8 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.USER_FIND_NOT_DEACTIVATED_BY_EMAIL + RestTemplateLinks.EMAIL
-                + email, HttpMethod.GET, entity, UserVO.class)).thenReturn(ResponseEntity.ok(userVO));
+            + RestTemplateLinks.USER_FIND_NOT_DEACTIVATED_BY_EMAIL + RestTemplateLinks.EMAIL
+            + email, HttpMethod.GET, entity, UserVO.class)).thenReturn(ResponseEntity.ok(userVO));
 
         assertEquals(Optional.of(userVO), restClient.findNotDeactivatedByEmail(email));
     }
@@ -247,8 +243,8 @@ class RestClientTest {
         when(httpServletRequest.getCookies()).thenReturn(cookies);
         when(httpServletRequest.getRequestURI()).thenReturn("/management");
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.USER_FIND_NOT_DEACTIVATED_BY_EMAIL + RestTemplateLinks.EMAIL
-                + email, HttpMethod.GET, entity, UserVO.class)).thenReturn(ResponseEntity.ok(userVO));
+            + RestTemplateLinks.USER_FIND_NOT_DEACTIVATED_BY_EMAIL + RestTemplateLinks.EMAIL
+            + email, HttpMethod.GET, entity, UserVO.class)).thenReturn(ResponseEntity.ok(userVO));
 
         assertEquals(Optional.of(userVO), restClient.findNotDeactivatedByEmail(email));
     }
@@ -262,9 +258,9 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.USER_FIND_ID_BY_EMAIL
-                + RestTemplateLinks.EMAIL + email, HttpMethod.GET, entity, Long.class))
-                .thenReturn(ResponseEntity.ok(1L));
+            + RestTemplateLinks.USER_FIND_ID_BY_EMAIL
+            + RestTemplateLinks.EMAIL + email, HttpMethod.GET, entity, Long.class))
+            .thenReturn(ResponseEntity.ok(1L));
 
         assertEquals(1L, restClient.findIdByEmail(email));
     }
@@ -279,9 +275,9 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.USER_REASONS
-                + RestTemplateLinks.ID + 1L
-                + RestTemplateLinks.ADMIN_LANG + "en", HttpMethod.GET, entity, String[].class))
-                .thenReturn(ResponseEntity.ok(test));
+            + RestTemplateLinks.ID + 1L
+            + RestTemplateLinks.ADMIN_LANG + "en", HttpMethod.GET, entity, String[].class))
+            .thenReturn(ResponseEntity.ok(test));
 
         assertEquals(listString, restClient.getDeactivationReason(1L, "en"));
     }
@@ -295,8 +291,8 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.USER_LANG
-                + RestTemplateLinks.ID + 1L, HttpMethod.GET, entity, String.class))
-                .thenReturn(ResponseEntity.ok(test));
+            + RestTemplateLinks.ID + 1L, HttpMethod.GET, entity, String.class))
+            .thenReturn(ResponseEntity.ok(test));
 
         assertEquals(test, restClient.getUserLang(1L));
     }
@@ -311,13 +307,13 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.USER_DEACTIVATE
-                + RestTemplateLinks.ID + 1L, HttpMethod.PUT, entity, Object.class))
-                .thenReturn(ResponseEntity.ok(Object));
+            + RestTemplateLinks.ID + 1L, HttpMethod.PUT, entity, Object.class))
+            .thenReturn(ResponseEntity.ok(Object));
 
         restClient.deactivateUser(1L, test);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.USER_DEACTIVATE
-                + RestTemplateLinks.ID + 1L, HttpMethod.PUT, entity, Object.class);
+            + RestTemplateLinks.ID + 1L, HttpMethod.PUT, entity, Object.class);
     }
 
     @Test
@@ -328,13 +324,13 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.USER_ACTIVATE
-                + RestTemplateLinks.ID + 1L, HttpMethod.PUT, entity, Object.class))
-                .thenReturn(ResponseEntity.ok(Object));
+            + RestTemplateLinks.ID + 1L, HttpMethod.PUT, entity, Object.class))
+            .thenReturn(ResponseEntity.ok(Object));
 
         restClient.setActivatedStatus(1L);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.USER_ACTIVATE
-                + RestTemplateLinks.ID + 1L, HttpMethod.PUT, entity, Object.class);
+            + RestTemplateLinks.ID + 1L, HttpMethod.PUT, entity, Object.class);
     }
 
     @Test
@@ -353,8 +349,8 @@ class RestClientTest {
         restClient.deactivateAllUsers(listId);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.USER_DEACTIVATE
-                + RestTemplateLinks.ID + listId, HttpMethod.PUT, entity, Long[].class);
+            + RestTemplateLinks.USER_DEACTIVATE
+            + RestTemplateLinks.ID + listId, HttpMethod.PUT, entity, Long[].class);
 
     }
 
@@ -368,13 +364,13 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.OWN_SECURITY_REGISTER, HttpMethod.POST, entity, Object.class))
-                .thenReturn(ResponseEntity.ok(Object));
+            + RestTemplateLinks.OWN_SECURITY_REGISTER, HttpMethod.POST, entity, Object.class))
+            .thenReturn(ResponseEntity.ok(Object));
 
         restClient.managementRegisterUser(userManagementDto);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.OWN_SECURITY_REGISTER, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.OWN_SECURITY_REGISTER, HttpMethod.POST, entity, Object.class);
     }
 
     @Test
@@ -387,13 +383,13 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.ADD_ECO_NEWS, HttpMethod.POST, entity, Object.class))
-                .thenReturn(ResponseEntity.ok(Object));
+            + RestTemplateLinks.ADD_ECO_NEWS, HttpMethod.POST, entity, Object.class))
+            .thenReturn(ResponseEntity.ok(Object));
 
         restClient.addEcoNews(message);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.ADD_ECO_NEWS, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.ADD_ECO_NEWS, HttpMethod.POST, entity, Object.class);
     }
 
     @Test
@@ -406,13 +402,13 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.ADD_EVENT_COMMENT, HttpMethod.POST, entity, Object.class))
-                .thenReturn(ResponseEntity.ok(Object));
+            + RestTemplateLinks.ADD_EVENT_COMMENT, HttpMethod.POST, entity, Object.class))
+            .thenReturn(ResponseEntity.ok(Object));
 
         restClient.sendNewEventComment(message);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.ADD_EVENT_COMMENT, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.ADD_EVENT_COMMENT, HttpMethod.POST, entity, Object.class);
     }
 
     @Test
@@ -420,14 +416,14 @@ class RestClientTest {
         SendReportEmailMessage message = ModelUtils.getSendReportEmailMessage();
         HttpEntity<SendReportEmailMessage> entity = new HttpEntity<>(message, ModelUtils.getHeaders());
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.SEND_REPORT, HttpMethod.POST, entity, Object.class))
-                .thenReturn(ResponseEntity.ok(Object));
+            + RestTemplateLinks.SEND_REPORT, HttpMethod.POST, entity, Object.class))
+            .thenReturn(ResponseEntity.ok(Object));
         when(jwtTool.createAccessToken(SYSTEM_EMAIL, Role.ROLE_ADMIN)).thenReturn("accessToken");
         restClient.sendReport(message);
 
         verify(jwtTool).createAccessToken(SYSTEM_EMAIL, Role.ROLE_ADMIN);
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.SEND_REPORT, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.SEND_REPORT, HttpMethod.POST, entity, Object.class);
     }
 
     @Test
@@ -440,13 +436,13 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.CHANGE_PLACE_STATUS, HttpMethod.POST, entity, Object.class))
-                .thenReturn(ResponseEntity.ok(Object));
+            + RestTemplateLinks.CHANGE_PLACE_STATUS, HttpMethod.POST, entity, Object.class))
+            .thenReturn(ResponseEntity.ok(Object));
 
         restClient.changePlaceStatus(message);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.CHANGE_PLACE_STATUS, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.CHANGE_PLACE_STATUS, HttpMethod.POST, entity, Object.class);
     }
 
     @Test
@@ -455,15 +451,15 @@ class RestClientTest {
         HttpEntity<SendHabitNotification> entity = new HttpEntity<>(notification, ModelUtils.getHeaders());
 
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.SEND_HABIT_NOTIFICATION, HttpMethod.POST, entity, Object.class))
-                .thenReturn(ResponseEntity.ok(Object));
+            + RestTemplateLinks.SEND_HABIT_NOTIFICATION, HttpMethod.POST, entity, Object.class))
+            .thenReturn(ResponseEntity.ok(Object));
         when(jwtTool.createAccessToken(SYSTEM_EMAIL, Role.ROLE_ADMIN)).thenReturn("accessToken");
 
         restClient.sendHabitNotification(notification);
 
         verify(jwtTool).createAccessToken(SYSTEM_EMAIL, Role.ROLE_ADMIN);
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.SEND_HABIT_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.SEND_HABIT_NOTIFICATION, HttpMethod.POST, entity, Object.class);
     }
 
     @Test
@@ -474,14 +470,14 @@ class RestClientTest {
         Pageable pageable = PageRequest.of(0, 10, Sort.by("id").ascending());
         List<UserManagementDto> ecoNewsDtos = Collections.singletonList(new UserManagementDto());
         PageableAdvancedDto<UserManagementDto> pageableAdvancedDto =
-                new PageableAdvancedDto<>(ecoNewsDtos, 2, 0, 3, 0, true, true, true, true);
+            new PageableAdvancedDto<>(ecoNewsDtos, 2, 0, 3, 0, true, true, true, true);
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                        + RestTemplateLinks.USER_FIND_USER_FOR_MANAGEMENT + RestTemplateLinks.PAGE + pageable.getPageNumber()
-                        + RestTemplateLinks.SIZE + pageable.getPageSize() + "&sort=id,ASC", HttpMethod.GET, entity,
-                new ParameterizedTypeReference<PageableAdvancedDto<UserManagementDto>>() {
-                })).thenReturn(ResponseEntity.ok(pageableAdvancedDto));
+            + RestTemplateLinks.USER_FIND_USER_FOR_MANAGEMENT + RestTemplateLinks.PAGE + pageable.getPageNumber()
+            + RestTemplateLinks.SIZE + pageable.getPageSize() + "&sort=id,ASC", HttpMethod.GET, entity,
+            new ParameterizedTypeReference<PageableAdvancedDto<UserManagementDto>>() {
+            })).thenReturn(ResponseEntity.ok(pageableAdvancedDto));
 
         assertEquals(pageableAdvancedDto, restClient.findUserForManagementByPage(pageable));
     }
@@ -493,27 +489,27 @@ class RestClientTest {
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.set(AUTHORIZATION, ACCESS_TOKEN);
         UserManagementViewDto userViewDto =
-                UserManagementViewDto.builder()
-                        .id("1L")
-                        .name("vivo")
-                        .email("test@ukr.net")
-                        .userCredo("Hello")
-                        .role("1")
-                        .userStatus("1")
-                        .build();
+            UserManagementViewDto.builder()
+                .id("1L")
+                .name("vivo")
+                .email("test@ukr.net")
+                .userCredo("Hello")
+                .role("1")
+                .userStatus("1")
+                .build();
         List<UserManagementVO> userManagementVOS = Collections.singletonList(new UserManagementVO());
         PageableAdvancedDto<UserManagementVO> userAdvancedDto =
-                new PageableAdvancedDto<>(userManagementVOS, 20, 0, 0, 0,
-                        true, true, true, true);
+            new PageableAdvancedDto<>(userManagementVOS, 20, 0, 0, 0,
+                true, true, true, true);
         HttpEntity<UserManagementViewDto> entity = new HttpEntity<>(userViewDto, headers);
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                        + RestTemplateLinks.USER_SEARCH + RestTemplateLinks.PAGE + pageable.getPageNumber()
-                        + RestTemplateLinks.SIZE + pageable.getPageSize()
-                        + RestTemplateLinks.SORT, HttpMethod.POST, entity,
-                new ParameterizedTypeReference<PageableAdvancedDto<UserManagementVO>>() {
-                })).thenReturn(ResponseEntity.ok(userAdvancedDto));
+            + RestTemplateLinks.USER_SEARCH + RestTemplateLinks.PAGE + pageable.getPageNumber()
+            + RestTemplateLinks.SIZE + pageable.getPageSize()
+            + RestTemplateLinks.SORT, HttpMethod.POST, entity,
+            new ParameterizedTypeReference<PageableAdvancedDto<UserManagementVO>>() {
+            })).thenReturn(ResponseEntity.ok(userAdvancedDto));
 
         assertEquals(userAdvancedDto, restClient.search(pageable, userViewDto));
     }
@@ -523,12 +519,12 @@ class RestClientTest {
         HttpEntity<String> entity = new HttpEntity<>(new HttpHeaders());
 
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.DELETE_DEACTIVATED_USERS,
-                HttpMethod.POST, entity, Object.class))
-                .thenReturn(ResponseEntity.ok(Object));
+            HttpMethod.POST, entity, Object.class))
+            .thenReturn(ResponseEntity.ok(Object));
         restClient.scheduleDeleteDeactivatedUsers();
 
         verify(restTemplate, times(1)).exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.DELETE_DEACTIVATED_USERS,
-                HttpMethod.POST, entity, Object.class);
+            HttpMethod.POST, entity, Object.class);
     }
 
     @Test
@@ -537,11 +533,11 @@ class RestClientTest {
         List<UserVO> userVOS = Collections.singletonList(ModelUtils.getUserVO());
 
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                        + RestTemplateLinks.USER_FIND_ALL_BY_EMAIL_NOTIFICATION
-                        + RestTemplateLinks.EMAIL_NOTIFICATION + EmailNotification.IMMEDIATELY,
-                HttpMethod.GET, entity, new ParameterizedTypeReference<List<UserVO>>() {
-                }))
-                .thenReturn(ResponseEntity.status(HttpStatus.OK).body(userVOS));
+            + RestTemplateLinks.USER_FIND_ALL_BY_EMAIL_NOTIFICATION
+            + RestTemplateLinks.EMAIL_NOTIFICATION + EmailNotification.IMMEDIATELY,
+            HttpMethod.GET, entity, new ParameterizedTypeReference<List<UserVO>>() {
+            }))
+            .thenReturn(ResponseEntity.status(HttpStatus.OK).body(userVOS));
 
         assertEquals(userVOS, restClient.findAllByEmailNotification(EmailNotification.IMMEDIATELY));
     }
@@ -554,9 +550,9 @@ class RestClientTest {
         Map<Integer, Long> expected = Collections.singletonMap(1, 1L);
 
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                        + RestTemplateLinks.FIND_ALL_REGISTRATION_MONTHS_MAP,
-                HttpMethod.GET, entity, new ParameterizedTypeReference<Map<Integer, Long>>() {
-                })).thenReturn(ResponseEntity.status(HttpStatus.OK).body(expected));
+            + RestTemplateLinks.FIND_ALL_REGISTRATION_MONTHS_MAP,
+            HttpMethod.GET, entity, new ParameterizedTypeReference<Map<Integer, Long>>() {
+            })).thenReturn(ResponseEntity.status(HttpStatus.OK).body(expected));
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
 
         assertEquals(expected, restClient.findAllRegistrationMonthsMap());
@@ -570,9 +566,9 @@ class RestClientTest {
         List<String> expected = Collections.singletonList("text");
 
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.FIND_ALL_USERS_CITIES,
-                HttpMethod.GET, entity, new ParameterizedTypeReference<List<String>>() {
-                }))
-                .thenReturn(ResponseEntity.status(HttpStatus.OK).body(expected));
+            HttpMethod.GET, entity, new ParameterizedTypeReference<List<String>>() {
+            }))
+            .thenReturn(ResponseEntity.status(HttpStatus.OK).body(expected));
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
 
         assertEquals(expected, restClient.findAllUsersCities());
@@ -587,14 +583,14 @@ class RestClientTest {
         HttpEntity<GeneralEmailMessage> entity = new HttpEntity<>(notification, headers);
 
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.SEND_GENERAL_EMAIL_NOTIFICATION, HttpMethod.POST, entity, Object.class))
-                .thenReturn(ResponseEntity.ok(Object));
+            + RestTemplateLinks.SEND_GENERAL_EMAIL_NOTIFICATION, HttpMethod.POST, entity, Object.class))
+            .thenReturn(ResponseEntity.ok(Object));
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
 
         restClient.sendEmailNotification(notification);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.SEND_GENERAL_EMAIL_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.SEND_GENERAL_EMAIL_NOTIFICATION, HttpMethod.POST, entity, Object.class);
     }
 
     @Test
@@ -606,14 +602,14 @@ class RestClientTest {
         HttpEntity<HabitAssignNotificationMessage> entity = new HttpEntity<>(notification, headers);
 
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.SEND_HABIT_ASSIGN_NOTIFICATION, HttpMethod.POST, entity, Object.class))
-                .thenReturn(ResponseEntity.ok(Object));
+            + RestTemplateLinks.SEND_HABIT_ASSIGN_NOTIFICATION, HttpMethod.POST, entity, Object.class))
+            .thenReturn(ResponseEntity.ok(Object));
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
 
         restClient.sendHabitAssignNotification(notification);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.SEND_HABIT_ASSIGN_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.SEND_HABIT_ASSIGN_NOTIFICATION, HttpMethod.POST, entity, Object.class);
     }
 
     @Test
@@ -625,18 +621,18 @@ class RestClientTest {
         HttpEntity<UserTaggedInCommentMessage> entity = new HttpEntity<>(message, headers);
 
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.SEND_USERS_MENTION_IN_COMMENT_NOTIFICATION, HttpMethod.POST, entity, Object.class))
-                .thenReturn(ResponseEntity.ok(Object));
+            + RestTemplateLinks.SEND_USERS_MENTION_IN_COMMENT_NOTIFICATION, HttpMethod.POST, entity, Object.class))
+            .thenReturn(ResponseEntity.ok(Object));
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
 
         restClient.sendUserTaggedInCommentNotification(message);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.SEND_USERS_MENTION_IN_COMMENT_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.SEND_USERS_MENTION_IN_COMMENT_NOTIFICATION, HttpMethod.POST, entity, Object.class);
     }
 
     @Test
-    void sendScheduledNotificationTest(){
+    void sendScheduledNotificationTest() {
         HttpHeaders headers = new HttpHeaders();
         headers.set(AUTHORIZATION, ACCESS_TOKEN);
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -645,13 +641,13 @@ class RestClientTest {
         HttpEntity<ScheduledEmailMessage> entity = new HttpEntity<>(message, headers);
 
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.SEND_SCHEDULED_NOTIFICATION, HttpMethod.POST, entity, Object.class))
-                .thenReturn(ResponseEntity.ok(Object));
+            + RestTemplateLinks.SEND_SCHEDULED_NOTIFICATION, HttpMethod.POST, entity, Object.class))
+            .thenReturn(ResponseEntity.ok(Object));
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
 
         restClient.sendScheduledEmailNotification(message);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-                + RestTemplateLinks.SEND_SCHEDULED_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+            + RestTemplateLinks.SEND_SCHEDULED_NOTIFICATION, HttpMethod.POST, entity, Object.class);
     }
 }

--- a/service-api/src/test/java/greencity/client/RestClientTest.java
+++ b/service-api/src/test/java/greencity/client/RestClientTest.java
@@ -15,8 +15,10 @@ import greencity.dto.achievement.UserVOAchievement;
 import greencity.dto.econews.EcoNewsForSendEmailDto;
 import greencity.dto.eventcomment.EventCommentForSendEmailDto;
 import greencity.enums.EmailNotification;
+import greencity.enums.NotificationType;
 import greencity.enums.Role;
 import greencity.message.GeneralEmailMessage;
+import greencity.message.ScheduledEmailMessage;
 import greencity.message.SendChangePlaceStatusEmailMessage;
 import greencity.message.SendHabitNotification;
 import greencity.message.SendReportEmailMessage;
@@ -86,8 +88,8 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.USER_FIND_BY_EMAIL
-            + RestTemplateLinks.EMAIL + "taras@gmail.com", HttpMethod.GET,
-            entity, UserVO.class)).thenReturn(ResponseEntity.ok(userVO));
+                        + RestTemplateLinks.EMAIL + "taras@gmail.com", HttpMethod.GET,
+                entity, UserVO.class)).thenReturn(ResponseEntity.ok(userVO));
 
         assertEquals(userVO, restClient.findByEmail("taras@gmail.com"));
     }
@@ -101,8 +103,8 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.USER_FIND_BY_ID + RestTemplateLinks.ID + 1L, HttpMethod.GET, entity, UserVO.class))
-            .thenReturn(ResponseEntity.ok(userVO));
+                + RestTemplateLinks.USER_FIND_BY_ID + RestTemplateLinks.ID + 1L, HttpMethod.GET, entity, UserVO.class))
+                .thenReturn(ResponseEntity.ok(userVO));
 
         assertEquals(userVO, restClient.findById(1L));
     }
@@ -116,8 +118,8 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.USER_FIND_BY_ID_FOR_ACHIEVEMENT + RestTemplateLinks.ID + 1L,
-            HttpMethod.GET, entity, UserVOAchievement.class)).thenReturn(ResponseEntity.ok(userVOAchievement));
+                        + RestTemplateLinks.USER_FIND_BY_ID_FOR_ACHIEVEMENT + RestTemplateLinks.ID + 1L,
+                HttpMethod.GET, entity, UserVOAchievement.class)).thenReturn(ResponseEntity.ok(userVOAchievement));
 
         assertEquals(userVOAchievement, restClient.findUserForAchievement(1L));
     }
@@ -131,15 +133,15 @@ class RestClientTest {
         Pageable pageable = PageRequest.of(0, 10);
         List<UserManagementDto> ecoNewsDtos = Collections.singletonList(new UserManagementDto());
         PageableAdvancedDto<UserManagementDto> pageableAdvancedDto =
-            new PageableAdvancedDto<>(ecoNewsDtos, 2, 0, 3, 0, true, true, true, true);
+                new PageableAdvancedDto<>(ecoNewsDtos, 2, 0, 3, 0, true, true, true, true);
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.SEARCH_BY + RestTemplateLinks.PAGE + pageable.getPageNumber()
-            + RestTemplateLinks.SIZE + pageable.getPageSize()
-            + RestTemplateLinks.QUERY + query, HttpMethod.GET, entity,
-            new ParameterizedTypeReference<PageableAdvancedDto<UserManagementDto>>() {
-            })).thenReturn(ResponseEntity.ok(pageableAdvancedDto));
+                        + RestTemplateLinks.SEARCH_BY + RestTemplateLinks.PAGE + pageable.getPageNumber()
+                        + RestTemplateLinks.SIZE + pageable.getPageSize()
+                        + RestTemplateLinks.QUERY + query, HttpMethod.GET, entity,
+                new ParameterizedTypeReference<PageableAdvancedDto<UserManagementDto>>() {
+                })).thenReturn(ResponseEntity.ok(pageableAdvancedDto));
 
         assertEquals(pageableAdvancedDto, restClient.searchBy(pageable, query));
     }
@@ -157,13 +159,13 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.USER + "/1", HttpMethod.PUT, entity, Object.class))
-            .thenReturn(ResponseEntity.ok(Object));
+                + RestTemplateLinks.USER + "/1", HttpMethod.PUT, entity, Object.class))
+                .thenReturn(ResponseEntity.ok(Object));
 
         restClient.updateUser(userManagementDto);
 
         assertEquals(ResponseEntity.ok(Object), restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.USER + "/1", HttpMethod.PUT, entity, Object.class));
+                + RestTemplateLinks.USER + "/1", HttpMethod.PUT, entity, Object.class));
     }
 
     @Test
@@ -171,7 +173,7 @@ class RestClientTest {
         Role newRole = Role.ROLE_MODERATOR;
         UserRoleDto userRoleDto = new UserRoleDto(newRole);
         String url = GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.USER + "/1/role";
+                + RestTemplateLinks.USER + "/1/role";
         HttpHeaders headers = new HttpHeaders();
         headers.set(AUTHORIZATION, ACCESS_TOKEN);
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -194,8 +196,8 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.USER_FIND_ALL, HttpMethod.GET, entity, UserVO[].class))
-            .thenReturn(ResponseEntity.of(Optional.of(userVOS)));
+                + RestTemplateLinks.USER_FIND_ALL, HttpMethod.GET, entity, UserVO[].class))
+                .thenReturn(ResponseEntity.of(Optional.of(userVOS)));
 
         assertEquals(Arrays.asList(userVOS), restClient.findAll());
     }
@@ -210,12 +212,12 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.USER + "/" + 1L + RestTemplateLinks.FRIENDS, HttpMethod.GET, entity,
-            UserManagementDto[].class)).thenReturn(ResponseEntity.ok(userManagementDtos));
+                        + RestTemplateLinks.USER + "/" + 1L + RestTemplateLinks.FRIENDS, HttpMethod.GET, entity,
+                UserManagementDto[].class)).thenReturn(ResponseEntity.ok(userManagementDtos));
         restClient.findUserFriendsByUserId(1L);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.USER + "/"
-            + 1L + RestTemplateLinks.FRIENDS, HttpMethod.GET, entity, UserManagementDto[].class);
+                + 1L + RestTemplateLinks.FRIENDS, HttpMethod.GET, entity, UserManagementDto[].class);
     }
 
     @Test
@@ -228,8 +230,8 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.USER_FIND_NOT_DEACTIVATED_BY_EMAIL + RestTemplateLinks.EMAIL
-            + email, HttpMethod.GET, entity, UserVO.class)).thenReturn(ResponseEntity.ok(userVO));
+                + RestTemplateLinks.USER_FIND_NOT_DEACTIVATED_BY_EMAIL + RestTemplateLinks.EMAIL
+                + email, HttpMethod.GET, entity, UserVO.class)).thenReturn(ResponseEntity.ok(userVO));
 
         assertEquals(Optional.of(userVO), restClient.findNotDeactivatedByEmail(email));
     }
@@ -245,8 +247,8 @@ class RestClientTest {
         when(httpServletRequest.getCookies()).thenReturn(cookies);
         when(httpServletRequest.getRequestURI()).thenReturn("/management");
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.USER_FIND_NOT_DEACTIVATED_BY_EMAIL + RestTemplateLinks.EMAIL
-            + email, HttpMethod.GET, entity, UserVO.class)).thenReturn(ResponseEntity.ok(userVO));
+                + RestTemplateLinks.USER_FIND_NOT_DEACTIVATED_BY_EMAIL + RestTemplateLinks.EMAIL
+                + email, HttpMethod.GET, entity, UserVO.class)).thenReturn(ResponseEntity.ok(userVO));
 
         assertEquals(Optional.of(userVO), restClient.findNotDeactivatedByEmail(email));
     }
@@ -260,9 +262,9 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.USER_FIND_ID_BY_EMAIL
-            + RestTemplateLinks.EMAIL + email, HttpMethod.GET, entity, Long.class))
-            .thenReturn(ResponseEntity.ok(1L));
+                + RestTemplateLinks.USER_FIND_ID_BY_EMAIL
+                + RestTemplateLinks.EMAIL + email, HttpMethod.GET, entity, Long.class))
+                .thenReturn(ResponseEntity.ok(1L));
 
         assertEquals(1L, restClient.findIdByEmail(email));
     }
@@ -277,9 +279,9 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.USER_REASONS
-            + RestTemplateLinks.ID + 1L
-            + RestTemplateLinks.ADMIN_LANG + "en", HttpMethod.GET, entity, String[].class))
-            .thenReturn(ResponseEntity.ok(test));
+                + RestTemplateLinks.ID + 1L
+                + RestTemplateLinks.ADMIN_LANG + "en", HttpMethod.GET, entity, String[].class))
+                .thenReturn(ResponseEntity.ok(test));
 
         assertEquals(listString, restClient.getDeactivationReason(1L, "en"));
     }
@@ -293,8 +295,8 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.USER_LANG
-            + RestTemplateLinks.ID + 1L, HttpMethod.GET, entity, String.class))
-            .thenReturn(ResponseEntity.ok(test));
+                + RestTemplateLinks.ID + 1L, HttpMethod.GET, entity, String.class))
+                .thenReturn(ResponseEntity.ok(test));
 
         assertEquals(test, restClient.getUserLang(1L));
     }
@@ -309,13 +311,13 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.USER_DEACTIVATE
-            + RestTemplateLinks.ID + 1L, HttpMethod.PUT, entity, Object.class))
-            .thenReturn(ResponseEntity.ok(Object));
+                + RestTemplateLinks.ID + 1L, HttpMethod.PUT, entity, Object.class))
+                .thenReturn(ResponseEntity.ok(Object));
 
         restClient.deactivateUser(1L, test);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.USER_DEACTIVATE
-            + RestTemplateLinks.ID + 1L, HttpMethod.PUT, entity, Object.class);
+                + RestTemplateLinks.ID + 1L, HttpMethod.PUT, entity, Object.class);
     }
 
     @Test
@@ -326,13 +328,13 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.USER_ACTIVATE
-            + RestTemplateLinks.ID + 1L, HttpMethod.PUT, entity, Object.class))
-            .thenReturn(ResponseEntity.ok(Object));
+                + RestTemplateLinks.ID + 1L, HttpMethod.PUT, entity, Object.class))
+                .thenReturn(ResponseEntity.ok(Object));
 
         restClient.setActivatedStatus(1L);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.USER_ACTIVATE
-            + RestTemplateLinks.ID + 1L, HttpMethod.PUT, entity, Object.class);
+                + RestTemplateLinks.ID + 1L, HttpMethod.PUT, entity, Object.class);
     }
 
     @Test
@@ -351,8 +353,8 @@ class RestClientTest {
         restClient.deactivateAllUsers(listId);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.USER_DEACTIVATE
-            + RestTemplateLinks.ID + listId, HttpMethod.PUT, entity, Long[].class);
+                + RestTemplateLinks.USER_DEACTIVATE
+                + RestTemplateLinks.ID + listId, HttpMethod.PUT, entity, Long[].class);
 
     }
 
@@ -366,13 +368,13 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.OWN_SECURITY_REGISTER, HttpMethod.POST, entity, Object.class))
-            .thenReturn(ResponseEntity.ok(Object));
+                + RestTemplateLinks.OWN_SECURITY_REGISTER, HttpMethod.POST, entity, Object.class))
+                .thenReturn(ResponseEntity.ok(Object));
 
         restClient.managementRegisterUser(userManagementDto);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.OWN_SECURITY_REGISTER, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.OWN_SECURITY_REGISTER, HttpMethod.POST, entity, Object.class);
     }
 
     @Test
@@ -385,13 +387,13 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.ADD_ECO_NEWS, HttpMethod.POST, entity, Object.class))
-            .thenReturn(ResponseEntity.ok(Object));
+                + RestTemplateLinks.ADD_ECO_NEWS, HttpMethod.POST, entity, Object.class))
+                .thenReturn(ResponseEntity.ok(Object));
 
         restClient.addEcoNews(message);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.ADD_ECO_NEWS, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.ADD_ECO_NEWS, HttpMethod.POST, entity, Object.class);
     }
 
     @Test
@@ -404,13 +406,13 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.ADD_EVENT_COMMENT, HttpMethod.POST, entity, Object.class))
-            .thenReturn(ResponseEntity.ok(Object));
+                + RestTemplateLinks.ADD_EVENT_COMMENT, HttpMethod.POST, entity, Object.class))
+                .thenReturn(ResponseEntity.ok(Object));
 
         restClient.sendNewEventComment(message);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.ADD_EVENT_COMMENT, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.ADD_EVENT_COMMENT, HttpMethod.POST, entity, Object.class);
     }
 
     @Test
@@ -418,14 +420,14 @@ class RestClientTest {
         SendReportEmailMessage message = ModelUtils.getSendReportEmailMessage();
         HttpEntity<SendReportEmailMessage> entity = new HttpEntity<>(message, ModelUtils.getHeaders());
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.SEND_REPORT, HttpMethod.POST, entity, Object.class))
-            .thenReturn(ResponseEntity.ok(Object));
+                + RestTemplateLinks.SEND_REPORT, HttpMethod.POST, entity, Object.class))
+                .thenReturn(ResponseEntity.ok(Object));
         when(jwtTool.createAccessToken(SYSTEM_EMAIL, Role.ROLE_ADMIN)).thenReturn("accessToken");
         restClient.sendReport(message);
 
         verify(jwtTool).createAccessToken(SYSTEM_EMAIL, Role.ROLE_ADMIN);
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.SEND_REPORT, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.SEND_REPORT, HttpMethod.POST, entity, Object.class);
     }
 
     @Test
@@ -438,13 +440,13 @@ class RestClientTest {
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.CHANGE_PLACE_STATUS, HttpMethod.POST, entity, Object.class))
-            .thenReturn(ResponseEntity.ok(Object));
+                + RestTemplateLinks.CHANGE_PLACE_STATUS, HttpMethod.POST, entity, Object.class))
+                .thenReturn(ResponseEntity.ok(Object));
 
         restClient.changePlaceStatus(message);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.CHANGE_PLACE_STATUS, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.CHANGE_PLACE_STATUS, HttpMethod.POST, entity, Object.class);
     }
 
     @Test
@@ -453,15 +455,15 @@ class RestClientTest {
         HttpEntity<SendHabitNotification> entity = new HttpEntity<>(notification, ModelUtils.getHeaders());
 
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.SEND_HABIT_NOTIFICATION, HttpMethod.POST, entity, Object.class))
-            .thenReturn(ResponseEntity.ok(Object));
+                + RestTemplateLinks.SEND_HABIT_NOTIFICATION, HttpMethod.POST, entity, Object.class))
+                .thenReturn(ResponseEntity.ok(Object));
         when(jwtTool.createAccessToken(SYSTEM_EMAIL, Role.ROLE_ADMIN)).thenReturn("accessToken");
 
         restClient.sendHabitNotification(notification);
 
         verify(jwtTool).createAccessToken(SYSTEM_EMAIL, Role.ROLE_ADMIN);
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.SEND_HABIT_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.SEND_HABIT_NOTIFICATION, HttpMethod.POST, entity, Object.class);
     }
 
     @Test
@@ -472,14 +474,14 @@ class RestClientTest {
         Pageable pageable = PageRequest.of(0, 10, Sort.by("id").ascending());
         List<UserManagementDto> ecoNewsDtos = Collections.singletonList(new UserManagementDto());
         PageableAdvancedDto<UserManagementDto> pageableAdvancedDto =
-            new PageableAdvancedDto<>(ecoNewsDtos, 2, 0, 3, 0, true, true, true, true);
+                new PageableAdvancedDto<>(ecoNewsDtos, 2, 0, 3, 0, true, true, true, true);
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.USER_FIND_USER_FOR_MANAGEMENT + RestTemplateLinks.PAGE + pageable.getPageNumber()
-            + RestTemplateLinks.SIZE + pageable.getPageSize() + "&sort=id,ASC", HttpMethod.GET, entity,
-            new ParameterizedTypeReference<PageableAdvancedDto<UserManagementDto>>() {
-            })).thenReturn(ResponseEntity.ok(pageableAdvancedDto));
+                        + RestTemplateLinks.USER_FIND_USER_FOR_MANAGEMENT + RestTemplateLinks.PAGE + pageable.getPageNumber()
+                        + RestTemplateLinks.SIZE + pageable.getPageSize() + "&sort=id,ASC", HttpMethod.GET, entity,
+                new ParameterizedTypeReference<PageableAdvancedDto<UserManagementDto>>() {
+                })).thenReturn(ResponseEntity.ok(pageableAdvancedDto));
 
         assertEquals(pageableAdvancedDto, restClient.findUserForManagementByPage(pageable));
     }
@@ -491,27 +493,27 @@ class RestClientTest {
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.set(AUTHORIZATION, ACCESS_TOKEN);
         UserManagementViewDto userViewDto =
-            UserManagementViewDto.builder()
-                .id("1L")
-                .name("vivo")
-                .email("test@ukr.net")
-                .userCredo("Hello")
-                .role("1")
-                .userStatus("1")
-                .build();
+                UserManagementViewDto.builder()
+                        .id("1L")
+                        .name("vivo")
+                        .email("test@ukr.net")
+                        .userCredo("Hello")
+                        .role("1")
+                        .userStatus("1")
+                        .build();
         List<UserManagementVO> userManagementVOS = Collections.singletonList(new UserManagementVO());
         PageableAdvancedDto<UserManagementVO> userAdvancedDto =
-            new PageableAdvancedDto<>(userManagementVOS, 20, 0, 0, 0,
-                true, true, true, true);
+                new PageableAdvancedDto<>(userManagementVOS, 20, 0, 0, 0,
+                        true, true, true, true);
         HttpEntity<UserManagementViewDto> entity = new HttpEntity<>(userViewDto, headers);
 
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.USER_SEARCH + RestTemplateLinks.PAGE + pageable.getPageNumber()
-            + RestTemplateLinks.SIZE + pageable.getPageSize()
-            + RestTemplateLinks.SORT, HttpMethod.POST, entity,
-            new ParameterizedTypeReference<PageableAdvancedDto<UserManagementVO>>() {
-            })).thenReturn(ResponseEntity.ok(userAdvancedDto));
+                        + RestTemplateLinks.USER_SEARCH + RestTemplateLinks.PAGE + pageable.getPageNumber()
+                        + RestTemplateLinks.SIZE + pageable.getPageSize()
+                        + RestTemplateLinks.SORT, HttpMethod.POST, entity,
+                new ParameterizedTypeReference<PageableAdvancedDto<UserManagementVO>>() {
+                })).thenReturn(ResponseEntity.ok(userAdvancedDto));
 
         assertEquals(userAdvancedDto, restClient.search(pageable, userViewDto));
     }
@@ -521,12 +523,12 @@ class RestClientTest {
         HttpEntity<String> entity = new HttpEntity<>(new HttpHeaders());
 
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.DELETE_DEACTIVATED_USERS,
-            HttpMethod.POST, entity, Object.class))
-            .thenReturn(ResponseEntity.ok(Object));
+                HttpMethod.POST, entity, Object.class))
+                .thenReturn(ResponseEntity.ok(Object));
         restClient.scheduleDeleteDeactivatedUsers();
 
         verify(restTemplate, times(1)).exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.DELETE_DEACTIVATED_USERS,
-            HttpMethod.POST, entity, Object.class);
+                HttpMethod.POST, entity, Object.class);
     }
 
     @Test
@@ -535,11 +537,11 @@ class RestClientTest {
         List<UserVO> userVOS = Collections.singletonList(ModelUtils.getUserVO());
 
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.USER_FIND_ALL_BY_EMAIL_NOTIFICATION
-            + RestTemplateLinks.EMAIL_NOTIFICATION + EmailNotification.IMMEDIATELY,
-            HttpMethod.GET, entity, new ParameterizedTypeReference<List<UserVO>>() {
-            }))
-            .thenReturn(ResponseEntity.status(HttpStatus.OK).body(userVOS));
+                        + RestTemplateLinks.USER_FIND_ALL_BY_EMAIL_NOTIFICATION
+                        + RestTemplateLinks.EMAIL_NOTIFICATION + EmailNotification.IMMEDIATELY,
+                HttpMethod.GET, entity, new ParameterizedTypeReference<List<UserVO>>() {
+                }))
+                .thenReturn(ResponseEntity.status(HttpStatus.OK).body(userVOS));
 
         assertEquals(userVOS, restClient.findAllByEmailNotification(EmailNotification.IMMEDIATELY));
     }
@@ -552,9 +554,9 @@ class RestClientTest {
         Map<Integer, Long> expected = Collections.singletonMap(1, 1L);
 
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.FIND_ALL_REGISTRATION_MONTHS_MAP,
-            HttpMethod.GET, entity, new ParameterizedTypeReference<Map<Integer, Long>>() {
-            })).thenReturn(ResponseEntity.status(HttpStatus.OK).body(expected));
+                        + RestTemplateLinks.FIND_ALL_REGISTRATION_MONTHS_MAP,
+                HttpMethod.GET, entity, new ParameterizedTypeReference<Map<Integer, Long>>() {
+                })).thenReturn(ResponseEntity.status(HttpStatus.OK).body(expected));
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
 
         assertEquals(expected, restClient.findAllRegistrationMonthsMap());
@@ -568,9 +570,9 @@ class RestClientTest {
         List<String> expected = Collections.singletonList("text");
 
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS + RestTemplateLinks.FIND_ALL_USERS_CITIES,
-            HttpMethod.GET, entity, new ParameterizedTypeReference<List<String>>() {
-            }))
-            .thenReturn(ResponseEntity.status(HttpStatus.OK).body(expected));
+                HttpMethod.GET, entity, new ParameterizedTypeReference<List<String>>() {
+                }))
+                .thenReturn(ResponseEntity.status(HttpStatus.OK).body(expected));
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
 
         assertEquals(expected, restClient.findAllUsersCities());
@@ -585,14 +587,14 @@ class RestClientTest {
         HttpEntity<GeneralEmailMessage> entity = new HttpEntity<>(notification, headers);
 
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.SEND_GENERAL_EMAIL_NOTIFICATION, HttpMethod.POST, entity, Object.class))
-            .thenReturn(ResponseEntity.ok(Object));
+                + RestTemplateLinks.SEND_GENERAL_EMAIL_NOTIFICATION, HttpMethod.POST, entity, Object.class))
+                .thenReturn(ResponseEntity.ok(Object));
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
 
         restClient.sendEmailNotification(notification);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.SEND_GENERAL_EMAIL_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.SEND_GENERAL_EMAIL_NOTIFICATION, HttpMethod.POST, entity, Object.class);
     }
 
     @Test
@@ -604,14 +606,14 @@ class RestClientTest {
         HttpEntity<HabitAssignNotificationMessage> entity = new HttpEntity<>(notification, headers);
 
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.SEND_HABIT_ASSIGN_NOTIFICATION, HttpMethod.POST, entity, Object.class))
-            .thenReturn(ResponseEntity.ok(Object));
+                + RestTemplateLinks.SEND_HABIT_ASSIGN_NOTIFICATION, HttpMethod.POST, entity, Object.class))
+                .thenReturn(ResponseEntity.ok(Object));
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
 
         restClient.sendHabitAssignNotification(notification);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.SEND_HABIT_ASSIGN_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.SEND_HABIT_ASSIGN_NOTIFICATION, HttpMethod.POST, entity, Object.class);
     }
 
     @Test
@@ -623,51 +625,33 @@ class RestClientTest {
         HttpEntity<UserTaggedInCommentMessage> entity = new HttpEntity<>(message, headers);
 
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.SEND_USERS_MENTION_IN_COMMENT_NOTIFICATION, HttpMethod.POST, entity, Object.class))
-            .thenReturn(ResponseEntity.ok(Object));
+                + RestTemplateLinks.SEND_USERS_MENTION_IN_COMMENT_NOTIFICATION, HttpMethod.POST, entity, Object.class))
+                .thenReturn(ResponseEntity.ok(Object));
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
 
         restClient.sendUserTaggedInCommentNotification(message);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.SEND_USERS_MENTION_IN_COMMENT_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.SEND_USERS_MENTION_IN_COMMENT_NOTIFICATION, HttpMethod.POST, entity, Object.class);
     }
 
     @Test
-    void sendUserReceivedCommentNotification() {
+    void sendScheduledNotificationTest(){
         HttpHeaders headers = new HttpHeaders();
         headers.set(AUTHORIZATION, ACCESS_TOKEN);
         headers.setContentType(MediaType.APPLICATION_JSON);
-        UserReceivedCommentMessage message = ModelUtils.getUserReceivedCommentMessage();
-        HttpEntity<UserReceivedCommentMessage> entity = new HttpEntity<>(message, headers);
+        ScheduledEmailMessage message = ModelUtils.getScheduledEmailMessage();
+
+        HttpEntity<ScheduledEmailMessage> entity = new HttpEntity<>(message, headers);
 
         when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.SEND_USER_RECEIVED_COMMENT_NOTIFICATION, HttpMethod.POST, entity, Object.class))
-            .thenReturn(ResponseEntity.ok(Object));
+                + RestTemplateLinks.SEND_SCHEDULED_NOTIFICATION, HttpMethod.POST, entity, Object.class))
+                .thenReturn(ResponseEntity.ok(Object));
         when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
 
-        restClient.sendUserReceivedCommentNotification(message);
+        restClient.sendScheduledEmailNotification(message);
 
         verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.SEND_USER_RECEIVED_COMMENT_NOTIFICATION, HttpMethod.POST, entity, Object.class);
-    }
-
-    @Test
-    void sendUserReceivedCommentReplyNotification() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.set(AUTHORIZATION, ACCESS_TOKEN);
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        UserReceivedCommentReplyMessage message = ModelUtils.getUserReceivedCommentReplyMessage();
-        HttpEntity<UserReceivedCommentReplyMessage> entity = new HttpEntity<>(message, headers);
-
-        when(restTemplate.exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.SEND_USER_RECEIVED_COMMENT_REPLY_NOTIFICATION, HttpMethod.POST, entity, Object.class))
-            .thenReturn(ResponseEntity.ok(Object));
-        when(jwtTool.createAccessToken(anyString(), any(Role.class))).thenReturn(TOKEN);
-
-        restClient.sendUserReceivedCommentReplyNotification(message);
-
-        verify(restTemplate).exchange(GREEN_CITY_USER_ADDRESS
-            + RestTemplateLinks.SEND_USER_RECEIVED_COMMENT_REPLY_NOTIFICATION, HttpMethod.POST, entity, Object.class);
+                + RestTemplateLinks.SEND_SCHEDULED_NOTIFICATION, HttpMethod.POST, entity, Object.class);
     }
 }

--- a/service/src/main/java/greencity/service/EcoNewsCommentServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsCommentServiceImpl.java
@@ -1,7 +1,6 @@
 package greencity.service;
 
 import greencity.achievement.AchievementCalculation;
-import greencity.constant.EmailNotificationMessagesConstants;
 import greencity.constant.ErrorMessage;
 import greencity.dto.PageableDto;
 import greencity.dto.econews.EcoNewsVO;
@@ -25,7 +24,6 @@ import greencity.enums.Role;
 import greencity.exception.exceptions.BadRequestException;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.exception.exceptions.UserHasNoPermissionToAccessException;
-import greencity.message.GeneralEmailMessage;
 import greencity.rating.RatingCalculation;
 import greencity.repository.EcoNewsCommentRepo;
 import greencity.repository.EcoNewsRepo;
@@ -79,12 +77,6 @@ public class EcoNewsCommentServiceImpl implements EcoNewsCommentService {
                     () -> new BadRequestException(ErrorMessage.COMMENT_NOT_FOUND_EXCEPTION));
             if (parentComment.getParentComment() == null) {
                 ecoNewsComment.setParentComment(parentComment);
-                notificationService.sendEmailNotification(GeneralEmailMessage.builder()
-                    .email(parentComment.getUser().getEmail())
-                    .subject(EmailNotificationMessagesConstants.REPLY_SUBJECT)
-                    .message(String.format(EmailNotificationMessagesConstants.REPLY_MESSAGE,
-                        ecoNewsComment.getUser().getName()))
-                    .build());
                 userNotificationService.createNotification(modelMapper.map(parentComment.getUser(), UserVO.class),
                     userVO, NotificationType.ECONEWS_COMMENT_REPLY, parentComment.getId(), parentComment.getText(),
                     econewsId, ecoNewsVO.getTitle());
@@ -97,11 +89,6 @@ public class EcoNewsCommentServiceImpl implements EcoNewsCommentService {
                 AchievementCategoryType.COMMENT_OR_REPLY, AchievementAction.ASSIGN);
         ratingCalculation.ratingCalculation(RatingCalculationEnum.COMMENT_OR_REPLY, userVO);
         ecoNewsComment.setStatus(CommentStatus.ORIGINAL);
-        notificationService.sendEmailNotification(GeneralEmailMessage.builder()
-            .email(ecoNewsVO.getAuthor().getEmail())
-            .subject(EmailNotificationMessagesConstants.ECONEWS_COMMENTED_SUBJECT)
-            .message(String.format(EmailNotificationMessagesConstants.ECONEWS_COMMENTED_MESSAGE, ecoNewsVO.getTitle()))
-            .build());
         userNotificationService.createNotification(ecoNewsVO.getAuthor(), userVO, NotificationType.ECONEWS_COMMENT,
             econewsId, ecoNewsVO.getTitle());
         return modelMapper.map(ecoNewsCommentRepo.save(ecoNewsComment), AddEcoNewsCommentDtoResponse.class);
@@ -219,11 +206,6 @@ public class EcoNewsCommentServiceImpl implements EcoNewsCommentService {
                 throw new BadRequestException(ErrorMessage.USER_HAS_NO_PERMISSION);
             }
             ecoNewsService.likeComment(userVO, ecoNewsCommentVO);
-            notificationService.sendEmailNotification(GeneralEmailMessage.builder()
-                .email(comment.getUser().getEmail())
-                .subject(EmailNotificationMessagesConstants.COMMENT_LIKE_SUBJECT)
-                .message(String.format(EmailNotificationMessagesConstants.COMMENT_LIKE_MESSAGE, userVO.getName()))
-                .build());
             EcoNews ecoNews = comment.getEcoNews();
             userNotificationService.createNotification(modelMapper.map(comment.getUser(), UserVO.class), userVO,
                 NotificationType.ECONEWS_COMMENT_LIKE, comment.getId(), comment.getText(),

--- a/service/src/main/java/greencity/service/EventCommentServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventCommentServiceImpl.java
@@ -79,16 +79,16 @@ public class EventCommentServiceImpl implements EventCommentService {
     @Override
     @Transactional
     public AddEventCommentDtoResponse save(Long eventId, AddEventCommentDtoRequest addEventCommentDtoRequest,
-                                           UserVO userVO, Locale locale) {
+        UserVO userVO, Locale locale) {
         EventComment eventComment = modelMapper.map(addEventCommentDtoRequest, EventComment.class);
         EventVO eventVO = eventService.findById(eventId);
         eventComment.setUser(modelMapper.map(userVO, User.class));
         eventComment.setEvent(modelMapper.map(eventVO, Event.class));
         if (addEventCommentDtoRequest.getParentCommentId() != null
-                && addEventCommentDtoRequest.getParentCommentId() > 0) {
+            && addEventCommentDtoRequest.getParentCommentId() > 0) {
             Long parentCommentId = addEventCommentDtoRequest.getParentCommentId();
             EventComment parentEventComment = eventCommentRepo.findById(parentCommentId)
-                    .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_COMMENT_NOT_FOUND_BY_ID + parentCommentId));
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_COMMENT_NOT_FOUND_BY_ID + parentCommentId));
 
             if (parentEventComment.getParentComment() != null) {
                 throw new BadRequestException(ErrorMessage.CANNOT_REPLY_THE_REPLY);
@@ -96,24 +96,24 @@ public class EventCommentServiceImpl implements EventCommentService {
 
             if (!parentEventComment.getEvent().getId().equals(eventId)) {
                 String message = ErrorMessage.EVENT_COMMENT_NOT_FOUND_BY_ID + parentCommentId
-                        + " in event with id: " + eventId;
+                    + " in event with id: " + eventId;
                 throw new NotFoundException(message);
             }
             userNotificationService.createNotification(modelMapper.map(parentEventComment.getUser(), UserVO.class),
-                    userVO, NotificationType.EVENT_COMMENT_REPLY, parentCommentId, parentEventComment.getText(),
-                    eventId, eventVO.getTitle());
+                userVO, NotificationType.EVENT_COMMENT_REPLY, parentCommentId, parentEventComment.getText(),
+                eventId, eventVO.getTitle());
         }
         eventComment.setStatus(CommentStatus.ORIGINAL);
         AddEventCommentDtoResponse addEventCommentDtoResponse = modelMapper.map(
-                eventCommentRepo.save(eventComment), AddEventCommentDtoResponse.class);
+            eventCommentRepo.save(eventComment), AddEventCommentDtoResponse.class);
         addEventCommentDtoResponse.setAuthor(modelMapper.map(userVO, EventCommentAuthorDto.class));
         EventCommentVO eventCommentVO = eventCommentVOMapper.convert(eventComment);
         sendNotificationToTaggedUser(eventVO, userVO, eventCommentVO, locale);
         ratingCalculation.ratingCalculation(RatingCalculationEnum.COMMENT_OR_REPLY, userVO);
         achievementCalculation.calculateAchievement(userVO,
-                AchievementCategoryType.COMMENT_OR_REPLY, AchievementAction.ASSIGN);
+            AchievementCategoryType.COMMENT_OR_REPLY, AchievementAction.ASSIGN);
         userNotificationService.createNotification(eventVO.getOrganizer(), userVO, NotificationType.EVENT_COMMENT,
-                eventId, eventVO.getTitle(), eventComment.getId(), eventComment.getText());
+            eventId, eventVO.getTitle(), eventComment.getId(), eventComment.getText());
         return addEventCommentDtoResponse;
     }
 
@@ -126,11 +126,11 @@ public class EventCommentServiceImpl implements EventCommentService {
     @Override
     public EventCommentDto getEventCommentById(Long id, UserVO userVO) {
         EventComment eventComment = eventCommentRepo.findById(id)
-                .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_COMMENT_NOT_FOUND_BY_ID + id));
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_COMMENT_NOT_FOUND_BY_ID + id));
 
         if (userVO != null) {
             eventComment.setCurrentUserLiked(eventComment.getUsersLiked().stream()
-                    .anyMatch(u -> u.getId().equals(userVO.getId())));
+                .anyMatch(u -> u.getId().equals(userVO.getId())));
         }
 
         return modelMapper.map(eventComment, EventCommentDto.class);
@@ -145,7 +145,7 @@ public class EventCommentServiceImpl implements EventCommentService {
     @Override
     public int countComments(Long eventId) {
         Event event = eventRepo.findById(eventId)
-                .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + eventId));
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + eventId));
         return eventCommentRepo.countNotDeletedEventCommentsByEvent(event.getId());
     }
 
@@ -165,25 +165,25 @@ public class EventCommentServiceImpl implements EventCommentService {
         }
 
         Page<EventComment> pages =
-                eventCommentRepo.findAllByParentCommentIdIsNullAndEventIdAndStatusNotOrderByCreatedDateDesc(pageable,
-                        eventId, CommentStatus.DELETED);
+            eventCommentRepo.findAllByParentCommentIdIsNullAndEventIdAndStatusNotOrderByCreatedDateDesc(pageable,
+                eventId, CommentStatus.DELETED);
 
         if (userVO != null) {
             pages.forEach(eventComment -> eventComment.setCurrentUserLiked(eventComment.getUsersLiked()
-                    .stream()
-                    .anyMatch(u -> u.getId().equals(userVO.getId()))));
+                .stream()
+                .anyMatch(u -> u.getId().equals(userVO.getId()))));
         }
 
         List<EventCommentDto> eventCommentDto = pages
-                .stream()
-                .map(eventComment -> modelMapper.map(eventComment, EventCommentDto.class))
-                .collect(Collectors.toList());
+            .stream()
+            .map(eventComment -> modelMapper.map(eventComment, EventCommentDto.class))
+            .collect(Collectors.toList());
 
         return new PageableDto<>(
-                eventCommentDto,
-                pages.getTotalElements(),
-                pages.getPageable().getPageNumber(),
-                pages.getTotalPages());
+            eventCommentDto,
+            pages.getTotalElements(),
+            pages.getPageable().getPageNumber(),
+            pages.getTotalPages());
     }
 
     /**
@@ -198,7 +198,7 @@ public class EventCommentServiceImpl implements EventCommentService {
     @Transactional
     public void update(String commentText, Long id, UserVO userVO, Locale locale) {
         EventComment eventComment = eventCommentRepo.findByIdAndStatusNot(id, CommentStatus.DELETED)
-                .orElseThrow(() -> new NotFoundException(ErrorMessage.COMMENT_NOT_FOUND_EXCEPTION));
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.COMMENT_NOT_FOUND_EXCEPTION));
         if (!userVO.getId().equals(eventComment.getUser().getId())) {
             throw new BadRequestException(ErrorMessage.NOT_A_CURRENT_USER);
         }
@@ -221,8 +221,8 @@ public class EventCommentServiceImpl implements EventCommentService {
     @Override
     public void delete(Long eventCommentId, UserVO user) {
         EventComment eventComment = eventCommentRepo
-                .findByIdAndStatusNot(eventCommentId, CommentStatus.DELETED)
-                .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_COMMENT_NOT_FOUND_BY_ID + eventCommentId));
+            .findByIdAndStatusNot(eventCommentId, CommentStatus.DELETED)
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_COMMENT_NOT_FOUND_BY_ID + eventCommentId));
 
         if (user.getRole() != Role.ROLE_ADMIN && !user.getId().equals(eventComment.getUser().getId())) {
             throw new UserHasNoPermissionToAccessException(ErrorMessage.USER_HAS_NO_PERMISSION);
@@ -230,11 +230,11 @@ public class EventCommentServiceImpl implements EventCommentService {
         eventComment.setStatus(CommentStatus.DELETED);
         if (eventComment.getComments() != null) {
             eventComment.getComments()
-                    .forEach(comment -> comment.setStatus(CommentStatus.DELETED));
+                .forEach(comment -> comment.setStatus(CommentStatus.DELETED));
         }
         ratingCalculation.ratingCalculation(RatingCalculationEnum.UNDO_COMMENT_OR_REPLY, user);
         achievementCalculation.calculateAchievement(user,
-                AchievementCategoryType.COMMENT_OR_REPLY, AchievementAction.DELETE);
+            AchievementCategoryType.COMMENT_OR_REPLY, AchievementAction.DELETE);
 
         eventCommentRepo.save(eventComment);
     }
@@ -251,23 +251,23 @@ public class EventCommentServiceImpl implements EventCommentService {
     @Override
     public PageableDto<EventCommentDto> findAllActiveReplies(Pageable pageable, Long parentCommentId, UserVO userVO) {
         Page<EventComment> pages =
-                eventCommentRepo.findAllByParentCommentIdAndStatusNotOrderByCreatedDateDesc(pageable, parentCommentId,
-                        CommentStatus.DELETED);
+            eventCommentRepo.findAllByParentCommentIdAndStatusNotOrderByCreatedDateDesc(pageable, parentCommentId,
+                CommentStatus.DELETED);
 
         if (userVO != null) {
             pages.forEach(ec -> ec.setCurrentUserLiked(ec.getUsersLiked().stream()
-                    .anyMatch(u -> u.getId().equals(userVO.getId()))));
+                .anyMatch(u -> u.getId().equals(userVO.getId()))));
         }
 
         List<EventCommentDto> eventCommentDtos = pages.stream()
-                .map(eventComment -> modelMapper.map(eventComment, EventCommentDto.class))
-                .collect(Collectors.toList());
+            .map(eventComment -> modelMapper.map(eventComment, EventCommentDto.class))
+            .collect(Collectors.toList());
 
         return new PageableDto<>(
-                eventCommentDtos,
-                pages.getTotalElements(),
-                pages.getPageable().getPageNumber(),
-                pages.getTotalPages());
+            eventCommentDtos,
+            pages.getTotalElements(),
+            pages.getPageable().getPageNumber(),
+            pages.getTotalPages());
     }
 
     /**
@@ -293,28 +293,28 @@ public class EventCommentServiceImpl implements EventCommentService {
     @Override
     public void like(Long commentId, UserVO userVO) {
         EventComment comment = eventCommentRepo.findByIdAndStatusNot(commentId, CommentStatus.DELETED)
-                .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_COMMENT_NOT_FOUND_BY_ID + commentId));
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_COMMENT_NOT_FOUND_BY_ID + commentId));
         if (comment.getUsersLiked().stream().anyMatch(user -> user.getId().equals(userVO.getId()))) {
             comment.getUsersLiked().removeIf(user -> user.getId().equals(userVO.getId()));
             ratingCalculation.ratingCalculation(RatingCalculationEnum.UNDO_LIKE_COMMENT_OR_REPLY, userVO);
             achievementCalculation.calculateAchievement(userVO,
-                    AchievementCategoryType.LIKE_COMMENT_OR_REPLY, AchievementAction.DELETE);
+                AchievementCategoryType.LIKE_COMMENT_OR_REPLY, AchievementAction.DELETE);
             userNotificationService.removeActionUserFromNotification(modelMapper.map(comment.getUser(), UserVO.class),
-                    userVO, commentId, NotificationType.EVENT_COMMENT_LIKE);
+                userVO, commentId, NotificationType.EVENT_COMMENT_LIKE);
         } else {
             comment.getUsersLiked().add(modelMapper.map(userVO, User.class));
             achievementCalculation.calculateAchievement(userVO,
-                    AchievementCategoryType.LIKE_COMMENT_OR_REPLY, AchievementAction.ASSIGN);
+                AchievementCategoryType.LIKE_COMMENT_OR_REPLY, AchievementAction.ASSIGN);
             ratingCalculation.ratingCalculation(RatingCalculationEnum.LIKE_COMMENT_OR_REPLY, userVO);
             notificationService.sendEmailNotification(GeneralEmailMessage.builder()
-                    .email(comment.getUser().getEmail())
-                    .subject(EmailNotificationMessagesConstants.COMMENT_LIKE_SUBJECT)
-                    .message(String.format(EmailNotificationMessagesConstants.COMMENT_LIKE_MESSAGE,
-                            userVO.getName()))
-                    .build());
+                .email(comment.getUser().getEmail())
+                .subject(EmailNotificationMessagesConstants.COMMENT_LIKE_SUBJECT)
+                .message(String.format(EmailNotificationMessagesConstants.COMMENT_LIKE_MESSAGE,
+                    userVO.getName()))
+                .build());
             Event event = comment.getEvent();
             userNotificationService.createNotification(modelMapper.map(comment.getUser(), UserVO.class), userVO,
-                    NotificationType.EVENT_COMMENT_LIKE, commentId, comment.getText(), event.getId(), event.getTitle());
+                NotificationType.EVENT_COMMENT_LIKE, commentId, comment.getText(), event.getId(), event.getTitle());
         }
         eventCommentRepo.save(comment);
     }
@@ -332,16 +332,16 @@ public class EventCommentServiceImpl implements EventCommentService {
     @Override
     public AmountCommentLikesDto countLikes(Long commentId, UserVO userVO) {
         EventComment comment = eventCommentRepo.findByIdAndStatusNot(commentId, CommentStatus.DELETED).orElseThrow(
-                () -> new NotFoundException(ErrorMessage.EVENT_COMMENT_NOT_FOUND_BY_ID + commentId));
+            () -> new NotFoundException(ErrorMessage.EVENT_COMMENT_NOT_FOUND_BY_ID + commentId));
 
         boolean isLiked =
-                userVO != null && comment.getUsersLiked().stream().anyMatch(u -> u.getId().equals(userVO.getId()));
+            userVO != null && comment.getUsersLiked().stream().anyMatch(u -> u.getId().equals(userVO.getId()));
         return AmountCommentLikesDto.builder()
-                .id(comment.getId())
-                .userId(userVO == null ? 0 : userVO.getId())
-                .isLiked(isLiked)
-                .amountLikes(comment.getUsersLiked().size())
-                .build();
+            .id(comment.getId())
+            .userId(userVO == null ? 0 : userVO.getId())
+            .isLiked(isLiked)
+            .amountLikes(comment.getUsersLiked().size())
+            .build();
     }
 
     /**
@@ -354,14 +354,14 @@ public class EventCommentServiceImpl implements EventCommentService {
     @Transactional
     public void eventCommentLikeAndCount(AmountCommentLikesDto amountCommentLikesDto) {
         EventComment comment = eventCommentRepo.findById(amountCommentLikesDto.getId()).orElseThrow(
-                () -> new BadRequestException(ErrorMessage.COMMENT_NOT_FOUND_EXCEPTION));
+            () -> new BadRequestException(ErrorMessage.COMMENT_NOT_FOUND_EXCEPTION));
         boolean isLiked = comment.getUsersLiked().stream().map(User::getId)
-                .anyMatch(x -> x.equals(amountCommentLikesDto.getUserId()));
+            .anyMatch(x -> x.equals(amountCommentLikesDto.getUserId()));
         amountCommentLikesDto.setLiked(isLiked);
         int size = comment.getUsersLiked().size();
         amountCommentLikesDto.setAmountLikes(size);
         messagingTemplate.convertAndSend("/topic/" + amountCommentLikesDto.getId() + "/eventComment",
-                amountCommentLikesDto);
+            amountCommentLikesDto);
     }
 
     /**
@@ -378,18 +378,18 @@ public class EventCommentServiceImpl implements EventCommentService {
             String formattedComment = formatComment(commentText);
             for (Long userId : usersId) {
                 User user = userRepo.findById(userId)
-                        .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_ID + userId));
+                    .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_ID + userId));
                 UserTaggedInCommentMessage message = UserTaggedInCommentMessage.builder()
-                        .commentedElementId(eventVO.getId())
-                        .elementName(eventVO.getTitle())
-                        .taggerName(userVO.getName())
-                        .language(locale.getLanguage())
-                        .creationDate(commentVO.getCreatedDate())
-                        .receiverName(user.getName())
-                        .receiverEmail(user.getEmail())
-                        .commentText(formattedComment)
-                        .baseLink(getBaseLink(eventVO.getId()))
-                        .build();
+                    .commentedElementId(eventVO.getId())
+                    .elementName(eventVO.getTitle())
+                    .taggerName(userVO.getName())
+                    .language(locale.getLanguage())
+                    .creationDate(commentVO.getCreatedDate())
+                    .receiverName(user.getName())
+                    .receiverEmail(user.getEmail())
+                    .commentText(formattedComment)
+                    .baseLink(getBaseLink(eventVO.getId()))
+                    .build();
                 notificationService.sendUsersTaggedInCommentEmailNotification(message);
             }
         }
@@ -431,7 +431,7 @@ public class EventCommentServiceImpl implements EventCommentService {
         while (matcher.find()) {
             Long userId = Long.valueOf(matcher.group(1));
             String username = userRepo.findById(userId).orElseThrow(
-                    () -> new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_ID + userId)).getName();
+                () -> new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_ID + userId)).getName();
             matcher.appendReplacement(formattedCommentBuilder, " <strong>@" + username + "</strong> ");
         }
         matcher.appendTail(formattedCommentBuilder);

--- a/service/src/main/java/greencity/service/FriendServiceImpl.java
+++ b/service/src/main/java/greencity/service/FriendServiceImpl.java
@@ -1,6 +1,5 @@
 package greencity.service;
 
-import greencity.constant.EmailNotificationMessagesConstants;
 import greencity.constant.ErrorMessage;
 import greencity.constant.FriendTupleConstant;
 import greencity.dto.PageableDto;
@@ -15,7 +14,6 @@ import greencity.exception.exceptions.BadRequestException;
 import greencity.exception.exceptions.NotDeletedException;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.exception.exceptions.UnsupportedSortException;
-import greencity.message.GeneralEmailMessage;
 import greencity.repository.CustomUserRepo;
 import greencity.repository.UserRepo;
 import lombok.AllArgsConstructor;
@@ -67,12 +65,6 @@ public class FriendServiceImpl implements FriendService {
         userRepo.addNewFriend(userId, friendId);
         User emailReceiver = userRepo.getReferenceById(friendId);
         User friendRequestSender = userRepo.getReferenceById(userId);
-        notificationService.sendEmailNotification(GeneralEmailMessage.builder()
-            .email(emailReceiver.getEmail())
-            .subject(EmailNotificationMessagesConstants.FRIEND_REQUEST_RECEIVED_SUBJECT)
-            .message(String.format(EmailNotificationMessagesConstants.FRIEND_REQUEST_RECEIVED_MESSAGE,
-                friendRequestSender.getName()))
-            .build());
         userNotificationService.createNotification(modelMapper.map(emailReceiver, UserVO.class),
             modelMapper.map(friendRequestSender, UserVO.class), NotificationType.FRIEND_REQUEST_RECEIVED);
     }
@@ -90,11 +82,6 @@ public class FriendServiceImpl implements FriendService {
         userRepo.acceptFriendRequest(userId, friendId);
         User user = userRepo.getReferenceById(userId);
         User friend = userRepo.getReferenceById(friendId);
-        notificationService.sendEmailNotification(GeneralEmailMessage.builder()
-            .email(friend.getEmail())
-            .subject(EmailNotificationMessagesConstants.FRIEND_REQUEST_ACCEPTED_SUBJECT)
-            .message(String.format(EmailNotificationMessagesConstants.FRIEND_REQUEST_ACCEPTED_MESSAGE, user.getName()))
-            .build());
         userNotificationService.createNotification(modelMapper.map(friend, UserVO.class),
             modelMapper.map(user, UserVO.class), NotificationType.FRIEND_REQUEST_ACCEPTED);
     }

--- a/service/src/main/java/greencity/service/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/NotificationServiceImpl.java
@@ -320,7 +320,7 @@ public class NotificationServiceImpl implements NotificationService {
 
     private ScheduledEmailMessage createScheduledEmailMessage(Notification notification, String language) {
         ResourceBundle bundle = ResourceBundle.getBundle("notification", Locale.forLanguageTag(language),
-                ResourceBundle.Control.getNoFallbackControl(ResourceBundle.Control.FORMAT_DEFAULT));
+            ResourceBundle.Control.getNoFallbackControl(ResourceBundle.Control.FORMAT_DEFAULT));
         String subject = bundle.getString(notification.getNotificationType() + "_TITLE");
         String bodyTemplate = bundle.getString(notification.getNotificationType().toString());
         String actionUserText;
@@ -336,18 +336,18 @@ public class NotificationServiceImpl implements NotificationService {
         String customMessage = notification.getCustomMessage() != null ? notification.getCustomMessage() : "";
         String secondMessage = notification.getSecondMessage() != null ? notification.getSecondMessage() : "";
         String body = bodyTemplate
-                .replace("{user}", actionUserText)
-                .replace("{message}", customMessage)
-                .replace("{secondMessage}", secondMessage);
+            .replace("{user}", actionUserText)
+            .replace("{message}", customMessage)
+            .replace("{secondMessage}", secondMessage);
 
         return ScheduledEmailMessage.builder()
-                .email(notification.getTargetUser().getEmail())
-                .username(notification.getTargetUser().getName())
-                .baseLink(createBaseLink(notification))
-                .subject(subject)
-                .body(body)
-                .language(language)
-                .build();
+            .email(notification.getTargetUser().getEmail())
+            .username(notification.getTargetUser().getName())
+            .baseLink(createBaseLink(notification))
+            .subject(subject)
+            .body(body)
+            .language(language)
+            .build();
     }
 
     private String createBaseLink(Notification notification) {

--- a/service/src/main/java/greencity/service/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/NotificationServiceImpl.java
@@ -58,7 +58,6 @@ public class NotificationServiceImpl implements NotificationService {
     @Value("${client.address}")
     private String clientAddress;
 
-
     @Override
     public void sendImmediatelyReport(PlaceVO newPlace) {
         log.info(LogMessage.IN_SEND_IMMEDIATELY_REPORT, newPlace.getName());
@@ -68,11 +67,11 @@ public class NotificationServiceImpl implements NotificationService {
         Map<CategoryDto, List<PlaceNotificationDto>> categoriesDtoWithPlacesDtoMap = new HashMap<>();
         CategoryDto map = modelMapper.map(newPlace.getCategory(), CategoryDto.class);
         List<PlaceNotificationDto> placeDtoList =
-                Collections.singletonList(modelMapper.map(newPlace, PlaceNotificationDto.class));
+            Collections.singletonList(modelMapper.map(newPlace, PlaceNotificationDto.class));
         categoriesDtoWithPlacesDtoMap.put(map, placeDtoList);
 
         restClient.sendReport(new SendReportEmailMessage(subscribers,
-                categoriesDtoWithPlacesDtoMap, emailNotification.toString()));
+            categoriesDtoWithPlacesDtoMap, emailNotification.toString()));
     }
 
     /**
@@ -119,9 +118,9 @@ public class NotificationServiceImpl implements NotificationService {
      *
      * @author Dmytro Dmytruk
      */
-    @Scheduled(cron = "0 0 10,19 * * *", zone = AppConstant.UKRAINE_TIMEZONE)
+    @Scheduled(fixedDelay = 10000)
     @Override
-    public void sendLikeScheduledEmail(){
+    public void sendLikeScheduledEmail() {
         log.info(LogMessage.IN_SEND_SCHEDULED_EMAIL, LocalDateTime.now(ZONE_ID), NotificationType.ECONEWS_COMMENT_LIKE);
         sendScheduledNotifications(NotificationType.ECONEWS_COMMENT_LIKE);
         log.info(LogMessage.IN_SEND_SCHEDULED_EMAIL, LocalDateTime.now(ZONE_ID), NotificationType.ECONEWS_LIKE);
@@ -137,7 +136,7 @@ public class NotificationServiceImpl implements NotificationService {
      */
     @Scheduled(cron = "0 0 11,20 * * *", zone = AppConstant.UKRAINE_TIMEZONE)
     @Override
-    public void sendCommentScheduledEmail(){
+    public void sendCommentScheduledEmail() {
         log.info(LogMessage.IN_SEND_SCHEDULED_EMAIL, LocalDateTime.now(ZONE_ID), NotificationType.ECONEWS_COMMENT);
         sendScheduledNotifications(NotificationType.ECONEWS_COMMENT);
         log.info(LogMessage.IN_SEND_SCHEDULED_EMAIL, LocalDateTime.now(ZONE_ID), NotificationType.EVENT_COMMENT);
@@ -151,8 +150,9 @@ public class NotificationServiceImpl implements NotificationService {
      */
     @Scheduled(cron = "0 0 12,21 * * *", zone = AppConstant.UKRAINE_TIMEZONE)
     @Override
-    public void sendCommentReplyScheduledEmail(){
-        log.info(LogMessage.IN_SEND_SCHEDULED_EMAIL, LocalDateTime.now(ZONE_ID), NotificationType.ECONEWS_COMMENT_REPLY);
+    public void sendCommentReplyScheduledEmail() {
+        log.info(LogMessage.IN_SEND_SCHEDULED_EMAIL, LocalDateTime.now(ZONE_ID),
+            NotificationType.ECONEWS_COMMENT_REPLY);
         sendScheduledNotifications(NotificationType.ECONEWS_COMMENT_REPLY);
         log.info(LogMessage.IN_SEND_SCHEDULED_EMAIL, LocalDateTime.now(ZONE_ID), NotificationType.EVENT_COMMENT_REPLY);
         sendScheduledNotifications(NotificationType.EVENT_COMMENT_REPLY);
@@ -165,10 +165,12 @@ public class NotificationServiceImpl implements NotificationService {
      */
     @Scheduled(cron = "0 0 13,22 * * *", zone = AppConstant.UKRAINE_TIMEZONE)
     @Override
-    public void sendFriendRequestScheduledEmail(){
-        log.info(LogMessage.IN_SEND_SCHEDULED_EMAIL, LocalDateTime.now(ZONE_ID), NotificationType.FRIEND_REQUEST_RECEIVED);
+    public void sendFriendRequestScheduledEmail() {
+        log.info(LogMessage.IN_SEND_SCHEDULED_EMAIL, LocalDateTime.now(ZONE_ID),
+            NotificationType.FRIEND_REQUEST_RECEIVED);
         sendScheduledNotifications(NotificationType.FRIEND_REQUEST_RECEIVED);
-        log.info(LogMessage.IN_SEND_SCHEDULED_EMAIL, LocalDateTime.now(ZONE_ID), NotificationType.FRIEND_REQUEST_ACCEPTED);
+        log.info(LogMessage.IN_SEND_SCHEDULED_EMAIL, LocalDateTime.now(ZONE_ID),
+            NotificationType.FRIEND_REQUEST_ACCEPTED);
         sendScheduledNotifications(NotificationType.FRIEND_REQUEST_ACCEPTED);
     }
 
@@ -184,8 +186,7 @@ public class NotificationServiceImpl implements NotificationService {
                         restClient.sendScheduledEmailNotification(message);
                     });
                 }
-            }
-            finally {
+            } finally {
                 RequestContextHolder.resetRequestAttributes();
             }
         });
@@ -203,11 +204,11 @@ public class NotificationServiceImpl implements NotificationService {
             try {
                 RequestContextHolder.setRequestAttributes(originalRequestAttributes);
                 usersEmails.forEach(attenderEmail -> restClient.sendEmailNotification(
-                        GeneralEmailMessage.builder()
-                                .email(attenderEmail)
-                                .subject(subject)
-                                .message(message)
-                                .build()));
+                    GeneralEmailMessage.builder()
+                        .email(attenderEmail)
+                        .subject(subject)
+                        .message(message)
+                        .build()));
             } finally {
                 RequestContextHolder.resetRequestAttributes();
             }
@@ -273,27 +274,27 @@ public class NotificationServiceImpl implements NotificationService {
         LocalDateTime endDate = LocalDateTime.now(ZONE_ID);
         if (!subscribers.isEmpty()) {
             List<Place> places = placeRepo.findAllByModifiedDateBetweenAndStatus(
-                    startDate, endDate, PlaceStatus.APPROVED);
+                startDate, endDate, PlaceStatus.APPROVED);
             categoriesDtoWithPlacesDtoMap = getCategoriesDtoWithPlacesDtoMap(places);
         }
         if (!categoriesDtoWithPlacesDtoMap.isEmpty()) {
             restClient.sendReport(
-                    new SendReportEmailMessage(subscribers, categoriesDtoWithPlacesDtoMap, emailNotification.toString()));
+                new SendReportEmailMessage(subscribers, categoriesDtoWithPlacesDtoMap, emailNotification.toString()));
         }
     }
 
     private List<PlaceAuthorDto> getSubscribers(EmailNotification emailNotification) {
         log.info(LogMessage.IN_GET_SUBSCRIBERS, emailNotification);
         return restClient.findAllByEmailNotification(emailNotification).stream()
-                .map(o -> modelMapper.map(o, PlaceAuthorDto.class))
-                .collect(Collectors.toList());
+            .map(o -> modelMapper.map(o, PlaceAuthorDto.class))
+            .collect(Collectors.toList());
     }
 
     private Map<CategoryDto, List<PlaceNotificationDto>> getCategoriesDtoWithPlacesDtoMap(List<Place> places) {
         log.info(LogMessage.IN_GET_CATEGORIES_WITH_PLACES_MAP, places.toString());
         List<PlaceNotificationDto> placeDto = places.stream()
-                .map(o -> modelMapper.map(o, PlaceNotificationDto.class))
-                .toList();
+            .map(o -> modelMapper.map(o, PlaceNotificationDto.class))
+            .toList();
         Map<CategoryDto, List<PlaceNotificationDto>> categoriesWithPlacesMap = new HashMap<>();
         List<CategoryDto> categories = getUniqueCategoriesFromPlaces(places);
         List<PlaceNotificationDto> placesByCategory = new ArrayList<>();
@@ -311,15 +312,15 @@ public class NotificationServiceImpl implements NotificationService {
     private List<CategoryDto> getUniqueCategoriesFromPlaces(List<Place> places) {
         log.info(LogMessage.IN_GET_UNIQUE_CATEGORIES_FROM_PLACES, places);
         return places.stream()
-                .map(Place::getCategory)
-                .distinct()
-                .map(o -> modelMapper.map(o, CategoryDto.class))
-                .toList();
+            .map(Place::getCategory)
+            .distinct()
+            .map(o -> modelMapper.map(o, CategoryDto.class))
+            .toList();
     }
 
     private ScheduledEmailMessage createScheduledEmailMessage(Notification notification, String language) {
         ResourceBundle bundle = ResourceBundle.getBundle("notification", Locale.forLanguageTag(language),
-                ResourceBundle.Control.getNoFallbackControl(ResourceBundle.Control.FORMAT_DEFAULT));
+            ResourceBundle.Control.getNoFallbackControl(ResourceBundle.Control.FORMAT_DEFAULT));
         String subject = bundle.getString(notification.getNotificationType() + "_TITLE");
         String bodyTemplate = bundle.getString(notification.getNotificationType().toString());
         String actionUserText;
@@ -332,17 +333,17 @@ public class NotificationServiceImpl implements NotificationService {
         }
         String secondMessage = notification.getSecondMessage() != null ? notification.getSecondMessage() : "";
         String body = bodyTemplate
-                .replace("{user}", actionUserText)
-                .replace("{message}", notification.getCustomMessage())
-                .replace("{secondMessage}", secondMessage);
+            .replace("{user}", actionUserText)
+            .replace("{message}", notification.getCustomMessage())
+            .replace("{secondMessage}", secondMessage);
         return ScheduledEmailMessage.builder()
-                .email(notification.getTargetUser().getEmail())
-                .username(notification.getTargetUser().getName())
-                .baseLink(createBaseLink(notification))
-                .subject(subject)
-                .body(body)
-                .language(language)
-                .build();
+            .email(notification.getTargetUser().getEmail())
+            .username(notification.getTargetUser().getName())
+            .baseLink(createBaseLink(notification))
+            .subject(subject)
+            .body(body)
+            .language(language)
+            .build();
     }
 
     private String createBaseLink(Notification notification) {

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -20,8 +20,12 @@ import greencity.dto.advice.AdviceVO;
 import greencity.dto.breaktime.BreakTimeDto;
 import greencity.dto.category.CategoryDto;
 import greencity.dto.category.CategoryVO;
-import greencity.dto.comment.PlaceCommentRequestDto;
-import greencity.dto.comment.PlaceCommentResponseDto;
+import greencity.dto.comment.AddCommentDtoRequest;
+import greencity.dto.comment.AddCommentDtoResponse;
+import greencity.dto.comment.CommentAuthorDto;
+import greencity.dto.comment.CommentDto;
+import greencity.dto.placecomment.PlaceCommentRequestDto;
+import greencity.dto.placecomment.PlaceCommentResponseDto;
 import greencity.dto.discount.DiscountValueDto;
 import greencity.dto.econews.AddEcoNewsDtoRequest;
 import greencity.dto.econews.AddEcoNewsDtoResponse;
@@ -140,41 +144,42 @@ import greencity.dto.user.UserTagDto;
 import greencity.dto.user.UserVO;
 import greencity.dto.useraction.UserActionVO;
 import greencity.dto.verifyemail.VerifyEmailVO;
-import greencity.entity.Achievement;
-import greencity.entity.AchievementCategory;
-import greencity.entity.Advice;
-import greencity.entity.BreakTime;
+import greencity.entity.User;
+import greencity.entity.Tag;
+import greencity.entity.Language;
+import greencity.entity.EcoNews;
+import greencity.entity.VerifyEmail;
+import greencity.entity.EcoNewsComment;
+import greencity.entity.HabitAssign;
+import greencity.entity.ShoppingListItem;
+import greencity.entity.HabitStatusCalendar;
+import greencity.entity.Habit;
+import greencity.entity.HabitTranslation;
+import greencity.entity.HabitStatistic;
+import greencity.entity.UserShoppingListItem;
+import greencity.entity.FactOfTheDay;
 import greencity.entity.Category;
+import greencity.entity.Place;
+import greencity.entity.HabitFact;
+import greencity.entity.Advice;
+import greencity.entity.Photo;
+import greencity.entity.HabitFactTranslation;
 import greencity.entity.PlaceComment;
 import greencity.entity.CustomShoppingListItem;
-import greencity.entity.DiscountValue;
-import greencity.entity.EcoNews;
-import greencity.entity.EcoNewsComment;
-import greencity.entity.FactOfTheDay;
-import greencity.entity.FactOfTheDayTranslation;
-import greencity.entity.FavoritePlace;
-import greencity.entity.Filter;
-import greencity.entity.Habit;
-import greencity.entity.HabitAssign;
-import greencity.entity.HabitFact;
-import greencity.entity.HabitFactTranslation;
-import greencity.entity.HabitStatistic;
-import greencity.entity.HabitStatusCalendar;
-import greencity.entity.HabitTranslation;
-import greencity.entity.Language;
-import greencity.entity.Location;
 import greencity.entity.Notification;
-import greencity.entity.OpeningHours;
-import greencity.entity.Photo;
-import greencity.entity.Place;
-import greencity.entity.ShoppingListItem;
+import greencity.entity.FactOfTheDayTranslation;
+import greencity.entity.Location;
+import greencity.entity.DiscountValue;
 import greencity.entity.Specification;
-import greencity.entity.Tag;
-import greencity.entity.User;
-import greencity.entity.UserAchievement;
+import greencity.entity.FavoritePlace;
+import greencity.entity.OpeningHours;
+import greencity.entity.Achievement;
+import greencity.entity.BreakTime;
+import greencity.entity.AchievementCategory;
 import greencity.entity.UserAction;
-import greencity.entity.UserShoppingListItem;
-import greencity.entity.VerifyEmail;
+import greencity.entity.Filter;
+import greencity.entity.UserAchievement;
+import greencity.entity.Comment;
 import greencity.entity.event.Address;
 import greencity.entity.event.Event;
 import greencity.entity.event.EventComment;
@@ -183,18 +188,19 @@ import greencity.entity.event.EventGrade;
 import greencity.entity.localization.AdviceTranslation;
 import greencity.entity.localization.ShoppingListItemTranslation;
 import greencity.entity.localization.TagTranslation;
-import greencity.enums.CommentStatus;
-import greencity.enums.EmailNotification;
-import greencity.enums.FactOfDayStatus;
-import greencity.enums.HabitAssignStatus;
-import greencity.enums.HabitRate;
-import greencity.enums.NotificationType;
-import greencity.enums.PlaceStatus;
-import greencity.enums.ProjectName;
-import greencity.enums.Role;
-import greencity.enums.ShoppingListItemStatus;
 import greencity.enums.TagType;
 import greencity.enums.UserStatus;
+import greencity.enums.Role;
+import greencity.enums.CommentStatus;
+import greencity.enums.HabitAssignStatus;
+import greencity.enums.HabitRate;
+import greencity.enums.ShoppingListItemStatus;
+import greencity.enums.FactOfDayStatus;
+import greencity.enums.ArticleType;
+import greencity.enums.EmailNotification;
+import greencity.enums.PlaceStatus;
+import greencity.enums.ProjectName;
+import greencity.enums.NotificationType;
 import jakarta.persistence.Tuple;
 import jakarta.persistence.TupleElement;
 import java.io.IOException;
@@ -220,6 +226,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
 import static greencity.enums.NotificationType.ECONEWS_COMMENT;
 import static greencity.enums.NotificationType.ECONEWS_COMMENT_LIKE;
 import static greencity.enums.NotificationType.ECONEWS_COMMENT_REPLY;
@@ -235,6 +242,7 @@ import static greencity.enums.NotificationType.EVENT_NAME_UPDATED;
 import static greencity.enums.NotificationType.EVENT_UPDATED;
 import static greencity.enums.NotificationType.FRIEND_REQUEST_ACCEPTED;
 import static greencity.enums.NotificationType.FRIEND_REQUEST_RECEIVED;
+import static greencity.enums.NotificationType.HABIT_LIKE;
 import static greencity.enums.ProjectName.GREENCITY;
 import static greencity.enums.ProjectName.PICKUP;
 import org.hibernate.sql.results.internal.TupleElementImpl;
@@ -692,9 +700,13 @@ public class ModelUtils {
     }
 
     public static HabitAssign getHabitAssign() {
+        return getHabitAssign(HabitAssignStatus.ACQUIRED);
+    }
+
+    public static HabitAssign getHabitAssign(HabitAssignStatus status) {
         return HabitAssign.builder()
             .id(1L)
-            .status(HabitAssignStatus.ACQUIRED)
+            .status(status)
             .createDate(ZonedDateTime.now())
             .habit(Habit.builder()
                 .id(1L)
@@ -917,7 +929,7 @@ public class ModelUtils {
     }
 
     public static List<UserShoppingListItem> getUserShoppingListItemList() {
-        List<UserShoppingListItem> getUserShoppingListItemList = new ArrayList();
+        List<UserShoppingListItem> getUserShoppingListItemList = new ArrayList<>();
         getUserShoppingListItemList.add(getFullUserShoppingListItem());
         getUserShoppingListItemList.add(getFullUserShoppingListItem());
         getUserShoppingListItemList.add(getFullUserShoppingListItem());
@@ -929,7 +941,7 @@ public class ModelUtils {
         ShoppingListItemTranslation translation = getShoppingListItemTranslations1();
         ShoppingListItemTranslation translation2 = getShoppingListItemTranslations1();
         ShoppingListItemTranslation translation3 = getShoppingListItemTranslations1();
-        List<ShoppingListItemTranslation> list = new ArrayList();
+        List<ShoppingListItemTranslation> list = new ArrayList<>();
         list.add(translation);
         list.add(translation2);
         list.add(translation3);
@@ -1463,7 +1475,7 @@ public class ModelUtils {
         return new FavoritePlaceVO(3L, "name", getUserVO(), getPlaceVO());
     }
 
-    public static PlaceComment getComment() {
+    public static PlaceComment getPlaceComment() {
         return new PlaceComment(1L, "text", getUser(),
             getPlace(), null, null, Collections.emptyList(), null, null, null);
     }
@@ -1556,8 +1568,11 @@ public class ModelUtils {
     }
 
     public static Habit getHabit() {
-        return Habit.builder().id(1L).image("image.png")
+        Habit habit = Habit.builder().id(1L).image("image.png")
+            .usersLiked(new HashSet<>())
             .complexity(1).tags(new HashSet<>(getTags())).build();
+
+        return habit.setHabitTranslations(List.of(getHabitTranslation(habit)));
     }
 
     public static Habit getHabitWithCustom() {
@@ -1573,6 +1588,17 @@ public class ModelUtils {
             .language(getLanguage())
             .name("test name")
             .habit(getHabit())
+            .build();
+    }
+
+    public static HabitTranslation getHabitTranslation(Habit habit) {
+        return HabitTranslation.builder()
+            .id(1L)
+            .description("test description")
+            .habitItem("test habit item")
+            .language(getLanguage())
+            .name("test name")
+            .habit(habit)
             .build();
     }
 
@@ -1727,6 +1753,7 @@ public class ModelUtils {
             .habitTranslation(new HabitTranslationDto())
             .defaultDuration(1)
             .tags(new ArrayList<>())
+            .habitAssignStatus(HabitAssignStatus.INPROGRESS)
             .build();
     }
 
@@ -2992,6 +3019,63 @@ public class ModelUtils {
             .build();
     }
 
+    public static Comment getComment() {
+        return Comment.builder()
+            .id(1L)
+            .articleType(ArticleType.HABIT)
+            .articleId(10L)
+            .text("text")
+            .usersLiked(new HashSet<>())
+            .createdDate(LocalDateTime.now())
+            .user(getUser())
+            .comments(List.of(getSubComment()))
+            .status(CommentStatus.ORIGINAL)
+            .build();
+    }
+
+    public static Comment getSubComment() {
+        return Comment.builder()
+            .id(5L)
+            .articleType(ArticleType.HABIT)
+            .articleId(10L)
+            .text("other text")
+            .usersLiked(new HashSet<>())
+            .createdDate(LocalDateTime.now())
+            .user(getUser())
+            .status(CommentStatus.ORIGINAL)
+            .build();
+    }
+
+    public static CommentDto getCommentDto() {
+        return CommentDto.builder()
+            .id(1L)
+            .text("text")
+            .createdDate(LocalDateTime.now())
+            .author(getCommentAuthorDto())
+            .status(CommentStatus.ORIGINAL.toString())
+            .build();
+    }
+
+    public static AddCommentDtoResponse getAddCommentDtoResponse() {
+        return AddCommentDtoResponse.builder()
+            .id(getComment().getId())
+            .author(getCommentAuthorDto())
+            .text(getComment().getText())
+            .build();
+    }
+
+    public static CommentAuthorDto getCommentAuthorDto() {
+        return CommentAuthorDto.builder()
+            .id(getUser().getId())
+            .name(getUser().getName().trim())
+            .profilePicturePath(getUser().getProfilePicturePath())
+            .build();
+    }
+
+    public static AddCommentDtoRequest getAddCommentDtoRequest() {
+        return new AddCommentDtoRequest("text", 10L);
+    }
+
     public static UserShoppingAndCustomShoppingListsDto getUserShoppingAndCustomShoppingListsDto() {
         return UserShoppingAndCustomShoppingListsDto.builder()
             .userShoppingListItemDto(List.of(getUserShoppingListItemResponseDto()))
@@ -3046,7 +3130,7 @@ public class ModelUtils {
             .build();
     }
 
-    public static CustomHabitDtoRequest getСustomHabitDtoRequestWithNewCustomShoppingListItem() {
+    public static CustomHabitDtoRequest getCustomHabitDtoRequestWithNewCustomShoppingListItem() {
         return CustomHabitDtoRequest.builder()
             .customShoppingListItemDto(List.of(
                 CustomShoppingListItemResponseDto.builder()
@@ -3544,7 +3628,8 @@ public class ModelUtils {
                 EVENT_JOINED,
                 EVENT_COMMENT,
                 FRIEND_REQUEST_ACCEPTED,
-                FRIEND_REQUEST_RECEIVED})
+                FRIEND_REQUEST_RECEIVED,
+                HABIT_LIKE})
             .build();
     }
 

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -20,12 +20,8 @@ import greencity.dto.advice.AdviceVO;
 import greencity.dto.breaktime.BreakTimeDto;
 import greencity.dto.category.CategoryDto;
 import greencity.dto.category.CategoryVO;
-import greencity.dto.comment.AddCommentDtoRequest;
-import greencity.dto.comment.AddCommentDtoResponse;
-import greencity.dto.comment.CommentAuthorDto;
-import greencity.dto.comment.CommentDto;
-import greencity.dto.placecomment.PlaceCommentRequestDto;
-import greencity.dto.placecomment.PlaceCommentResponseDto;
+import greencity.dto.comment.PlaceCommentRequestDto;
+import greencity.dto.comment.PlaceCommentResponseDto;
 import greencity.dto.discount.DiscountValueDto;
 import greencity.dto.econews.AddEcoNewsDtoRequest;
 import greencity.dto.econews.AddEcoNewsDtoResponse;
@@ -144,42 +140,41 @@ import greencity.dto.user.UserTagDto;
 import greencity.dto.user.UserVO;
 import greencity.dto.useraction.UserActionVO;
 import greencity.dto.verifyemail.VerifyEmailVO;
-import greencity.entity.User;
-import greencity.entity.Tag;
-import greencity.entity.Language;
-import greencity.entity.EcoNews;
-import greencity.entity.VerifyEmail;
-import greencity.entity.EcoNewsComment;
-import greencity.entity.HabitAssign;
-import greencity.entity.ShoppingListItem;
-import greencity.entity.HabitStatusCalendar;
-import greencity.entity.Habit;
-import greencity.entity.HabitTranslation;
-import greencity.entity.HabitStatistic;
-import greencity.entity.UserShoppingListItem;
-import greencity.entity.FactOfTheDay;
-import greencity.entity.Category;
-import greencity.entity.Place;
-import greencity.entity.HabitFact;
+import greencity.entity.Achievement;
+import greencity.entity.AchievementCategory;
 import greencity.entity.Advice;
-import greencity.entity.Photo;
-import greencity.entity.HabitFactTranslation;
+import greencity.entity.BreakTime;
+import greencity.entity.Category;
 import greencity.entity.PlaceComment;
 import greencity.entity.CustomShoppingListItem;
-import greencity.entity.Notification;
-import greencity.entity.FactOfTheDayTranslation;
-import greencity.entity.Location;
 import greencity.entity.DiscountValue;
-import greencity.entity.Specification;
+import greencity.entity.EcoNews;
+import greencity.entity.EcoNewsComment;
+import greencity.entity.FactOfTheDay;
+import greencity.entity.FactOfTheDayTranslation;
 import greencity.entity.FavoritePlace;
-import greencity.entity.OpeningHours;
-import greencity.entity.Achievement;
-import greencity.entity.BreakTime;
-import greencity.entity.AchievementCategory;
-import greencity.entity.UserAction;
 import greencity.entity.Filter;
+import greencity.entity.Habit;
+import greencity.entity.HabitAssign;
+import greencity.entity.HabitFact;
+import greencity.entity.HabitFactTranslation;
+import greencity.entity.HabitStatistic;
+import greencity.entity.HabitStatusCalendar;
+import greencity.entity.HabitTranslation;
+import greencity.entity.Language;
+import greencity.entity.Location;
+import greencity.entity.Notification;
+import greencity.entity.OpeningHours;
+import greencity.entity.Photo;
+import greencity.entity.Place;
+import greencity.entity.ShoppingListItem;
+import greencity.entity.Specification;
+import greencity.entity.Tag;
+import greencity.entity.User;
 import greencity.entity.UserAchievement;
-import greencity.entity.Comment;
+import greencity.entity.UserAction;
+import greencity.entity.UserShoppingListItem;
+import greencity.entity.VerifyEmail;
 import greencity.entity.event.Address;
 import greencity.entity.event.Event;
 import greencity.entity.event.EventComment;
@@ -188,19 +183,18 @@ import greencity.entity.event.EventGrade;
 import greencity.entity.localization.AdviceTranslation;
 import greencity.entity.localization.ShoppingListItemTranslation;
 import greencity.entity.localization.TagTranslation;
-import greencity.enums.TagType;
-import greencity.enums.UserStatus;
-import greencity.enums.Role;
 import greencity.enums.CommentStatus;
+import greencity.enums.EmailNotification;
+import greencity.enums.FactOfDayStatus;
 import greencity.enums.HabitAssignStatus;
 import greencity.enums.HabitRate;
-import greencity.enums.ShoppingListItemStatus;
-import greencity.enums.FactOfDayStatus;
-import greencity.enums.ArticleType;
-import greencity.enums.EmailNotification;
+import greencity.enums.NotificationType;
 import greencity.enums.PlaceStatus;
 import greencity.enums.ProjectName;
-import greencity.enums.NotificationType;
+import greencity.enums.Role;
+import greencity.enums.ShoppingListItemStatus;
+import greencity.enums.TagType;
+import greencity.enums.UserStatus;
 import jakarta.persistence.Tuple;
 import jakarta.persistence.TupleElement;
 import java.io.IOException;
@@ -226,7 +220,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import static greencity.enums.NotificationType.ECONEWS_COMMENT;
 import static greencity.enums.NotificationType.ECONEWS_COMMENT_LIKE;
 import static greencity.enums.NotificationType.ECONEWS_COMMENT_REPLY;
@@ -242,7 +235,6 @@ import static greencity.enums.NotificationType.EVENT_NAME_UPDATED;
 import static greencity.enums.NotificationType.EVENT_UPDATED;
 import static greencity.enums.NotificationType.FRIEND_REQUEST_ACCEPTED;
 import static greencity.enums.NotificationType.FRIEND_REQUEST_RECEIVED;
-import static greencity.enums.NotificationType.HABIT_LIKE;
 import static greencity.enums.ProjectName.GREENCITY;
 import static greencity.enums.ProjectName.PICKUP;
 import org.hibernate.sql.results.internal.TupleElementImpl;
@@ -700,13 +692,9 @@ public class ModelUtils {
     }
 
     public static HabitAssign getHabitAssign() {
-        return getHabitAssign(HabitAssignStatus.ACQUIRED);
-    }
-
-    public static HabitAssign getHabitAssign(HabitAssignStatus status) {
         return HabitAssign.builder()
             .id(1L)
-            .status(status)
+            .status(HabitAssignStatus.ACQUIRED)
             .createDate(ZonedDateTime.now())
             .habit(Habit.builder()
                 .id(1L)
@@ -929,7 +917,7 @@ public class ModelUtils {
     }
 
     public static List<UserShoppingListItem> getUserShoppingListItemList() {
-        List<UserShoppingListItem> getUserShoppingListItemList = new ArrayList<>();
+        List<UserShoppingListItem> getUserShoppingListItemList = new ArrayList();
         getUserShoppingListItemList.add(getFullUserShoppingListItem());
         getUserShoppingListItemList.add(getFullUserShoppingListItem());
         getUserShoppingListItemList.add(getFullUserShoppingListItem());
@@ -941,7 +929,7 @@ public class ModelUtils {
         ShoppingListItemTranslation translation = getShoppingListItemTranslations1();
         ShoppingListItemTranslation translation2 = getShoppingListItemTranslations1();
         ShoppingListItemTranslation translation3 = getShoppingListItemTranslations1();
-        List<ShoppingListItemTranslation> list = new ArrayList<>();
+        List<ShoppingListItemTranslation> list = new ArrayList();
         list.add(translation);
         list.add(translation2);
         list.add(translation3);
@@ -1475,7 +1463,7 @@ public class ModelUtils {
         return new FavoritePlaceVO(3L, "name", getUserVO(), getPlaceVO());
     }
 
-    public static PlaceComment getPlaceComment() {
+    public static PlaceComment getComment() {
         return new PlaceComment(1L, "text", getUser(),
             getPlace(), null, null, Collections.emptyList(), null, null, null);
     }
@@ -1568,11 +1556,8 @@ public class ModelUtils {
     }
 
     public static Habit getHabit() {
-        Habit habit = Habit.builder().id(1L).image("image.png")
-            .usersLiked(new HashSet<>())
+        return Habit.builder().id(1L).image("image.png")
             .complexity(1).tags(new HashSet<>(getTags())).build();
-
-        return habit.setHabitTranslations(List.of(getHabitTranslation(habit)));
     }
 
     public static Habit getHabitWithCustom() {
@@ -1588,17 +1573,6 @@ public class ModelUtils {
             .language(getLanguage())
             .name("test name")
             .habit(getHabit())
-            .build();
-    }
-
-    public static HabitTranslation getHabitTranslation(Habit habit) {
-        return HabitTranslation.builder()
-            .id(1L)
-            .description("test description")
-            .habitItem("test habit item")
-            .language(getLanguage())
-            .name("test name")
-            .habit(habit)
             .build();
     }
 
@@ -1753,7 +1727,6 @@ public class ModelUtils {
             .habitTranslation(new HabitTranslationDto())
             .defaultDuration(1)
             .tags(new ArrayList<>())
-            .habitAssignStatus(HabitAssignStatus.INPROGRESS)
             .build();
     }
 
@@ -3019,63 +2992,6 @@ public class ModelUtils {
             .build();
     }
 
-    public static Comment getComment() {
-        return Comment.builder()
-            .id(1L)
-            .articleType(ArticleType.HABIT)
-            .articleId(10L)
-            .text("text")
-            .usersLiked(new HashSet<>())
-            .createdDate(LocalDateTime.now())
-            .user(getUser())
-            .comments(List.of(getSubComment()))
-            .status(CommentStatus.ORIGINAL)
-            .build();
-    }
-
-    public static Comment getSubComment() {
-        return Comment.builder()
-            .id(5L)
-            .articleType(ArticleType.HABIT)
-            .articleId(10L)
-            .text("other text")
-            .usersLiked(new HashSet<>())
-            .createdDate(LocalDateTime.now())
-            .user(getUser())
-            .status(CommentStatus.ORIGINAL)
-            .build();
-    }
-
-    public static CommentDto getCommentDto() {
-        return CommentDto.builder()
-            .id(1L)
-            .text("text")
-            .createdDate(LocalDateTime.now())
-            .author(getCommentAuthorDto())
-            .status(CommentStatus.ORIGINAL.toString())
-            .build();
-    }
-
-    public static AddCommentDtoResponse getAddCommentDtoResponse() {
-        return AddCommentDtoResponse.builder()
-            .id(getComment().getId())
-            .author(getCommentAuthorDto())
-            .text(getComment().getText())
-            .build();
-    }
-
-    public static CommentAuthorDto getCommentAuthorDto() {
-        return CommentAuthorDto.builder()
-            .id(getUser().getId())
-            .name(getUser().getName().trim())
-            .profilePicturePath(getUser().getProfilePicturePath())
-            .build();
-    }
-
-    public static AddCommentDtoRequest getAddCommentDtoRequest() {
-        return new AddCommentDtoRequest("text", 10L);
-    }
-
     public static UserShoppingAndCustomShoppingListsDto getUserShoppingAndCustomShoppingListsDto() {
         return UserShoppingAndCustomShoppingListsDto.builder()
             .userShoppingListItemDto(List.of(getUserShoppingListItemResponseDto()))
@@ -3130,7 +3046,7 @@ public class ModelUtils {
             .build();
     }
 
-    public static CustomHabitDtoRequest getCustomHabitDtoRequestWithNewCustomShoppingListItem() {
+    public static CustomHabitDtoRequest getСustomHabitDtoRequestWithNewCustomShoppingListItem() {
         return CustomHabitDtoRequest.builder()
             .customShoppingListItemDto(List.of(
                 CustomShoppingListItemResponseDto.builder()
@@ -3628,8 +3544,7 @@ public class ModelUtils {
                 EVENT_JOINED,
                 EVENT_COMMENT,
                 FRIEND_REQUEST_ACCEPTED,
-                FRIEND_REQUEST_RECEIVED,
-                HABIT_LIKE})
+                FRIEND_REQUEST_RECEIVED})
             .build();
     }
 

--- a/service/src/test/java/greencity/service/EventCommentServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventCommentServiceImplTest.java
@@ -112,6 +112,7 @@ class EventCommentServiceImplTest {
         when(eventCommentRepo.save(any(EventComment.class))).then(AdditionalAnswers.returnsFirstArg());
         when(eventCommentRepo.findById(anyLong())).thenReturn(Optional.of(eventComment));
         when(modelMapper.map(userVO, EventCommentAuthorDto.class)).thenReturn(eventCommentAuthorDto);
+        when(modelMapper.map(eventComment.getUser(), UserVO.class)).thenReturn(userVO);
         when(modelMapper.map(userVO, User.class)).thenReturn(user);
         when(modelMapper.map(eventVO, Event.class)).thenReturn(event);
         when(modelMapper.map(addEventCommentDtoRequest, EventComment.class)).thenReturn(eventComment);

--- a/service/src/test/java/greencity/service/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/NotificationServiceImplTest.java
@@ -68,9 +68,9 @@ class NotificationServiceImplTest {
     void sendImmediatelyReportTest() {
         EmailNotification emailNotification = EmailNotification.IMMEDIATELY;
         CategoryVO category = CategoryVO.builder()
-                .id(12L)
-                .name("category")
-                .build();
+            .id(12L)
+            .name("category")
+            .build();
 
         UserVO userVO = ModelUtils.getUserVO();
         userVO.setEmailNotification(emailNotification);
@@ -86,18 +86,18 @@ class NotificationServiceImplTest {
         place.setCategory(category);
 
         when(restClient.findAllByEmailNotification(emailNotification))
-                .thenReturn(Collections.singletonList(userVO));
+            .thenReturn(Collections.singletonList(userVO));
         when(modelMapper.map(userVO, PlaceAuthorDto.class))
-                .thenReturn(new PlaceAuthorDto(1L, "dto", "email"));
+            .thenReturn(new PlaceAuthorDto(1L, "dto", "email"));
         when(modelMapper.map(place.getCategory(), CategoryDto.class))
-                .thenReturn(new CategoryDto("category", "test", null));
+            .thenReturn(new CategoryDto("category", "test", null));
         when(modelMapper.map(place, PlaceNotificationDto.class))
-                .thenReturn(new PlaceNotificationDto("name", new CategoryDto("category", "test", null)));
+            .thenReturn(new PlaceNotificationDto("name", new CategoryDto("category", "test", null)));
 
         notificationService.sendImmediatelyReport(place);
 
         verify(restClient, Mockito.times(1))
-                .sendReport(any(SendReportEmailMessage.class));
+            .sendReport(any(SendReportEmailMessage.class));
     }
 
     @Test
@@ -118,24 +118,24 @@ class NotificationServiceImplTest {
         List<Place> testPlaces = Arrays.asList(testPlace1, testPlace2);
 
         when(restClient.findAllByEmailNotification(emailNotification))
-                .thenReturn(Collections.singletonList(userVO));
+            .thenReturn(Collections.singletonList(userVO));
         when(modelMapper.map(userVO, PlaceAuthorDto.class))
-                .thenReturn(new PlaceAuthorDto(1L, "dto", "email"));
+            .thenReturn(new PlaceAuthorDto(1L, "dto", "email"));
         when(placeRepo.findAllByModifiedDateBetweenAndStatus(any(LocalDateTime.class), any(LocalDateTime.class), any()))
-                .thenReturn(testPlaces);
+            .thenReturn(testPlaces);
         when(modelMapper.map(testPlace1, PlaceNotificationDto.class))
-                .thenReturn(new PlaceNotificationDto("name", new CategoryDto("category", "test", null)));
+            .thenReturn(new PlaceNotificationDto("name", new CategoryDto("category", "test", null)));
         when(modelMapper.map(testPlace2, PlaceNotificationDto.class))
-                .thenReturn(new PlaceNotificationDto("name1", new CategoryDto("category1", "test", null)));
+            .thenReturn(new PlaceNotificationDto("name1", new CategoryDto("category1", "test", null)));
         when(modelMapper.map(testPlace1.getCategory(), CategoryDto.class))
-                .thenReturn(new CategoryDto("category", "test", null));
+            .thenReturn(new CategoryDto("category", "test", null));
         when(modelMapper.map(testPlace2.getCategory(), CategoryDto.class))
-                .thenReturn(new CategoryDto("category1", "test", null));
+            .thenReturn(new CategoryDto("category1", "test", null));
 
         notificationService.sendDailyReport();
 
         verify(restClient, Mockito.times(1))
-                .sendReport(any(SendReportEmailMessage.class));
+            .sendReport(any(SendReportEmailMessage.class));
 
     }
 
@@ -157,24 +157,24 @@ class NotificationServiceImplTest {
         List<Place> testPlaces = Arrays.asList(testPlace1, testPlace2);
 
         when(restClient.findAllByEmailNotification(emailNotification))
-                .thenReturn(Collections.singletonList(userVO));
+            .thenReturn(Collections.singletonList(userVO));
         when(modelMapper.map(userVO, PlaceAuthorDto.class))
-                .thenReturn(new PlaceAuthorDto(1L, "dto", "email"));
+            .thenReturn(new PlaceAuthorDto(1L, "dto", "email"));
         when(placeRepo.findAllByModifiedDateBetweenAndStatus(any(LocalDateTime.class), any(LocalDateTime.class), any()))
-                .thenReturn(testPlaces);
+            .thenReturn(testPlaces);
         when(modelMapper.map(testPlace1, PlaceNotificationDto.class))
-                .thenReturn(new PlaceNotificationDto("name", new CategoryDto("category", "test", null)));
+            .thenReturn(new PlaceNotificationDto("name", new CategoryDto("category", "test", null)));
         when(modelMapper.map(testPlace2, PlaceNotificationDto.class))
-                .thenReturn(new PlaceNotificationDto("name1", new CategoryDto("category1", "test", null)));
+            .thenReturn(new PlaceNotificationDto("name1", new CategoryDto("category1", "test", null)));
         when(modelMapper.map(testPlace1.getCategory(), CategoryDto.class))
-                .thenReturn(new CategoryDto("category", "test", null));
+            .thenReturn(new CategoryDto("category", "test", null));
         when(modelMapper.map(testPlace2.getCategory(), CategoryDto.class))
-                .thenReturn(new CategoryDto("category1", "test", null));
+            .thenReturn(new CategoryDto("category1", "test", null));
 
         notificationService.sendWeeklyReport();
 
         verify(restClient, Mockito.times(1))
-                .sendReport(any(SendReportEmailMessage.class));
+            .sendReport(any(SendReportEmailMessage.class));
 
     }
 
@@ -196,24 +196,24 @@ class NotificationServiceImplTest {
         List<Place> testPlaces = Arrays.asList(testPlace1, testPlace2);
 
         when(restClient.findAllByEmailNotification(emailNotification))
-                .thenReturn(Collections.singletonList(userVO));
+            .thenReturn(Collections.singletonList(userVO));
         when(modelMapper.map(userVO, PlaceAuthorDto.class))
-                .thenReturn(new PlaceAuthorDto(1L, "dto", "email"));
+            .thenReturn(new PlaceAuthorDto(1L, "dto", "email"));
         when(placeRepo.findAllByModifiedDateBetweenAndStatus(any(LocalDateTime.class), any(LocalDateTime.class), any()))
-                .thenReturn(testPlaces);
+            .thenReturn(testPlaces);
         when(modelMapper.map(testPlace1, PlaceNotificationDto.class))
-                .thenReturn(new PlaceNotificationDto("name", new CategoryDto("category", "test", null)));
+            .thenReturn(new PlaceNotificationDto("name", new CategoryDto("category", "test", null)));
         when(modelMapper.map(testPlace2, PlaceNotificationDto.class))
-                .thenReturn(new PlaceNotificationDto("name1", new CategoryDto("category1", "test", null)));
+            .thenReturn(new PlaceNotificationDto("name1", new CategoryDto("category1", "test", null)));
         when(modelMapper.map(testPlace1.getCategory(), CategoryDto.class))
-                .thenReturn(new CategoryDto("category", "test", null));
+            .thenReturn(new CategoryDto("category", "test", null));
         when(modelMapper.map(testPlace2.getCategory(), CategoryDto.class))
-                .thenReturn(new CategoryDto("category1", "test", null));
+            .thenReturn(new CategoryDto("category1", "test", null));
 
         notificationService.sendMonthlyReport();
 
         verify(restClient, Mockito.times(1))
-                .sendReport(any(SendReportEmailMessage.class));
+            .sendReport(any(SendReportEmailMessage.class));
     }
 
     @Test
@@ -224,7 +224,7 @@ class NotificationServiceImplTest {
         ArgumentCaptor<GeneralEmailMessage> emailMessageCaptor = ArgumentCaptor.forClass(GeneralEmailMessage.class);
         notificationService.sendEmailNotification(setOfEmails, subject, message);
         await().atMost(5, SECONDS)
-                .untilAsserted(() -> verify(restClient, times(3)).sendEmailNotification(emailMessageCaptor.capture()));
+            .untilAsserted(() -> verify(restClient, times(3)).sendEmailNotification(emailMessageCaptor.capture()));
         List<GeneralEmailMessage> capturedEmailMessages = emailMessageCaptor.getAllValues();
         assertFalse(capturedEmailMessages.isEmpty());
         for (GeneralEmailMessage capturedEmailMessage : capturedEmailMessages) {
@@ -243,7 +243,7 @@ class NotificationServiceImplTest {
         ArgumentCaptor<GeneralEmailMessage> emailMessageCaptor = ArgumentCaptor.forClass(GeneralEmailMessage.class);
         notificationService.sendEmailNotification(generalEmailMessage);
         await().atMost(5, SECONDS)
-                .untilAsserted(() -> verify(restClient).sendEmailNotification(emailMessageCaptor.capture()));
+            .untilAsserted(() -> verify(restClient).sendEmailNotification(emailMessageCaptor.capture()));
         GeneralEmailMessage capturedEmailMessage = emailMessageCaptor.getValue();
         assertEquals(email, capturedEmailMessage.getEmail());
         assertEquals(subject, capturedEmailMessage.getSubject());
@@ -253,12 +253,12 @@ class NotificationServiceImplTest {
     @Test
     void sendHabitAssignEmailNotification() {
         HabitAssignNotificationMessage message = new HabitAssignNotificationMessage(
-                "sender", "receiver", "receiver@example.com", "habit", "en", 123L);
+            "sender", "receiver", "receiver@example.com", "habit", "en", 123L);
         ArgumentCaptor<HabitAssignNotificationMessage> emailMessageCaptor =
-                ArgumentCaptor.forClass(HabitAssignNotificationMessage.class);
+            ArgumentCaptor.forClass(HabitAssignNotificationMessage.class);
         notificationService.sendHabitAssignEmailNotification(message);
         await().atMost(5, SECONDS)
-                .untilAsserted(() -> verify(restClient).sendHabitAssignNotification(emailMessageCaptor.capture()));
+            .untilAsserted(() -> verify(restClient).sendHabitAssignNotification(emailMessageCaptor.capture()));
         HabitAssignNotificationMessage capturedMessage = emailMessageCaptor.getValue();
         assertEquals(message.getReceiverEmail(), capturedMessage.getReceiverEmail());
         assertEquals(message.getHabitAssignId(), capturedMessage.getHabitAssignId());
@@ -270,18 +270,18 @@ class NotificationServiceImplTest {
     @Test
     void sendUserTaggedInCommentNotificationTest() {
         UserTaggedInCommentMessage message = UserTaggedInCommentMessage.builder()
-                .receiverEmail("receiver@example.com")
-                .receiverName("receiver")
-                .commentText("test")
-                .taggerName("tagger")
-                .commentedElementId(1L)
-                .language("en")
-                .build();
+            .receiverEmail("receiver@example.com")
+            .receiverName("receiver")
+            .commentText("test")
+            .taggerName("tagger")
+            .commentedElementId(1L)
+            .language("en")
+            .build();
         ArgumentCaptor<UserTaggedInCommentMessage> captor =
-                ArgumentCaptor.forClass(UserTaggedInCommentMessage.class);
+            ArgumentCaptor.forClass(UserTaggedInCommentMessage.class);
         notificationService.sendUsersTaggedInCommentEmailNotification(message);
         await().atMost(5, SECONDS)
-                .untilAsserted(() -> verify(restClient).sendUserTaggedInCommentNotification(captor.capture()));
+            .untilAsserted(() -> verify(restClient).sendUserTaggedInCommentNotification(captor.capture()));
         UserTaggedInCommentMessage capturedMessage = captor.getValue();
         assertEquals(message.getReceiverEmail(), capturedMessage.getReceiverEmail());
         assertEquals(message.getReceiverName(), capturedMessage.getReceiverName());
@@ -296,13 +296,13 @@ class NotificationServiceImplTest {
         User targetUser = ModelUtils.getUser();
         notification.setTargetUser(targetUser);
         when(notificationRepo.findAllByNotificationTypeAndViewedIsFalse(NotificationType.FRIEND_REQUEST_RECEIVED))
-                .thenReturn(Collections.singletonList(notification));
+            .thenReturn(Collections.singletonList(notification));
         when(notificationRepo.findAllByNotificationTypeAndViewedIsFalse(NotificationType.FRIEND_REQUEST_ACCEPTED))
-                .thenReturn(Collections.singletonList(notification));
+            .thenReturn(Collections.singletonList(notification));
         notificationService.sendFriendRequestScheduledEmail();
         ArgumentCaptor<ScheduledEmailMessage> captor = ArgumentCaptor.forClass(ScheduledEmailMessage.class);
         await().atMost(5, SECONDS)
-                .untilAsserted(() -> verify(restClient, times(2)).sendScheduledEmailNotification(captor.capture()));
+            .untilAsserted(() -> verify(restClient, times(2)).sendScheduledEmailNotification(captor.capture()));
         List<ScheduledEmailMessage> capturedMessages = captor.getAllValues();
         for (ScheduledEmailMessage capturedMessage : capturedMessages) {
             assertEquals(notification.getTargetUser().getEmail(), capturedMessage.getEmail());
@@ -316,13 +316,13 @@ class NotificationServiceImplTest {
         User targetUser = ModelUtils.getUser();
         notification.setTargetUser(targetUser);
         when(notificationRepo.findAllByNotificationTypeAndViewedIsFalse(NotificationType.ECONEWS_COMMENT_REPLY))
-                .thenReturn(Collections.singletonList(notification));
+            .thenReturn(Collections.singletonList(notification));
         when(notificationRepo.findAllByNotificationTypeAndViewedIsFalse(NotificationType.EVENT_COMMENT_REPLY))
-                .thenReturn(Collections.singletonList(notification));
+            .thenReturn(Collections.singletonList(notification));
         notificationService.sendCommentReplyScheduledEmail();
         ArgumentCaptor<ScheduledEmailMessage> captor = ArgumentCaptor.forClass(ScheduledEmailMessage.class);
         await().atMost(5, SECONDS)
-                .untilAsserted(() -> verify(restClient, times(2)).sendScheduledEmailNotification(captor.capture()));
+            .untilAsserted(() -> verify(restClient, times(2)).sendScheduledEmailNotification(captor.capture()));
         List<ScheduledEmailMessage> capturedMessages = captor.getAllValues();
         for (ScheduledEmailMessage capturedMessage : capturedMessages) {
             assertEquals(notification.getTargetUser().getEmail(), capturedMessage.getEmail());
@@ -336,13 +336,13 @@ class NotificationServiceImplTest {
         User targetUser = ModelUtils.getUser();
         notification.setTargetUser(targetUser);
         when(notificationRepo.findAllByNotificationTypeAndViewedIsFalse(NotificationType.ECONEWS_COMMENT))
-                .thenReturn(Collections.singletonList(notification));
+            .thenReturn(Collections.singletonList(notification));
         when(notificationRepo.findAllByNotificationTypeAndViewedIsFalse(NotificationType.EVENT_COMMENT))
-                .thenReturn(Collections.singletonList(notification));
+            .thenReturn(Collections.singletonList(notification));
         notificationService.sendCommentScheduledEmail();
         ArgumentCaptor<ScheduledEmailMessage> captor = ArgumentCaptor.forClass(ScheduledEmailMessage.class);
         await().atMost(5, SECONDS)
-                .untilAsserted(() -> verify(restClient, times(2)).sendScheduledEmailNotification(captor.capture()));
+            .untilAsserted(() -> verify(restClient, times(2)).sendScheduledEmailNotification(captor.capture()));
         List<ScheduledEmailMessage> capturedMessages = captor.getAllValues();
         for (ScheduledEmailMessage capturedMessage : capturedMessages) {
             assertEquals(notification.getTargetUser().getEmail(), capturedMessage.getEmail());
@@ -356,15 +356,15 @@ class NotificationServiceImplTest {
         User targetUser = ModelUtils.getUser();
         notification.setTargetUser(targetUser);
         when(notificationRepo.findAllByNotificationTypeAndViewedIsFalse(NotificationType.ECONEWS_COMMENT_LIKE))
-                .thenReturn(Collections.singletonList(notification));
+            .thenReturn(Collections.singletonList(notification));
         when(notificationRepo.findAllByNotificationTypeAndViewedIsFalse(NotificationType.ECONEWS_LIKE))
-                .thenReturn(Collections.singletonList(notification));
+            .thenReturn(Collections.singletonList(notification));
         when(notificationRepo.findAllByNotificationTypeAndViewedIsFalse(NotificationType.EVENT_COMMENT_LIKE))
-                .thenReturn(Collections.singletonList(notification));
+            .thenReturn(Collections.singletonList(notification));
         notificationService.sendLikeScheduledEmail();
         ArgumentCaptor<ScheduledEmailMessage> captor = ArgumentCaptor.forClass(ScheduledEmailMessage.class);
         await().atMost(5, SECONDS)
-                .untilAsserted(() -> verify(restClient, times(3)).sendScheduledEmailNotification(captor.capture()));
+            .untilAsserted(() -> verify(restClient, times(3)).sendScheduledEmailNotification(captor.capture()));
         List<ScheduledEmailMessage> capturedMessages = captor.getAllValues();
         for (ScheduledEmailMessage capturedMessage : capturedMessages) {
             assertEquals(notification.getTargetUser().getEmail(), capturedMessage.getEmail());

--- a/service/src/test/java/greencity/service/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/NotificationServiceImplTest.java
@@ -18,12 +18,17 @@ import greencity.dto.place.PlaceVO;
 import greencity.dto.user.PlaceAuthorDto;
 import greencity.dto.user.UserVO;
 import greencity.entity.Category;
+import greencity.entity.Notification;
 import greencity.entity.Place;
+import greencity.entity.User;
 import greencity.enums.EmailNotification;
+import greencity.enums.NotificationType;
 import greencity.message.GeneralEmailMessage;
 import greencity.message.HabitAssignNotificationMessage;
+import greencity.message.ScheduledEmailMessage;
 import greencity.message.SendReportEmailMessage;
 import greencity.message.UserTaggedInCommentMessage;
+import greencity.repository.NotificationRepo;
 import greencity.repository.PlaceRepo;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
@@ -51,6 +56,9 @@ class NotificationServiceImplTest {
     private PlaceRepo placeRepo;
 
     @Mock
+    private NotificationRepo notificationRepo;
+
+    @Mock
     private ModelMapper modelMapper;
 
     @Mock
@@ -60,9 +68,9 @@ class NotificationServiceImplTest {
     void sendImmediatelyReportTest() {
         EmailNotification emailNotification = EmailNotification.IMMEDIATELY;
         CategoryVO category = CategoryVO.builder()
-            .id(12L)
-            .name("category")
-            .build();
+                .id(12L)
+                .name("category")
+                .build();
 
         UserVO userVO = ModelUtils.getUserVO();
         userVO.setEmailNotification(emailNotification);
@@ -78,18 +86,18 @@ class NotificationServiceImplTest {
         place.setCategory(category);
 
         when(restClient.findAllByEmailNotification(emailNotification))
-            .thenReturn(Collections.singletonList(userVO));
+                .thenReturn(Collections.singletonList(userVO));
         when(modelMapper.map(userVO, PlaceAuthorDto.class))
-            .thenReturn(new PlaceAuthorDto(1L, "dto", "email"));
+                .thenReturn(new PlaceAuthorDto(1L, "dto", "email"));
         when(modelMapper.map(place.getCategory(), CategoryDto.class))
-            .thenReturn(new CategoryDto("category", "test", null));
+                .thenReturn(new CategoryDto("category", "test", null));
         when(modelMapper.map(place, PlaceNotificationDto.class))
-            .thenReturn(new PlaceNotificationDto("name", new CategoryDto("category", "test", null)));
+                .thenReturn(new PlaceNotificationDto("name", new CategoryDto("category", "test", null)));
 
         notificationService.sendImmediatelyReport(place);
 
         verify(restClient, Mockito.times(1))
-            .sendReport(any(SendReportEmailMessage.class));
+                .sendReport(any(SendReportEmailMessage.class));
     }
 
     @Test
@@ -110,24 +118,24 @@ class NotificationServiceImplTest {
         List<Place> testPlaces = Arrays.asList(testPlace1, testPlace2);
 
         when(restClient.findAllByEmailNotification(emailNotification))
-            .thenReturn(Collections.singletonList(userVO));
+                .thenReturn(Collections.singletonList(userVO));
         when(modelMapper.map(userVO, PlaceAuthorDto.class))
-            .thenReturn(new PlaceAuthorDto(1L, "dto", "email"));
+                .thenReturn(new PlaceAuthorDto(1L, "dto", "email"));
         when(placeRepo.findAllByModifiedDateBetweenAndStatus(any(LocalDateTime.class), any(LocalDateTime.class), any()))
-            .thenReturn(testPlaces);
+                .thenReturn(testPlaces);
         when(modelMapper.map(testPlace1, PlaceNotificationDto.class))
-            .thenReturn(new PlaceNotificationDto("name", new CategoryDto("category", "test", null)));
+                .thenReturn(new PlaceNotificationDto("name", new CategoryDto("category", "test", null)));
         when(modelMapper.map(testPlace2, PlaceNotificationDto.class))
-            .thenReturn(new PlaceNotificationDto("name1", new CategoryDto("category1", "test", null)));
+                .thenReturn(new PlaceNotificationDto("name1", new CategoryDto("category1", "test", null)));
         when(modelMapper.map(testPlace1.getCategory(), CategoryDto.class))
-            .thenReturn(new CategoryDto("category", "test", null));
+                .thenReturn(new CategoryDto("category", "test", null));
         when(modelMapper.map(testPlace2.getCategory(), CategoryDto.class))
-            .thenReturn(new CategoryDto("category1", "test", null));
+                .thenReturn(new CategoryDto("category1", "test", null));
 
         notificationService.sendDailyReport();
 
         verify(restClient, Mockito.times(1))
-            .sendReport(any(SendReportEmailMessage.class));
+                .sendReport(any(SendReportEmailMessage.class));
 
     }
 
@@ -149,24 +157,24 @@ class NotificationServiceImplTest {
         List<Place> testPlaces = Arrays.asList(testPlace1, testPlace2);
 
         when(restClient.findAllByEmailNotification(emailNotification))
-            .thenReturn(Collections.singletonList(userVO));
+                .thenReturn(Collections.singletonList(userVO));
         when(modelMapper.map(userVO, PlaceAuthorDto.class))
-            .thenReturn(new PlaceAuthorDto(1L, "dto", "email"));
+                .thenReturn(new PlaceAuthorDto(1L, "dto", "email"));
         when(placeRepo.findAllByModifiedDateBetweenAndStatus(any(LocalDateTime.class), any(LocalDateTime.class), any()))
-            .thenReturn(testPlaces);
+                .thenReturn(testPlaces);
         when(modelMapper.map(testPlace1, PlaceNotificationDto.class))
-            .thenReturn(new PlaceNotificationDto("name", new CategoryDto("category", "test", null)));
+                .thenReturn(new PlaceNotificationDto("name", new CategoryDto("category", "test", null)));
         when(modelMapper.map(testPlace2, PlaceNotificationDto.class))
-            .thenReturn(new PlaceNotificationDto("name1", new CategoryDto("category1", "test", null)));
+                .thenReturn(new PlaceNotificationDto("name1", new CategoryDto("category1", "test", null)));
         when(modelMapper.map(testPlace1.getCategory(), CategoryDto.class))
-            .thenReturn(new CategoryDto("category", "test", null));
+                .thenReturn(new CategoryDto("category", "test", null));
         when(modelMapper.map(testPlace2.getCategory(), CategoryDto.class))
-            .thenReturn(new CategoryDto("category1", "test", null));
+                .thenReturn(new CategoryDto("category1", "test", null));
 
         notificationService.sendWeeklyReport();
 
         verify(restClient, Mockito.times(1))
-            .sendReport(any(SendReportEmailMessage.class));
+                .sendReport(any(SendReportEmailMessage.class));
 
     }
 
@@ -188,24 +196,24 @@ class NotificationServiceImplTest {
         List<Place> testPlaces = Arrays.asList(testPlace1, testPlace2);
 
         when(restClient.findAllByEmailNotification(emailNotification))
-            .thenReturn(Collections.singletonList(userVO));
+                .thenReturn(Collections.singletonList(userVO));
         when(modelMapper.map(userVO, PlaceAuthorDto.class))
-            .thenReturn(new PlaceAuthorDto(1L, "dto", "email"));
+                .thenReturn(new PlaceAuthorDto(1L, "dto", "email"));
         when(placeRepo.findAllByModifiedDateBetweenAndStatus(any(LocalDateTime.class), any(LocalDateTime.class), any()))
-            .thenReturn(testPlaces);
+                .thenReturn(testPlaces);
         when(modelMapper.map(testPlace1, PlaceNotificationDto.class))
-            .thenReturn(new PlaceNotificationDto("name", new CategoryDto("category", "test", null)));
+                .thenReturn(new PlaceNotificationDto("name", new CategoryDto("category", "test", null)));
         when(modelMapper.map(testPlace2, PlaceNotificationDto.class))
-            .thenReturn(new PlaceNotificationDto("name1", new CategoryDto("category1", "test", null)));
+                .thenReturn(new PlaceNotificationDto("name1", new CategoryDto("category1", "test", null)));
         when(modelMapper.map(testPlace1.getCategory(), CategoryDto.class))
-            .thenReturn(new CategoryDto("category", "test", null));
+                .thenReturn(new CategoryDto("category", "test", null));
         when(modelMapper.map(testPlace2.getCategory(), CategoryDto.class))
-            .thenReturn(new CategoryDto("category1", "test", null));
+                .thenReturn(new CategoryDto("category1", "test", null));
 
         notificationService.sendMonthlyReport();
 
         verify(restClient, Mockito.times(1))
-            .sendReport(any(SendReportEmailMessage.class));
+                .sendReport(any(SendReportEmailMessage.class));
     }
 
     @Test
@@ -216,7 +224,7 @@ class NotificationServiceImplTest {
         ArgumentCaptor<GeneralEmailMessage> emailMessageCaptor = ArgumentCaptor.forClass(GeneralEmailMessage.class);
         notificationService.sendEmailNotification(setOfEmails, subject, message);
         await().atMost(5, SECONDS)
-            .untilAsserted(() -> verify(restClient, times(3)).sendEmailNotification(emailMessageCaptor.capture()));
+                .untilAsserted(() -> verify(restClient, times(3)).sendEmailNotification(emailMessageCaptor.capture()));
         List<GeneralEmailMessage> capturedEmailMessages = emailMessageCaptor.getAllValues();
         assertFalse(capturedEmailMessages.isEmpty());
         for (GeneralEmailMessage capturedEmailMessage : capturedEmailMessages) {
@@ -235,7 +243,7 @@ class NotificationServiceImplTest {
         ArgumentCaptor<GeneralEmailMessage> emailMessageCaptor = ArgumentCaptor.forClass(GeneralEmailMessage.class);
         notificationService.sendEmailNotification(generalEmailMessage);
         await().atMost(5, SECONDS)
-            .untilAsserted(() -> verify(restClient).sendEmailNotification(emailMessageCaptor.capture()));
+                .untilAsserted(() -> verify(restClient).sendEmailNotification(emailMessageCaptor.capture()));
         GeneralEmailMessage capturedEmailMessage = emailMessageCaptor.getValue();
         assertEquals(email, capturedEmailMessage.getEmail());
         assertEquals(subject, capturedEmailMessage.getSubject());
@@ -245,12 +253,12 @@ class NotificationServiceImplTest {
     @Test
     void sendHabitAssignEmailNotification() {
         HabitAssignNotificationMessage message = new HabitAssignNotificationMessage(
-            "sender", "receiver", "receiver@example.com", "habit", "en", 123L);
+                "sender", "receiver", "receiver@example.com", "habit", "en", 123L);
         ArgumentCaptor<HabitAssignNotificationMessage> emailMessageCaptor =
-            ArgumentCaptor.forClass(HabitAssignNotificationMessage.class);
+                ArgumentCaptor.forClass(HabitAssignNotificationMessage.class);
         notificationService.sendHabitAssignEmailNotification(message);
         await().atMost(5, SECONDS)
-            .untilAsserted(() -> verify(restClient).sendHabitAssignNotification(emailMessageCaptor.capture()));
+                .untilAsserted(() -> verify(restClient).sendHabitAssignNotification(emailMessageCaptor.capture()));
         HabitAssignNotificationMessage capturedMessage = emailMessageCaptor.getValue();
         assertEquals(message.getReceiverEmail(), capturedMessage.getReceiverEmail());
         assertEquals(message.getHabitAssignId(), capturedMessage.getHabitAssignId());
@@ -262,23 +270,105 @@ class NotificationServiceImplTest {
     @Test
     void sendUserTaggedInCommentNotificationTest() {
         UserTaggedInCommentMessage message = UserTaggedInCommentMessage.builder()
-            .receiverEmail("receiver@example.com")
-            .receiverName("receiver")
-            .commentText("test")
-            .taggerName("tagger")
-            .commentedElementId(1L)
-            .language("en")
-            .build();
+                .receiverEmail("receiver@example.com")
+                .receiverName("receiver")
+                .commentText("test")
+                .taggerName("tagger")
+                .commentedElementId(1L)
+                .language("en")
+                .build();
         ArgumentCaptor<UserTaggedInCommentMessage> captor =
-            ArgumentCaptor.forClass(UserTaggedInCommentMessage.class);
+                ArgumentCaptor.forClass(UserTaggedInCommentMessage.class);
         notificationService.sendUsersTaggedInCommentEmailNotification(message);
         await().atMost(5, SECONDS)
-            .untilAsserted(() -> verify(restClient).sendUserTaggedInCommentNotification(captor.capture()));
+                .untilAsserted(() -> verify(restClient).sendUserTaggedInCommentNotification(captor.capture()));
         UserTaggedInCommentMessage capturedMessage = captor.getValue();
         assertEquals(message.getReceiverEmail(), capturedMessage.getReceiverEmail());
         assertEquals(message.getReceiverName(), capturedMessage.getReceiverName());
         assertEquals(message.getCommentText(), capturedMessage.getCommentText());
         assertEquals(message.getLanguage(), capturedMessage.getLanguage());
         assertEquals(message.getTaggerName(), capturedMessage.getTaggerName());
+    }
+
+    @Test
+    void sendFriendRequestScheduledEmail() {
+        Notification notification = ModelUtils.getNotification();
+        User targetUser = ModelUtils.getUser();
+        notification.setTargetUser(targetUser);
+        when(notificationRepo.findAllByNotificationTypeAndViewedIsFalse(NotificationType.FRIEND_REQUEST_RECEIVED))
+                .thenReturn(Collections.singletonList(notification));
+        when(notificationRepo.findAllByNotificationTypeAndViewedIsFalse(NotificationType.FRIEND_REQUEST_ACCEPTED))
+                .thenReturn(Collections.singletonList(notification));
+        notificationService.sendFriendRequestScheduledEmail();
+        ArgumentCaptor<ScheduledEmailMessage> captor = ArgumentCaptor.forClass(ScheduledEmailMessage.class);
+        await().atMost(5, SECONDS)
+                .untilAsserted(() -> verify(restClient, times(2)).sendScheduledEmailNotification(captor.capture()));
+        List<ScheduledEmailMessage> capturedMessages = captor.getAllValues();
+        for (ScheduledEmailMessage capturedMessage : capturedMessages) {
+            assertEquals(notification.getTargetUser().getEmail(), capturedMessage.getEmail());
+            assertEquals(notification.getTargetUser().getName(), capturedMessage.getUsername());
+        }
+    }
+
+    @Test
+    void sendCommentReplyScheduledEmail() {
+        Notification notification = ModelUtils.getNotification();
+        User targetUser = ModelUtils.getUser();
+        notification.setTargetUser(targetUser);
+        when(notificationRepo.findAllByNotificationTypeAndViewedIsFalse(NotificationType.ECONEWS_COMMENT_REPLY))
+                .thenReturn(Collections.singletonList(notification));
+        when(notificationRepo.findAllByNotificationTypeAndViewedIsFalse(NotificationType.EVENT_COMMENT_REPLY))
+                .thenReturn(Collections.singletonList(notification));
+        notificationService.sendCommentReplyScheduledEmail();
+        ArgumentCaptor<ScheduledEmailMessage> captor = ArgumentCaptor.forClass(ScheduledEmailMessage.class);
+        await().atMost(5, SECONDS)
+                .untilAsserted(() -> verify(restClient, times(2)).sendScheduledEmailNotification(captor.capture()));
+        List<ScheduledEmailMessage> capturedMessages = captor.getAllValues();
+        for (ScheduledEmailMessage capturedMessage : capturedMessages) {
+            assertEquals(notification.getTargetUser().getEmail(), capturedMessage.getEmail());
+            assertEquals(notification.getTargetUser().getName(), capturedMessage.getUsername());
+        }
+    }
+
+    @Test
+    void sendCommentScheduledEmail() {
+        Notification notification = ModelUtils.getNotification();
+        User targetUser = ModelUtils.getUser();
+        notification.setTargetUser(targetUser);
+        when(notificationRepo.findAllByNotificationTypeAndViewedIsFalse(NotificationType.ECONEWS_COMMENT))
+                .thenReturn(Collections.singletonList(notification));
+        when(notificationRepo.findAllByNotificationTypeAndViewedIsFalse(NotificationType.EVENT_COMMENT))
+                .thenReturn(Collections.singletonList(notification));
+        notificationService.sendCommentScheduledEmail();
+        ArgumentCaptor<ScheduledEmailMessage> captor = ArgumentCaptor.forClass(ScheduledEmailMessage.class);
+        await().atMost(5, SECONDS)
+                .untilAsserted(() -> verify(restClient, times(2)).sendScheduledEmailNotification(captor.capture()));
+        List<ScheduledEmailMessage> capturedMessages = captor.getAllValues();
+        for (ScheduledEmailMessage capturedMessage : capturedMessages) {
+            assertEquals(notification.getTargetUser().getEmail(), capturedMessage.getEmail());
+            assertEquals(notification.getTargetUser().getName(), capturedMessage.getUsername());
+        }
+    }
+
+    @Test
+    void sendLikeScheduledEmail() {
+        Notification notification = ModelUtils.getNotification();
+        User targetUser = ModelUtils.getUser();
+        notification.setTargetUser(targetUser);
+        when(notificationRepo.findAllByNotificationTypeAndViewedIsFalse(NotificationType.ECONEWS_COMMENT_LIKE))
+                .thenReturn(Collections.singletonList(notification));
+        when(notificationRepo.findAllByNotificationTypeAndViewedIsFalse(NotificationType.ECONEWS_LIKE))
+                .thenReturn(Collections.singletonList(notification));
+        when(notificationRepo.findAllByNotificationTypeAndViewedIsFalse(NotificationType.EVENT_COMMENT_LIKE))
+                .thenReturn(Collections.singletonList(notification));
+        notificationService.sendLikeScheduledEmail();
+        ArgumentCaptor<ScheduledEmailMessage> captor = ArgumentCaptor.forClass(ScheduledEmailMessage.class);
+        await().atMost(5, SECONDS)
+                .untilAsserted(() -> verify(restClient, times(3)).sendScheduledEmailNotification(captor.capture()));
+        List<ScheduledEmailMessage> capturedMessages = captor.getAllValues();
+        for (ScheduledEmailMessage capturedMessage : capturedMessages) {
+            assertEquals(notification.getTargetUser().getEmail(), capturedMessage.getEmail());
+            assertEquals(notification.getTargetUser().getName(), capturedMessage.getUsername());
+        }
     }
 }


### PR DESCRIPTION
GreenCity PR
https://github.com/ita-social-projects/GreenCity/issues/7377

Summary Of Changes 🔥
Changed email notification logic, unread notifications with types 
- ECONEWS_COMMENT_LIKE
- ECONEWS_LIKE
- EVENT_COMMENT_LIKE
- ECONEWS_COMMENT
- EVENT_COMMENT
- ECONEWS_COMMENT_REPLY
- EVENT_COMMENT_REPLY
- FRIEND_REQUEST_RECEIVED
- FRIEND_REQUEST_ACCEPTED
are sent 2 times a day with one email

Issue Link 📋
#7377

How to test 📋
PR Checklist Forms
(to be filled out by PR submitter)
[ ] Code is up-to-date with the dev branch.
[x] You've successfully built and run the tests locally.
[x] There are new or updated unit tests validating the change.
[x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
[x] This template filled (above this section).
[x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
[x] NEED_REVIEW and READY_FOR_REVIEW labels are added.
[x] All files reviewed before sending to reviewers