### PR TITLE
Add server.tomcat.relaxed-query-chars=<, >, [, \,, ], ^, `, {, |, } to application.properties

### DIFF
--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -37,3 +37,5 @@ spring.messaging.stomp.websocket.allowed-origins=\
   http://localhost:4205, \
   http://localhost:4200/, \
   http://localhost:4205/*
+
+server.tomcat.relaxed-query-chars=<, >, [, \,, ], ^, `, {, |, }


### PR DESCRIPTION
[https://github.com/ita-social-projects/GreenCity/issues/6399](https://github.com/ita-social-projects/GreenCity/issues/6399
)
Added the server.tomcat.relaxed-query-chars=... property to application.properties. This prevents Tomcat from rejecting requests with these characters.