### PR TITLE
fix find achievements by category HABIT

### DIFF
--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -179,7 +179,7 @@ public class ModelUtils {
     public static AchievementVO getAchievementVO() {
         return new AchievementVO(1L, "ACQUIRED_HABIT_14_DAYS", "Набуття звички протягом 14 днів",
             "Acquired habit 14 days",
-            new AchievementCategoryVO(1L, "name"), 1, 0);
+            new AchievementCategoryVO(1L, "name"), null, 1, 0);
     }
 
     public static UserManagementDto getUserManagementDto() {

--- a/dao/src/main/java/greencity/repository/HabitTranslationRepo.java
+++ b/dao/src/main/java/greencity/repository/HabitTranslationRepo.java
@@ -482,4 +482,16 @@ public interface HabitTranslationRepo
         + "AND ht.habit.id = :id "
         + "AND ht.habit.isDeleted = false")
     HabitTranslation getHabitTranslationByUaLanguage(Long id);
+
+    /**
+     * Method that returns all habit translations in English language by habit id.
+     *
+     * @param id {@link Long} habit id.
+     * @return {@link HabitTranslation}.
+     */
+    @Query("SELECT ht FROM HabitTranslation ht "
+        + "WHERE ht.language.id = 2 "
+        + "AND ht.habit.id = :id "
+        + "AND ht.habit.isDeleted = false")
+    HabitTranslation getHabitTranslationByEnLanguage(Long id);
 }

--- a/service-api/src/main/java/greencity/dto/achievement/AchievementVO.java
+++ b/service-api/src/main/java/greencity/dto/achievement/AchievementVO.java
@@ -1,6 +1,7 @@
 package greencity.dto.achievement;
 
 import greencity.dto.achievementcategory.AchievementCategoryVO;
+import greencity.dto.habit.HabitVO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -19,6 +20,8 @@ public class AchievementVO {
     private String nameEng;
     @NotEmpty
     private AchievementCategoryVO achievementCategory;
+
+    private HabitVO habit;
 
     @NotEmpty
     private Integer condition;

--- a/service/src/main/java/greencity/service/AchievementServiceImpl.java
+++ b/service/src/main/java/greencity/service/AchievementServiceImpl.java
@@ -112,7 +112,7 @@ public class AchievementServiceImpl implements AchievementService {
                 for (UserAction action : allActions) {
                     if ((action.getHabit() == null && action.getAchievementCategory().getId()
                         .equals(achievementVO.getAchievementCategory().getId()))
-                            || (action.getHabit() != null && achievementVO.getHabit() != null
+                        || (action.getHabit() != null && achievementVO.getHabit() != null
                             && action.getHabit().getId().equals(achievementVO.getHabit().getId()))) {
                         achievementCategoryProgress = action.getCount();
                         break;

--- a/service/src/main/java/greencity/service/AchievementServiceImpl.java
+++ b/service/src/main/java/greencity/service/AchievementServiceImpl.java
@@ -265,7 +265,7 @@ public class AchievementServiceImpl implements AchievementService {
             achievementConditionUserHabitMap.put(duration, habitInProgress
                 .stream()
                 .filter(habitAssign -> habitAssign.getDuration().equals(duration)
-                    || habitAssign.getDuration().compareTo(duration) > 0)
+                    || habitAssign.getDuration().compareTo(duration) < 0)
                 .toList());
         }
         for (Integer duration : habitAchievementsDurations) {

--- a/service/src/main/java/greencity/service/AchievementServiceImpl.java
+++ b/service/src/main/java/greencity/service/AchievementServiceImpl.java
@@ -264,7 +264,8 @@ public class AchievementServiceImpl implements AchievementService {
         for (Integer duration : habitAchievementsDurations) {
             achievementConditionUserHabitMap.put(duration, habitInProgress
                 .stream()
-                .filter(habitAssign -> habitAssign.getDuration().equals(duration) || habitAssign.getDuration().compareTo(duration) > 0)
+                .filter(habitAssign -> habitAssign.getDuration().equals(duration)
+                    || habitAssign.getDuration().compareTo(duration) > 0)
                 .toList());
         }
         for (Integer duration : habitAchievementsDurations) {

--- a/service/src/main/java/greencity/service/AchievementServiceImpl.java
+++ b/service/src/main/java/greencity/service/AchievementServiceImpl.java
@@ -6,8 +6,12 @@ import greencity.dto.achievement.AchievementManagementDto;
 import greencity.dto.achievement.AchievementPostDto;
 import greencity.dto.achievement.AchievementVO;
 import greencity.dto.achievement.ActionDto;
+import greencity.dto.habit.HabitVO;
 import greencity.entity.Achievement;
 import greencity.entity.AchievementCategory;
+import greencity.entity.Habit;
+import greencity.entity.HabitAssign;
+import greencity.entity.HabitTranslation;
 import greencity.entity.UserAchievement;
 import greencity.entity.UserAction;
 import greencity.enums.AchievementStatus;
@@ -17,9 +21,13 @@ import greencity.exception.exceptions.NotUpdatedException;
 import greencity.exception.exceptions.WrongIdException;
 import greencity.repository.AchievementCategoryRepo;
 import greencity.repository.AchievementRepo;
-import java.util.Optional;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.List;
 import java.util.stream.Collectors;
+import greencity.repository.HabitAssignRepo;
+import greencity.repository.HabitTranslationRepo;
 import greencity.repository.UserAchievementRepo;
 import greencity.repository.UserActionRepo;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +51,8 @@ public class AchievementServiceImpl implements AchievementService {
     private final SimpMessagingTemplate messagingTemplate;
     private final AchievementCategoryRepo achievementCategoryRepo;
     private final UserActionRepo userActionRepo;
+    private final HabitAssignRepo habitAssignRepo;
+    private final HabitTranslationRepo habitTranslationRepo;
     private final RatingPointsService ratingPointsService;
 
     /**
@@ -93,15 +103,17 @@ public class AchievementServiceImpl implements AchievementService {
         List<AchievementVO> achievements = switch (achievementStatus) {
             case ACHIEVED -> findAllAchieved(userId, searchAchievementCategoryId);
             case UNACHIEVED -> findUnachieved(userId, searchAchievementCategoryId);
-            case null, default -> findAllAchievementsWithAnyStatus(searchAchievementCategoryId);
+            case null, default -> findAllAchievementsWithAnyStatus(userId, searchAchievementCategoryId);
         };
         if (achievementCategoryId == null) {
             List<UserAction> allActions = userActionRepo.findAllByUserId(userId);
             return achievements.stream().map(achievementVO -> {
                 int achievementCategoryProgress = 0;
                 for (UserAction action : allActions) {
-                    if (action.getAchievementCategory().getId()
-                        .equals(achievementVO.getAchievementCategory().getId())) {
+                    if ((action.getHabit() == null && action.getAchievementCategory().getId()
+                        .equals(achievementVO.getAchievementCategory().getId()))
+                            || (action.getHabit() != null && achievementVO.getHabit() != null
+                            && action.getHabit().getId().equals(achievementVO.getHabit().getId()))) {
                         achievementCategoryProgress = action.getCount();
                         break;
                     }
@@ -110,11 +122,28 @@ public class AchievementServiceImpl implements AchievementService {
             })
                 .toList();
         } else {
-            UserAction achievementAction =
-                userActionRepo.findByUserIdAndAchievementCategoryId(userId, achievementCategoryId);
-            int achievementCategoryProgress = achievementAction != null ? achievementAction.getCount() : 0;
-            return achievements.stream().map(achievementVO -> achievementVO.setProgress(achievementCategoryProgress))
-                .toList();
+            Long habitAchievementCategory = findCategoryByName("HABIT").getId();
+            if (achievementCategoryId.equals(habitAchievementCategory)) {
+                return achievements.stream()
+                    .map(achievementVO -> {
+                        int achievementCategoryProgress = 0;
+                        if (achievementVO.getHabit() != null) {
+                            UserAction achievementAction =
+                                userActionRepo.findByUserIdAndAchievementCategoryIdAndHabitId(userId,
+                                    achievementCategoryId, achievementVO.getHabit().getId());
+                            achievementCategoryProgress = achievementAction != null ? achievementAction.getCount() : 0;
+                        }
+                        return achievementVO.setProgress(achievementCategoryProgress);
+                    })
+                    .toList();
+            } else {
+                UserAction achievementAction =
+                    userActionRepo.findByUserIdAndAchievementCategoryId(userId, achievementCategoryId);
+                int achievementCategoryProgress = achievementAction != null ? achievementAction.getCount() : 0;
+                return achievements.stream()
+                    .map(achievementVO -> achievementVO.setProgress(achievementCategoryProgress))
+                    .toList();
+            }
         }
     }
 
@@ -201,53 +230,96 @@ public class AchievementServiceImpl implements AchievementService {
         achievement.setCondition(achievementPostDto.getCondition());
     }
 
-    private List<AchievementVO> findAllAchievementsWithAnyStatus(Long achievementCategoryId) {
-        if (achievementCategoryId == null) {
-            return achievementRepo.findAll()
-                .stream()
-                .map(this::mapToVO)
-                .toList();
-        } else {
-            return achievementRepo.findAllByAchievementCategoryId(achievementCategoryId)
-                .stream()
-                .map(this::mapToVO)
-                .toList();
-        }
+    private List<AchievementVO> findAllAchievementsWithAnyStatus(Long userId, Long achievementCategoryId) {
+        List<AchievementVO> achievements = new ArrayList<>();
+        achievements.addAll(findAllAchieved(userId, achievementCategoryId));
+        achievements.addAll(findUnachieved(userId, achievementCategoryId));
+        return achievements;
     }
 
     private List<AchievementVO> findAllAchieved(Long userId, Long achievementCategoryId) {
+        List<UserAchievement> achievements;
         if (achievementCategoryId == null) {
-            return userAchievementRepo.getUserAchievementByUserId(userId)
-                .stream()
-                .map(userAchievement -> userAchievement.getAchievement().getId())
-                .map(achievementRepo::findById)
-                .flatMap(Optional::stream)
-                .map(this::mapToVO)
-                .toList();
+            achievements = userAchievementRepo.getUserAchievementByUserId(userId);
         } else {
-            return userAchievementRepo
-                .findAllByUserIdAndAchievement_AchievementCategoryId(userId, achievementCategoryId)
-                .stream()
-                .map(userAchievement -> userAchievement.getAchievement().getId())
-                .map(achievementRepo::findById)
-                .flatMap(Optional::stream)
-                .map(this::mapToVO)
-                .toList();
+            achievements =
+                userAchievementRepo.findAllByUserIdAndAchievement_AchievementCategoryId(userId, achievementCategoryId);
         }
+        return achievements.stream()
+            .map(userAchievement -> {
+                Long achievementId = userAchievement.getAchievement().getId();
+                Achievement achievement = achievementRepo.findById(achievementId).orElse(null);
+                AchievementVO achievementVO = mapToVO(achievement);
+                if (userAchievement.getHabit() != null) {
+                    HabitTranslation translationUa =
+                        habitTranslationRepo.getHabitTranslationByUaLanguage(userAchievement.getHabit().getId());
+                    HabitTranslation translationEn =
+                        habitTranslationRepo.getHabitTranslationByEnLanguage(userAchievement.getHabit().getId());
+                    achievementVO.setHabit(mapHabitToVO(userAchievement.getHabit()));
+                    achievementVO.setName(achievementVO.getName() + " " + translationUa.getName());
+                    achievementVO.setNameEng(achievementVO.getName() + " " + translationEn.getName());
+                }
+                return achievementVO;
+            })
+            .toList();
     }
 
     private List<AchievementVO> findUnachieved(Long userId, Long achievementCategoryId) {
+        List<Achievement> achievements;
         if (achievementCategoryId == null) {
-            return achievementRepo.searchAchievementsUnAchieved(userId)
-                .stream()
-                .map(this::mapToVO)
-                .toList();
+            achievements = achievementRepo.searchAchievementsUnAchieved(userId);
         } else {
-            return achievementRepo.searchAchievementsUnAchievedByCategory(userId, achievementCategoryId)
-                .stream()
-                .map(this::mapToVO)
-                .toList();
+            achievements = achievementRepo.searchAchievementsUnAchievedByCategory(userId, achievementCategoryId);
         }
+        List<AchievementVO> achievementsToReturn = new ArrayList<>(achievements.stream()
+            .map(this::mapToVO)
+            .toList());
+
+        Long habitAchievementCategory = findCategoryByName("HABIT").getId();
+        if (achievementCategoryId == null || achievementCategoryId.equals(habitAchievementCategory)) {
+            findUnachievedHabitAchievements(userId, habitAchievementCategory, achievementsToReturn);
+        }
+
+        return achievementsToReturn;
+    }
+
+    private void findUnachievedHabitAchievements(Long userId, Long categoryId, List<AchievementVO> achievements) {
+        List<AchievementVO> unachievedHabitAchievements = new ArrayList<>();
+        List<HabitAssign> habitInProgress = habitAssignRepo.findAllInProgressHabitAssignsRelatedToUser(userId);
+        List<Integer> habitAchievementsDurations = achievementRepo.findAllByAchievementCategoryId(categoryId)
+            .stream()
+            .map(Achievement::getCondition)
+            .toList();
+        Map<Integer, List<HabitAssign>> achievementConditionUserHabitMap = new HashMap<>();
+        for (Integer duration : habitAchievementsDurations) {
+            achievementConditionUserHabitMap.put(duration, habitInProgress
+                .stream()
+                .filter(habitAssign -> habitAssign.getDuration().equals(duration))
+                .toList());
+        }
+        for (Integer duration : habitAchievementsDurations) {
+            AchievementVO achievementByDuration = findByCategoryIdAndCondition(categoryId, duration);
+            if (!achievementConditionUserHabitMap.get(duration).isEmpty()) {
+                achievements.remove(achievementByDuration);
+            }
+            for (HabitAssign habitAssign : achievementConditionUserHabitMap.get(duration)) {
+                HabitTranslation translationUa =
+                    habitTranslationRepo.getHabitTranslationByUaLanguage(habitAssign.getHabit().getId());
+                HabitTranslation translationEn =
+                    habitTranslationRepo.getHabitTranslationByEnLanguage(habitAssign.getHabit().getId());
+                AchievementVO achievementByHabit = AchievementVO.builder()
+                    .id(achievementByDuration.getId())
+                    .title(achievementByDuration.getTitle())
+                    .name(achievementByDuration.getName() + " " + translationUa.getName())
+                    .nameEng(achievementByDuration.getNameEng() + " " + translationEn.getName())
+                    .achievementCategory(achievementByDuration.getAchievementCategory())
+                    .condition(achievementByDuration.getCondition())
+                    .habit(mapHabitToVO(habitAssign.getHabit()))
+                    .build();
+                unachievedHabitAchievements.add(achievementByHabit);
+            }
+        }
+        achievements.addAll(unachievedHabitAchievements);
     }
 
     private PageableAdvancedDto<AchievementVO> createPageable(Page<Achievement> pages) {
@@ -269,5 +341,9 @@ public class AchievementServiceImpl implements AchievementService {
 
     private AchievementVO mapToVO(Achievement achievement) {
         return modelMapper.map(achievement, AchievementVO.class);
+    }
+
+    private HabitVO mapHabitToVO(Habit habit) {
+        return modelMapper.map(habit, HabitVO.class);
     }
 }

--- a/service/src/main/java/greencity/service/AchievementServiceImpl.java
+++ b/service/src/main/java/greencity/service/AchievementServiceImpl.java
@@ -105,8 +105,7 @@ public class AchievementServiceImpl implements AchievementService {
             case UNACHIEVED -> findUnachieved(userId, searchAchievementCategoryId);
             case null, default -> findAllAchievementsWithAnyStatus(userId, searchAchievementCategoryId);
         };
-        setAchievementsProgress(userId, achievementCategoryId, achievements);
-        return achievements;
+        return setAchievementsProgress(userId, achievementCategoryId, achievements);
     }
 
     /**
@@ -318,11 +317,12 @@ public class AchievementServiceImpl implements AchievementService {
         return modelMapper.map(habit, HabitVO.class);
     }
 
-    private void setAchievementsProgress(Long userId, Long achievementCategoryId, List<AchievementVO> achievements) {
+    private List<AchievementVO> setAchievementsProgress(Long userId, Long achievementCategoryId,
+        List<AchievementVO> achievements) {
         if (achievementCategoryId == null) {
-            achievements = setAchievementsProgressForAllCategories(userId, achievements);
+            return setAchievementsProgressForAllCategories(userId, achievements);
         } else {
-            achievements = setAchievementsProgressForOneCategory(userId, achievementCategoryId, achievements);
+            return setAchievementsProgressForOneCategory(userId, achievementCategoryId, achievements);
         }
     }
 

--- a/service/src/main/java/greencity/service/AchievementServiceImpl.java
+++ b/service/src/main/java/greencity/service/AchievementServiceImpl.java
@@ -264,7 +264,7 @@ public class AchievementServiceImpl implements AchievementService {
         for (Integer duration : habitAchievementsDurations) {
             achievementConditionUserHabitMap.put(duration, habitInProgress
                 .stream()
-                .filter(habitAssign -> habitAssign.getDuration().equals(duration))
+                .filter(habitAssign -> habitAssign.getDuration().equals(duration) || habitAssign.getDuration().compareTo(duration) > 0)
                 .toList());
         }
         for (Integer duration : habitAchievementsDurations) {

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -1379,7 +1379,7 @@ public class ModelUtils {
 
     public static AchievementVO getAchievementVO() {
         return new AchievementVO(1L, "ACQUIRED_HABIT_14_DAYS", "Набуття звички протягом 14 днів",
-            "Acquired habit 14 days", new AchievementCategoryVO(),
+            "Acquired habit 14 days", new AchievementCategoryVO(), null,
             1, 0);
     }
 

--- a/service/src/test/java/greencity/achievement/AchievementCalculationTest.java
+++ b/service/src/test/java/greencity/achievement/AchievementCalculationTest.java
@@ -69,7 +69,8 @@ class AchievementCalculationTest {
         UserAchievement userAchievement = ModelUtils.getUserAchievement();
         user.setUserAchievements(Collections.singletonList(userAchievement));
         AchievementVO achievementVO =
-            new AchievementVO(1L, "CREATED_5_NEWS", "CREATED_5_NEWS", "CREATED_5_NEWS", new AchievementCategoryVO(), 1,
+            new AchievementVO(1L, "CREATED_5_NEWS", "CREATED_5_NEWS", "CREATED_5_NEWS", new AchievementCategoryVO(),
+                null, 1,
                 0);
         when(achievementCategoryService.findByName(AchievementCategoryType.CREATE_NEWS.name()))
             .thenReturn(achievementCategoryVO);
@@ -102,7 +103,8 @@ class AchievementCalculationTest {
         UserAchievement userAchievement = ModelUtils.getUserAchievement();
         user.setUserAchievements(Collections.singletonList(userAchievement));
         AchievementVO achievementVO =
-            new AchievementVO(1L, "CREATED_5_NEWS", "CREATED_5_NEWS", "CREATED_5_NEWS", new AchievementCategoryVO(), 1,
+            new AchievementVO(1L, "CREATED_5_NEWS", "CREATED_5_NEWS", "CREATED_5_NEWS", new AchievementCategoryVO(),
+                null, 1,
                 0);
         RatingPoints ratingPoints = ModelUtils.getRatingPointsAcquiredHabit14Days();
         when(ratingPointsRepo.findByNameOrThrow("ACQUIRED_HABIT_14_DAYS")).thenReturn(ratingPoints);
@@ -140,7 +142,8 @@ class AchievementCalculationTest {
         UserAchievement userAchievement = ModelUtils.getUserAchievement();
         user.setUserAchievements(Collections.singletonList(userAchievement));
         AchievementVO achievementVO =
-            new AchievementVO(1L, "CREATED_5_NEWS", "CREATED_5_NEWS", "CREATED_5_NEWS", new AchievementCategoryVO(), 1,
+            new AchievementVO(1L, "CREATED_5_NEWS", "CREATED_5_NEWS", "CREATED_5_NEWS", new AchievementCategoryVO(),
+                null, 1,
                 0);
         RatingPoints ratingPoints = ModelUtils.getRatingPointsAcquiredHabit14Days();
         when(ratingPointsRepo.findByNameOrThrow("ACQUIRED_HABIT_14_DAYS")).thenReturn(ratingPoints);
@@ -249,7 +252,8 @@ class AchievementCalculationTest {
         UserAchievement userAchievement = ModelUtils.getUserAchievement();
         user.setUserAchievements(Collections.singletonList(userAchievement));
         AchievementVO achievementVO =
-            new AchievementVO(1L, "CREATED_5_NEWS", "CREATED_5_NEWS", "CREATED_5_NEWS", new AchievementCategoryVO(), 1,
+            new AchievementVO(1L, "CREATED_5_NEWS", "CREATED_5_NEWS", "CREATED_5_NEWS", new AchievementCategoryVO(),
+                null, 1,
                 0);
         when(achievementCategoryService.findByName(AchievementCategoryType.CREATE_NEWS.name()))
             .thenReturn(achievementCategoryVO);
@@ -278,7 +282,8 @@ class AchievementCalculationTest {
         UserAchievement userAchievement = ModelUtils.getUserAchievement();
         user.setUserAchievements(Collections.singletonList(userAchievement));
         AchievementVO achievementVO =
-            new AchievementVO(1L, "CREATED_5_NEWS", "CREATED_5_NEWS", "CREATED_5_NEWS", new AchievementCategoryVO(), 1,
+            new AchievementVO(1L, "CREATED_5_NEWS", "CREATED_5_NEWS", "CREATED_5_NEWS", new AchievementCategoryVO(),
+                null, 1,
                 0);
         RatingPoints ratingPoints = ModelUtils.getRatingPointsAcquiredHabit14Days();
         when(achievementCategoryService.findByName(AchievementCategoryType.CREATE_NEWS.name()))

--- a/service/src/test/java/greencity/service/AchievementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/AchievementServiceImplTest.java
@@ -288,18 +288,19 @@ class AchievementServiceImplTest {
         when(userService.findByEmail("email@gmail.com")).thenReturn(getUserVO());
         when(achievementCategoryRepo.findById(anyLong())).thenReturn(Optional.of(achievementCategory));
         when(achievementRepo.searchAchievementsUnAchievedByCategory(anyLong(), anyLong()))
-                .thenReturn(List.of(achievement));
+            .thenReturn(List.of(achievement));
         when(modelMapper.map(achievement, AchievementVO.class))
-                .thenReturn(achievementVO);
+            .thenReturn(achievementVO);
         when(achievementCategoryRepo.findByName("HABIT")).thenReturn(Optional.of(achievementCategory));
-        when(habitAssignRepo.findAllInProgressHabitAssignsRelatedToUser(anyLong())).thenReturn(List.of(habitAssign, habitAssign2));
+        when(habitAssignRepo.findAllInProgressHabitAssignsRelatedToUser(anyLong()))
+            .thenReturn(List.of(habitAssign, habitAssign2));
         when(achievementRepo.findAllByAchievementCategoryId(anyLong())).thenReturn(List.of(achievement));
         when(achievementRepo.findByAchievementCategoryIdAndCondition(anyLong(), anyInt()))
-                .thenReturn(Optional.of(achievement));
+            .thenReturn(Optional.of(achievement));
         when(habitTranslationRepo.getHabitTranslationByUaLanguage(anyLong())).thenReturn(getHabitTranslationUa());
         when(habitTranslationRepo.getHabitTranslationByEnLanguage(anyLong())).thenReturn(getHabitTranslation());
         List<AchievementVO> findAllResult =
-                achievementService.findAllByTypeAndCategory("email@gmail.com", UNACHIEVED, achievementCategory.getId());
+            achievementService.findAllByTypeAndCategory("email@gmail.com", UNACHIEVED, achievementCategory.getId());
         assertEquals(1, findAllResult.size());
         assertEquals(1L, (long) findAllResult.getFirst().getId());
         verify(userService).findByEmail("email@gmail.com");
@@ -389,7 +390,8 @@ class AchievementServiceImplTest {
         userAchievement.setHabit(null);
         when(userService.findByEmail("email@gmail.com")).thenReturn(getUserVO());
         when(achievementCategoryRepo.findById(anyLong())).thenReturn(Optional.of(getAchievementCategory()));
-        when(userAchievementRepo.findAllByUserIdAndAchievement_AchievementCategoryId(anyLong(),anyLong())).thenReturn(List.of(userAchievement));
+        when(userAchievementRepo.findAllByUserIdAndAchievement_AchievementCategoryId(anyLong(), anyLong()))
+            .thenReturn(List.of(userAchievement));
         when(achievementRepo.findById(anyLong())).thenReturn(Optional.of(achievement));
         when(modelMapper.map(achievement, AchievementVO.class)).thenReturn(achievementVO);
         Integer result = achievementService.findAchievementCountByTypeAndCategory("email@gmail.com", ACHIEVED, 1L);
@@ -411,7 +413,8 @@ class AchievementServiceImplTest {
         AchievementCategory habitCategory = ModelUtils.getAchievementCategory().setId(0L);
         when(userService.findByEmail("email@gmail.com")).thenReturn(getUserVO());
         when(achievementCategoryRepo.findById(anyLong())).thenReturn(Optional.of(achievementCategory));
-        when(achievementRepo.searchAchievementsUnAchievedByCategory(anyLong(), anyLong())).thenReturn(List.of(achievement));
+        when(achievementRepo.searchAchievementsUnAchievedByCategory(anyLong(), anyLong()))
+            .thenReturn(List.of(achievement));
         when(modelMapper.map(achievement, AchievementVO.class)).thenReturn(achievementVO);
         when(achievementCategoryRepo.findByName("HABIT")).thenReturn(Optional.of(habitCategory));
         Integer result = achievementService.findAchievementCountByTypeAndCategory("email@gmail.com", UNACHIEVED, 1L);


### PR DESCRIPTION
#7608 

- [x] Achievements for habit for each achievement in category "HABIT" retrieve due to user assigned habit(INPROGRESS or ACQUIRED)
- [x] Each "HABIT" achievement name provide corresponding habit name
- [x] Achivement progress for category"HABIT" setted according to user habit streak
- [x] Test updated
- [x] Count achievements service method updated to reduce runtime