### PR TITLE
Small fixes in getRandomFactOfTheDayForUser method

### DIFF
--- a/service/src/main/java/greencity/service/FactOfTheDayServiceImpl.java
+++ b/service/src/main/java/greencity/service/FactOfTheDayServiceImpl.java
@@ -250,7 +250,11 @@ public class FactOfTheDayServiceImpl implements FactOfTheDayService {
     @Override
     public FactOfTheDayTranslationDTO getRandomFactOfTheDayForUser(String languageCode, String userEmail) {
         Set<Long> userTagIds = tagsRepo.findTagsIdByUserHabitsInProgress(userEmail);
-        return getRandomFactOfTheDayByLanguageAndTags(languageCode, userTagIds);
+        try {
+            return getRandomFactOfTheDayByLanguageAndTags(languageCode, userTagIds);
+        } catch (NotFoundException e) {
+            return null;
+        }
     }
 
     /**

--- a/service/src/test/java/greencity/service/FactOfTheDayServiceImplTest.java
+++ b/service/src/test/java/greencity/service/FactOfTheDayServiceImplTest.java
@@ -24,6 +24,7 @@ import static greencity.enums.TagType.FACT_OF_THE_DAY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import greencity.repository.TagsRepo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -362,9 +363,9 @@ class FactOfTheDayServiceImplTest {
 
         when(tagsRepo.findTagsIdByUserHabitsInProgress(userEmail)).thenReturn(Collections.emptySet());
 
-        assertThrows(NotFoundException.class, () -> {
-            factOfTheDayService.getRandomFactOfTheDayForUser(languageCode, userEmail);
-        });
+        FactOfTheDayTranslationDTO result = factOfTheDayService.getRandomFactOfTheDayForUser(languageCode, userEmail);
+
+        assertNull(result);
     }
 
     @Test


### PR DESCRIPTION
# GreenCity PR

## Issue Link :clipboard:
[#7384](https://github.com/ita-social-projects/GreenCity/issues/7384)

## Summary Of Changes :fire:

## Changed
- In the getRandomFactOfTheDayForUser method (in the case when the user does not have Habits in the "In progress" status, or there is no fact of the day with the required tag), null will be returned instead of NotFoundException.

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers