### PR TITLE
Added additional checking when deleting RatingPoints

### DIFF
--- a/dao/src/main/java/greencity/repository/RatingPointsRepo.java
+++ b/dao/src/main/java/greencity/repository/RatingPointsRepo.java
@@ -70,4 +70,11 @@ public interface RatingPointsRepo extends JpaRepository<RatingPoints, Long> {
     @Transactional
     @Query("UPDATE RatingPoints rp SET rp.name = :newName WHERE rp.name = :oldName")
     void updateRatingPointsName(String oldName, String newName);
+
+    @Transactional
+    @Query(nativeQuery = true,
+        value = "SELECT COUNT(a) > 0 FROM rating_points rp INNER JOIN achievements a  "
+            + "ON a.title = CASE WHEN rp.name LIKE 'UNDO_%' THEN SUBSTRING(rp.name, 6) ELSE rp.name END "
+            + "WHERE rp.id = :id")
+    boolean checkByIdForExistenceOfAchievement(@Param("id") Long id);
 }

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -200,4 +200,6 @@ public class ErrorMessage {
         "The rating points does not exist by this name: ";
     public static final String RATING_POINTS_NOT_FOUND_BY_ID =
         "The rating points does not exist by this id: ";
+    public static final String DELETING_RATING_POINTS_NOT_ALLOWED =
+        "Deleting this RatingPoints is not possible because an Achievement with such name still exists.";
 }


### PR DESCRIPTION
# GreenCity

## Summary Of Changes :fire:

## Issue Link :clipboard:
[#7541](https://github.com/ita-social-projects/GreenCity/issues/7541)

## Added
* Added an additional check when deleting RatingPoints for the existence of an Achievement with the same name to prevent an error when calculating the rating in the future.

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers