### PR TITLE
Refactor comments url

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -46,7 +46,8 @@ public class SecurityConfig {
     private static final String CATEGORIES = "/categories";
     private static final String ECO_NEWS = "/eco-news";
     private static final String ECO_NEWS_ID = "/{ecoNewsId}";
-    private static final String ECO_NEWS_COMMENTS = ECO_NEWS + ECO_NEWS_ID + COMMENTS;
+    private static final String ECO_NEWS_ID_COMMENTS = ECO_NEWS + ECO_NEWS_ID + COMMENTS;
+    private static final String ECO_NEWS_COMMENTS = ECO_NEWS + COMMENTS;
     private static final String REPLIES = "/replies";
     private static final String LIKE = "/like";
     private static final String LIKES = "/likes";
@@ -165,8 +166,8 @@ public class SecurityConfig {
                     ECO_NEWS + ECO_NEWS_ID,
                     ECO_NEWS + ECO_NEWS_ID + LIKES + COUNT,
                     ECO_NEWS + ECO_NEWS_ID + DISLIKES + COUNT,
-                    ECO_NEWS_COMMENTS,
-                    ECO_NEWS_COMMENTS + ACTIVE,
+                    ECO_NEWS_ID_COMMENTS,
+                    ECO_NEWS_ID_COMMENTS + ACTIVE,
                     ECO_NEWS_COMMENTS + PARENT_COMMENT_ID + REPLIES + ACTIVE,
                     ECO_NEWS_COMMENTS + PARENT_COMMENT_ID + REPLIES + ACTIVE + COUNT,
                     ECO_NEWS + COMMENTS,
@@ -174,12 +175,12 @@ public class SecurityConfig {
                     ECO_NEWS + COMMENTS + LIKE,
                     ECO_NEWS + COMMENTS + COMMENT_ID + LIKES + COUNT,
                     ECO_NEWS + COMMENTS + ACTIVE,
-                    ECO_NEWS_COMMENTS + COUNT,
+                    ECO_NEWS_ID_COMMENTS + COUNT,
                     EVENTS_ID_COMMENTS,
                     EVENTS_ID_COMMENTS + COMMENT_ID,
                     EVENTS_COMMENTS + COMMENT_ID,
                     EVENTS_ID_COMMENTS + COMMENT_ID + COUNT,
-                    EVENTS_ID_COMMENTS + PARENT_COMMENT_ID + REPLIES + ACTIVE,
+                    EVENTS_COMMENTS + PARENT_COMMENT_ID + REPLIES + ACTIVE,
                     EVENTS_COMMENTS + PARENT_COMMENT_ID + REPLIES + COUNT,
                     EVENTS_COMMENTS + LIKE,
                     EVENTS_COMMENTS + COMMENT_ID + LIKES + COUNT,
@@ -279,8 +280,8 @@ public class SecurityConfig {
                     ECO_NEWS + ECO_NEWS_ID + LIKES,
                     ECO_NEWS + ECO_NEWS_ID + DISLIKES,
                     ECO_NEWS + COMMENTS + LIKE,
-                    ECO_NEWS_COMMENTS,
-                    ECO_NEWS_COMMENTS + COMMENT_ID + LIKES,
+                    ECO_NEWS_ID_COMMENTS,
+                    ECO_NEWS_ID_COMMENTS + COMMENT_ID + LIKES,
                     EVENTS_ID_COMMENTS,
                     EVENTS_COMMENTS + LIKE + COMMENT_ID,
                     EVENTS,
@@ -317,7 +318,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.PUT,
                     "/habit/statistic/{id}",
                     ECO_NEWS + ECO_NEWS_ID,
-                    ECO_NEWS_COMMENTS + COMMENT_ID,
+                    ECO_NEWS_ID_COMMENTS + COMMENT_ID,
                     "/favorite_place/",
                     "/user/profile",
                     EVENTS_COMMENTS + COMMENT_ID,
@@ -349,7 +350,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.DELETE,
                     ECO_NEWS + ECO_NEWS_ID,
                     ECO_NEWS + COMMENTS + ECO_NEWS_ID,
-                    ECO_NEWS_COMMENTS + COMMENT_ID,
+                    ECO_NEWS_ID_COMMENTS + COMMENT_ID,
                     HABITS + "/comments/{id}",
                     CUSTOM_SHOPPING_LIST_ITEMS,
                     CUSTOM_SHOPPING_LIST_URL,

--- a/core/src/main/java/greencity/controller/EcoNewsCommentController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsCommentController.java
@@ -81,8 +81,8 @@ public class EcoNewsCommentController {
         consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<AddCommentDtoResponse> save(@PathVariable Long ecoNewsId,
         @Valid @RequestPart AddCommentDtoRequest request,
-        @RequestPart(value = "images", required = false) @Nullable @ImageArrayValidation @Size(max = 5,
-            message = "Download up to 5 images") MultipartFile[] images,
+        @RequestPart(value = "images", required = false) @Nullable @Size(max = 5,
+            message = "Download up to 5 images") @ImageArrayValidation MultipartFile[] images,
         @Parameter(hidden = true) @ValidLanguage Locale locale,
         @Parameter(hidden = true) @CurrentUser UserVO user) {
         return ResponseEntity
@@ -124,10 +124,9 @@ public class EcoNewsCommentController {
             content = @Content(examples = @ExampleObject(HttpStatuses.NOT_FOUND))),
     })
     @ApiPageable
-    @GetMapping("{ecoNewsId}/comments/{parentCommentId}/replies/active")
+    @GetMapping("/comments/{parentCommentId}/replies/active")
     public ResponseEntity<PageableDto<CommentDto>> getAllActiveReplies(
         @Parameter(hidden = true) Pageable pageable,
-        @PathVariable Long ecoNewsId,
         @PathVariable Long parentCommentId,
         @Parameter(hidden = true) @CurrentUser UserVO userVO) {
         return ResponseEntity
@@ -149,8 +148,8 @@ public class EcoNewsCommentController {
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND,
             content = @Content(examples = @ExampleObject(HttpStatuses.NOT_FOUND))),
     })
-    @GetMapping("{ecoNewsId}/comments/{parentCommentId}/replies/active/count")
-    public int getCountOfActiveReplies(@PathVariable Long ecoNewsId, @PathVariable Long parentCommentId) {
+    @GetMapping("/comments/{parentCommentId}/replies/active/count")
+    public int getCountOfActiveReplies(@PathVariable Long parentCommentId) {
         return commentService.countAllActiveReplies(parentCommentId);
     }
 

--- a/core/src/main/java/greencity/controller/EventCommentController.java
+++ b/core/src/main/java/greencity/controller/EventCommentController.java
@@ -73,8 +73,8 @@ public class EventCommentController {
         @PathVariable Long eventId,
         @Valid @RequestPart AddCommentDtoRequest request,
         @Parameter(hidden = true) @CurrentUser UserVO user,
-        @RequestPart(value = "images", required = false) @Nullable @ImageArrayValidation @Size(max = 5,
-            message = "Download up to 5 images") MultipartFile[] images,
+        @RequestPart(value = "images", required = false) @Nullable @Size(max = 5,
+            message = "Download up to 5 images") @ImageArrayValidation MultipartFile[] images,
         @Parameter(hidden = true) @ValidLanguage Locale locale) {
         return ResponseEntity
             .status(HttpStatus.CREATED)

--- a/core/src/main/java/greencity/controller/EventCommentController.java
+++ b/core/src/main/java/greencity/controller/EventCommentController.java
@@ -210,10 +210,9 @@ public class EventCommentController {
             content = @Content(examples = @ExampleObject(HttpStatuses.NOT_FOUND)))
     })
     @ApiPageable
-    @GetMapping("{eventId}/comments/{parentCommentId}/replies/active")
+    @GetMapping("/comments/{parentCommentId}/replies/active")
     public ResponseEntity<PageableDto<CommentDto>> findAllActiveReplies(
         @Parameter(hidden = true) Pageable pageable,
-        @PathVariable Long eventId,
         @PathVariable Long parentCommentId,
         @Parameter(hidden = true) @CurrentUser UserVO userVO) {
         return ResponseEntity.ok()

--- a/core/src/main/java/greencity/controller/HabitCommentController.java
+++ b/core/src/main/java/greencity/controller/HabitCommentController.java
@@ -65,8 +65,8 @@ public class HabitCommentController {
         consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<AddCommentDtoResponse> save(@PathVariable Long habitId,
         @Valid @RequestPart AddCommentDtoRequest request,
-        @RequestPart(value = "images", required = false) @Nullable @ImageArrayValidation @Size(max = 5,
-            message = "Download up to 5 images") MultipartFile[] images,
+        @RequestPart(value = "images", required = false) @Nullable @Size(max = 5,
+            message = "Download up to 5 images") @ImageArrayValidation MultipartFile[] images,
         @Parameter(hidden = true) @CurrentUser UserVO userVO,
         @Parameter(hidden = true) @ValidLanguage Locale locale) {
         return ResponseEntity

--- a/core/src/test/java/greencity/controller/EcoNewsCommentControllerTest.java
+++ b/core/src/test/java/greencity/controller/EcoNewsCommentControllerTest.java
@@ -196,7 +196,7 @@ class EcoNewsCommentControllerTest {
         when(commentService.getAllActiveReplies(pageable, parentCommentId, userVO))
             .thenReturn(commentReplies);
 
-        mockMvc.perform(get(ECONEWS_LINK + "/{ecoNewsId}/comments/{parentCommentId}/replies/active", 1, parentCommentId)
+        mockMvc.perform(get(ECONEWS_LINK + "/comments/{parentCommentId}/replies/active", parentCommentId)
             .principal(principal)
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON))
@@ -210,7 +210,7 @@ class EcoNewsCommentControllerTest {
     @SneakyThrows
     void getAllActiveRepliesWithNotValidIdBadRequestTest() {
         String notValidId = "id";
-        mockMvc.perform(get(ECONEWS_LINK + "/1/comments/{parentCommentId}/replies/active", notValidId))
+        mockMvc.perform(get(ECONEWS_LINK + "/comments/{parentCommentId}/replies/active", notValidId))
             .andExpect(status().isBadRequest());
     }
 
@@ -233,7 +233,7 @@ class EcoNewsCommentControllerTest {
             .getAllActiveReplies(pageable, parentCommentId, userVO);
 
         Assertions.assertThatThrownBy(
-            () -> mockMvc.perform(get(ECONEWS_LINK + "/1/comments/{parentCommentId}/replies/active",
+            () -> mockMvc.perform(get(ECONEWS_LINK + "/comments/{parentCommentId}/replies/active",
                 parentCommentId).principal(principal)).andExpect(status().isNotFound()))
             .hasCause(new NotFoundException(errorMessage));
 
@@ -249,7 +249,7 @@ class EcoNewsCommentControllerTest {
         String expectedResponse = "<Integer>10</Integer>";
         when(commentService.countAllActiveReplies(parentCommentId)).thenReturn(repliesAmount);
 
-        mockMvc.perform(get(ECONEWS_LINK + "/1/comments/{parentCommentId}/replies/active/count", parentCommentId))
+        mockMvc.perform(get(ECONEWS_LINK + "/comments/{parentCommentId}/replies/active/count", parentCommentId))
             .andExpect(status().isOk())
             .andExpect(content().xml(expectedResponse));
 
@@ -260,7 +260,7 @@ class EcoNewsCommentControllerTest {
     @SneakyThrows
     void getCountOfActiveRepliesBadRequestTest() {
         String notValidId = "id";
-        mockMvc.perform(get(ECONEWS_LINK + "/1/comments/{parentCommentId}/replies/active/count", notValidId))
+        mockMvc.perform(get(ECONEWS_LINK + "/comments/{parentCommentId}/replies/active/count", notValidId))
             .andExpect(status().isBadRequest());
     }
 
@@ -275,7 +275,7 @@ class EcoNewsCommentControllerTest {
             .countAllActiveReplies(parentCommentId);
 
         Assertions.assertThatThrownBy(() -> mockMvc.perform(
-            get(ECONEWS_LINK + "/1/comments/{parentCommentId}/replies/active/count", parentCommentId))
+            get(ECONEWS_LINK + "/comments/{parentCommentId}/replies/active/count", parentCommentId))
             .andExpect(status().isNotFound()))
             .hasCause(new NotFoundException(errorMessage));
 

--- a/core/src/test/java/greencity/controller/EventCommentControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventCommentControllerTest.java
@@ -225,7 +225,6 @@ class EventCommentControllerTest {
     @SneakyThrows
     void findAllReplies() {
         Long parentCommentId = 1L;
-        Long eventId = 1L;
         int pageNumber = 0;
         int pageSize = 20;
         UserVO userVO = getUserVO();
@@ -243,8 +242,7 @@ class EventCommentControllerTest {
 
         mockMvc
             .perform(
-                get(EVENT_ID_COMMENT_CONTROLLER_LINK + "/{parentCommentId}/replies/active?statuses=EDITED,ORIGINAL",
-                    eventId,
+                get(EVENT_COMMENTS_CONTROLLER_LINK + "/{parentCommentId}/replies/active?statuses=EDITED,ORIGINAL",
                     parentCommentId)
                     .principal(principal)
                     .contentType(MediaType.APPLICATION_JSON)
@@ -259,9 +257,8 @@ class EventCommentControllerTest {
     @SneakyThrows
     void findAllRepliesWithNotValidIdBadRequestTest() {
         String notValidId = "id";
-        Long eventId = 1L;
         mockMvc
-            .perform(get(EVENT_ID_COMMENT_CONTROLLER_LINK + "/{parentCommentId}/replies/active", eventId, notValidId))
+            .perform(get(EVENT_COMMENTS_CONTROLLER_LINK + "/{parentCommentId}/replies/active", notValidId))
             .andExpect(status().isBadRequest());
     }
 
@@ -269,7 +266,6 @@ class EventCommentControllerTest {
     @SneakyThrows
     void findAllActiveRepliesWithNonexistentIdNotFoundTest() {
         Long parentCommentId = 1L;
-        Long eventId = 1L;
 
         int pageNumber = 0;
         int pageSize = 20;
@@ -287,8 +283,8 @@ class EventCommentControllerTest {
         Assertions.assertThatThrownBy(
             () -> mockMvc
                 .perform(get(
-                    EVENT_ID_COMMENT_CONTROLLER_LINK + "/{parentCommentId}/replies/active/?statuses=ORIGINAL,EDITED",
-                    eventId, parentCommentId)
+                    EVENT_COMMENTS_CONTROLLER_LINK + "/{parentCommentId}/replies/active/?statuses=ORIGINAL,EDITED",
+                    parentCommentId)
                     .principal(principal))
                 .andExpect(status().isNotFound()))
             .hasCause(new NotFoundException(errorMessage));


### PR DESCRIPTION
# GreenCity PR
Feature sending notification after liking a comment

## Summary Of Changes :fire:

## Issue Link :clipboard:
#7617 

## Changes
* Updated methods getAllActiveReplies() in EcoNewsCommentController.java, EventCommentController.java, by changing URL from GetMapping("{ecoNewsId}/comments/{parentCommentId}/replies/active") to GetMapping("/comments/{parentCommentId}/replies/active");
* Changed the order of annotation execution on method save() in EcoNewsCommentController.java, EventCommentController.java, and HabitCommentController.java for better performance;
* Updated SecurityConfig.java;
* Updated test cases with previous logic, according to a new one.


# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the dev branch.
- [X] You've successfully built and run the tests locally.
- [X] New or updated unit tests validate the change.
- [X] JIRA/ Github Issue number & title in PR title (ISSUE-#7617)
- [X] This template is filled (above this section).
- [X] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [X] NEED_REVIEW and READY_FOR_REVIEW labels are added.
- [X] All files reviewed before sending to reviewers