### PR TITLE
Fixed endpoints "/fact-of-the-day/random" and "/fact-of-the-day/random/by-tags" to return one random fact with all possible translations

### DIFF
--- a/core/src/main/java/greencity/controller/FactOfTheDayController.java
+++ b/core/src/main/java/greencity/controller/FactOfTheDayController.java
@@ -1,7 +1,5 @@
 package greencity.controller;
 
-import greencity.annotations.ApiLocale;
-import greencity.annotations.ValidLanguage;
 import greencity.constant.HttpStatuses;
 import greencity.dto.factoftheday.FactOfTheDayTranslationDTO;
 import greencity.dto.factoftheday.FactOfTheDayVO;
@@ -13,7 +11,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,7 +27,6 @@ public class FactOfTheDayController {
     /**
      * Method which return a random {@link FactOfTheDayVO}.
      *
-     * @param locale string code od language example: en
      * @return {@link FactOfTheDayTranslationDTO}
      */
     @Operation(summary = "Get random fact of the day.")
@@ -40,17 +36,14 @@ public class FactOfTheDayController {
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND,
             content = @Content(examples = @ExampleObject(HttpStatuses.NOT_FOUND)))
     })
-    @ApiLocale
     @GetMapping("/random")
-    public ResponseEntity<FactOfTheDayTranslationDTO> getRandomFactOfTheDay(
-        @Parameter(hidden = true) @ValidLanguage Locale locale) {
-        return ResponseEntity.ok().body(factOfTheDayService.getRandomGeneralFactOfTheDay(locale.getLanguage()));
+    public ResponseEntity<FactOfTheDayTranslationDTO> getRandomFactOfTheDay() {
+        return ResponseEntity.ok().body(factOfTheDayService.getRandomGeneralFactOfTheDay());
     }
 
     /**
-     * Returns a random fact of the day based on the user's habit tags and language.
+     * Returns a random fact of the day based on the user's habit tags.
      *
-     * @param locale the language code (e.g., "en")
      * @return {@link FactOfTheDayTranslationDTO} containing the translated fact.
      */
     @Operation(summary = "Get a random fact of the day based on habits tags.")
@@ -63,11 +56,8 @@ public class FactOfTheDayController {
             content = @Content(examples = @ExampleObject(HttpStatuses.NOT_FOUND)))
     })
     @GetMapping("/random/by-tags")
-    @ApiLocale
     public ResponseEntity<FactOfTheDayTranslationDTO> getRandomFactOfTheDayByTags(
-        @Parameter(hidden = true) @ValidLanguage Locale locale,
         @Parameter(hidden = true) Principal principal) {
-        return ResponseEntity.ok(factOfTheDayService.getRandomFactOfTheDayForUser(locale.getLanguage(),
-            principal.getName()));
+        return ResponseEntity.ok(factOfTheDayService.getRandomFactOfTheDayForUser(principal.getName()));
     }
 }

--- a/core/src/test/java/greencity/controller/FactOfTheDayControllerTest.java
+++ b/core/src/test/java/greencity/controller/FactOfTheDayControllerTest.java
@@ -41,7 +41,7 @@ class FactOfTheDayControllerTest {
     void getRandomFactOfTheDayTest() throws Exception {
         mockMvc.perform(get(factOfTheDayLink + "/random"))
             .andExpect(status().isOk());
-        verify(factOfTheDayService).getRandomGeneralFactOfTheDay("en");
+        verify(factOfTheDayService).getRandomGeneralFactOfTheDay();
     }
 
     @Test
@@ -55,6 +55,6 @@ class FactOfTheDayControllerTest {
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
 
-        verify(factOfTheDayService).getRandomFactOfTheDayForUser("en", "testUser@example.com");
+        verify(factOfTheDayService).getRandomFactOfTheDayForUser("testUser@example.com");
     }
 }

--- a/dao/src/main/java/greencity/constant/CacheConstants.java
+++ b/dao/src/main/java/greencity/constant/CacheConstants.java
@@ -9,7 +9,6 @@ import lombok.experimental.UtilityClass;
 public class CacheConstants {
     public static final String HABIT_ITEM_STATISTIC_CACHE = "habit_item_statistic_cache";
     public static final String FACT_OF_THE_DAY_CACHE_NAME = "fact_of_the_day_cache";
-    public static final String HABIT_FACT_OF_DAY_CACHE = "habit_fact_of_day_cache";
     public static final String NEWEST_ECO_NEWS_CACHE_NAME = "newest_eco_news_cache";
     public static final String SOCIAL_NETWORK_IMAGE_CACHE_NAME = "social_network_image_cache";
 }

--- a/service-api/src/main/java/greencity/dto/factoftheday/FactOfTheDayTranslationDTO.java
+++ b/service-api/src/main/java/greencity/dto/factoftheday/FactOfTheDayTranslationDTO.java
@@ -1,14 +1,17 @@
 package greencity.dto.factoftheday;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import java.util.List;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class FactOfTheDayTranslationDTO {
     private Long id;
 
-    private String content;
+    private List<FactOfTheDayTranslationEmbeddedPostDTO> factOfTheDayTranslations;
 }

--- a/service-api/src/main/java/greencity/service/FactOfTheDayService.java
+++ b/service-api/src/main/java/greencity/service/FactOfTheDayService.java
@@ -69,30 +69,27 @@ public interface FactOfTheDayService {
      * Returns a random {@link FactOfTheDayTranslationDTO} based on the provided
      * language code and habit tags.
      *
-     * @param languageCode the code of the desired language (e.g., "en")
-     * @param tagsId       a set of tag IDs associated with habits
-     * @return a random fact of the day translation
+     * @param tagsId a set of tag IDs associated with habits
+     * @return a random fact of the day
      */
-    FactOfTheDayTranslationDTO getRandomFactOfTheDayByLanguageAndTags(String languageCode, Set<Long> tagsId);
+    FactOfTheDayTranslationDTO getRandomFactOfTheDayByTags(Set<Long> tagsId);
 
     /**
      * Returns a random general {@link FactOfTheDayTranslationDTO} for the specified
      * language.
      *
-     * @param languageCode the code of the desired language (e.g., "en")
-     * @return a random general fact of the day translation
+     * @return a random general fact of the day
      */
-    FactOfTheDayTranslationDTO getRandomGeneralFactOfTheDay(String languageCode);
+    FactOfTheDayTranslationDTO getRandomGeneralFactOfTheDay();
 
     /**
      * Returns a random {@link FactOfTheDayTranslationDTO} for a user based on the
      * provided language code and the user's habit tags.
      *
-     * @param languageCode the code of the desired language (e.g., "en")
-     * @param email        the email of the user for whom the tags are retrieved
-     * @return a random fact of the day translation based on the user's habits
+     * @param email the email of the user for whom the tags are retrieved
+     * @return a random fact of the day based on the user's habits
      */
-    FactOfTheDayTranslationDTO getRandomFactOfTheDayForUser(String languageCode, String email);
+    FactOfTheDayTranslationDTO getRandomFactOfTheDayForUser(String email);
 
     /**
      * Retrieves all tags associated with Facts of the Day.

--- a/service/src/main/java/greencity/mapping/FactOfTheDayTranslationDTOMapper.java
+++ b/service/src/main/java/greencity/mapping/FactOfTheDayTranslationDTOMapper.java
@@ -1,0 +1,23 @@
+package greencity.mapping;
+
+import greencity.dto.factoftheday.FactOfTheDayTranslationDTO;
+import greencity.dto.factoftheday.FactOfTheDayTranslationEmbeddedPostDTO;
+import greencity.entity.FactOfTheDay;
+import org.modelmapper.AbstractConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FactOfTheDayTranslationDTOMapper extends AbstractConverter<FactOfTheDay, FactOfTheDayTranslationDTO> {
+    @Override
+    protected FactOfTheDayTranslationDTO convert(FactOfTheDay factOfTheDay) {
+        return FactOfTheDayTranslationDTO.builder()
+            .id(factOfTheDay.getId())
+            .factOfTheDayTranslations(factOfTheDay.getFactOfTheDayTranslations().stream()
+                .map(factOfTheDayTranslation -> FactOfTheDayTranslationEmbeddedPostDTO.builder()
+                    .content(factOfTheDayTranslation.getContent())
+                    .languageCode(factOfTheDayTranslation.getLanguage().getCode())
+                    .build())
+                .toList())
+            .build();
+    }
+}

--- a/service/src/main/java/greencity/service/FactOfTheDayServiceImpl.java
+++ b/service/src/main/java/greencity/service/FactOfTheDayServiceImpl.java
@@ -183,37 +183,29 @@ public class FactOfTheDayServiceImpl implements FactOfTheDayService {
      */
     @Override
     @Cacheable(value = CacheConstants.FACT_OF_THE_DAY_CACHE_NAME)
-    public FactOfTheDayTranslationDTO getRandomFactOfTheDayByLanguageAndTags(String languageCode, Set<Long> tagIds) {
+    public FactOfTheDayTranslationDTO getRandomFactOfTheDayByTags(Set<Long> tagIds) {
         FactOfTheDay factOfTheDay = factOfTheDayRepo.getRandomFactOfTheDay(tagIds)
             .orElseThrow(() -> new NotFoundException(ErrorMessage.FACT_OF_THE_DAY_NOT_FOUND));
-
-        FactOfTheDayTranslation factTranslation = factOfTheDay.getFactOfTheDayTranslations()
-            .stream()
-            .filter(translation -> translation.getLanguage().getCode().equals(languageCode))
-            .findAny()
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.FACT_OF_THE_DAY_NOT_FOUND));
-
-        return modelMapper.map(factTranslation, FactOfTheDayTranslationDTO.class);
+        return modelMapper.map(factOfTheDay, FactOfTheDayTranslationDTO.class);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public FactOfTheDayTranslationDTO getRandomGeneralFactOfTheDay(String languageCode) {
+    public FactOfTheDayTranslationDTO getRandomGeneralFactOfTheDay() {
         List<Tag> tags = tagsRepo.findTagsByType(FACT_OF_THE_DAY);
-        return getRandomFactOfTheDayByLanguageAndTags(languageCode,
-            tags.stream().map(Tag::getId).collect(Collectors.toSet()));
+        return getRandomFactOfTheDayByTags(tags.stream().map(Tag::getId).collect(Collectors.toSet()));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public FactOfTheDayTranslationDTO getRandomFactOfTheDayForUser(String languageCode, String userEmail) {
+    public FactOfTheDayTranslationDTO getRandomFactOfTheDayForUser(String userEmail) {
         Set<Long> userTagIds = tagsRepo.findTagsIdByUserHabitsInProgress(userEmail);
         try {
-            return getRandomFactOfTheDayByLanguageAndTags(languageCode, userTagIds);
+            return getRandomFactOfTheDayByTags(userTagIds);
         } catch (NotFoundException e) {
             return null;
         }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -1017,7 +1017,14 @@ public class ModelUtils {
 
     public static FactOfTheDay getFactOfTheDay() {
         return new FactOfTheDay(1L, "Fact of the day",
-            Collections.singletonList(ModelUtils.getFactOfTheDayTranslation()), ZonedDateTime.now(),
+            List.of(ModelUtils.getFactOfTheDayTranslation(), FactOfTheDayTranslation.builder()
+                .id(2L)
+                .content("Контент")
+                .language(new Language(2L, "ua", Collections.emptyList(), Collections.emptyList(),
+                    Collections.emptyList()))
+                .factOfTheDay(null)
+                .build()),
+            ZonedDateTime.now(),
             Collections.emptySet());
     }
 
@@ -1027,8 +1034,7 @@ public class ModelUtils {
 
     public static FactOfTheDayPostDTO getFactOfTheDayPostDto() {
         return new FactOfTheDayPostDTO(1L, "name",
-            Collections.singletonList(
-                new FactOfTheDayTranslationEmbeddedPostDTO("content", AppConstant.DEFAULT_LANGUAGE_CODE)),
+            Collections.singletonList(getFactOfTheDayTranslationEmbeddedPostDTO()),
             Collections.singletonList(25L));
     }
 
@@ -1156,7 +1162,14 @@ public class ModelUtils {
     }
 
     public static FactOfTheDayTranslationDTO getFactOfTheDayTranslationDTO() {
-        return new FactOfTheDayTranslationDTO(1L, "content");
+        return new FactOfTheDayTranslationDTO(1L, List.of(getFactOfTheDayTranslationEmbeddedPostDTO()));
+    }
+
+    public static FactOfTheDayTranslationEmbeddedPostDTO getFactOfTheDayTranslationEmbeddedPostDTO() {
+        return FactOfTheDayTranslationEmbeddedPostDTO.builder()
+            .content("content")
+            .languageCode(AppConstant.DEFAULT_LANGUAGE_CODE)
+            .build();
     }
 
     public static LocationAddressAndGeoDto getLocationAddressAndGeoDto() {

--- a/service/src/test/java/greencity/mapping/FactOfTheDayTranslationDTOMapperTest.java
+++ b/service/src/test/java/greencity/mapping/FactOfTheDayTranslationDTOMapperTest.java
@@ -1,0 +1,50 @@
+package greencity.mapping;
+
+import greencity.ModelUtils;
+import greencity.dto.factoftheday.FactOfTheDayTranslationDTO;
+import greencity.dto.factoftheday.FactOfTheDayTranslationEmbeddedPostDTO;
+import greencity.entity.FactOfTheDay;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FactOfTheDayTranslationDTOMapperTest {
+
+    private FactOfTheDayTranslationDTOMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new FactOfTheDayTranslationDTOMapper();
+    }
+
+    @Test
+    void convert_ShouldMapFactOfTheDayToDTO() {
+        FactOfTheDay factOfTheDay = ModelUtils.getFactOfTheDay();
+
+        FactOfTheDayTranslationDTO dto = mapper.convert(factOfTheDay);
+
+        assertThat(dto.getId()).isEqualTo(1L);
+        assertThat(dto.getFactOfTheDayTranslations()).hasSize(2);
+
+        FactOfTheDayTranslationEmbeddedPostDTO embeddedDTO2 = dto.getFactOfTheDayTranslations().get(0);
+        assertThat(embeddedDTO2.getContent()).isEqualTo("Content");
+        assertThat(embeddedDTO2.getLanguageCode()).isEqualTo("en");
+
+        FactOfTheDayTranslationEmbeddedPostDTO embeddedDTO1 = dto.getFactOfTheDayTranslations().get(1);
+        assertThat(embeddedDTO1.getContent()).isEqualTo("Контент");
+        assertThat(embeddedDTO1.getLanguageCode()).isEqualTo("ua");
+    }
+
+    @Test
+    void convert_ShouldReturnEmptyList_WhenNoTranslations() {
+        FactOfTheDay factOfTheDay = new FactOfTheDay(2L, "Fact of the day", Collections.emptyList(),
+            ZonedDateTime.now(), Collections.emptySet());
+
+        FactOfTheDayTranslationDTO dto = mapper.convert(factOfTheDay);
+
+        assertThat(dto.getId()).isEqualTo(2L);
+        assertThat(dto.getFactOfTheDayTranslations()).isEmpty();
+    }
+}

--- a/service/src/test/java/greencity/service/FactOfTheDayServiceImplTest.java
+++ b/service/src/test/java/greencity/service/FactOfTheDayServiceImplTest.java
@@ -9,7 +9,6 @@ import greencity.dto.factoftheday.FactOfTheDayTranslationVO;
 import greencity.dto.language.LanguageDTO;
 import greencity.dto.tag.TagDto;
 import greencity.entity.FactOfTheDay;
-import greencity.entity.FactOfTheDayTranslation;
 import greencity.entity.Language;
 import greencity.entity.Tag;
 import greencity.exception.exceptions.NotFoundException;

--- a/service/src/test/java/greencity/service/FactOfTheDayServiceImplTest.java
+++ b/service/src/test/java/greencity/service/FactOfTheDayServiceImplTest.java
@@ -133,7 +133,6 @@ class FactOfTheDayServiceImplTest {
         when(modelMapper.map(dbFact.getFactOfTheDayTranslations().get(0), FactOfTheDayTranslationVO.class)).thenReturn(
             ModelUtils.getFactOfTheDayTranslationVO());
         when(languageService.findByCode("en")).thenReturn(languageDTO);
-        when(modelMapper.map(languageDTO, Language.class)).thenReturn(ModelUtils.getLanguage());
         when(factOfTheDayTranslationService.saveAll(anyList())).thenReturn(null);
         when(tagsRepo.findTagsById(List.of(25L))).thenReturn(tagDtos);
 
@@ -235,94 +234,84 @@ class FactOfTheDayServiceImplTest {
     }
 
     @Test
-    void getRandomFactOfTheDayByLanguageAndTags_success() {
-        Language language = ModelUtils.getLanguage();
+    void getRandomFactOfTheDayByTags_success() {
         Set<Long> tagIds = Set.of(1L, 2L);
         FactOfTheDay factOfTheDay = ModelUtils.getFactOfTheDay();
-        FactOfTheDayTranslation factTranslation = ModelUtils.getFactOfTheDayTranslation();
         FactOfTheDayTranslationDTO expectedDto = ModelUtils.getFactOfTheDayTranslationDTO();
 
         when(factOfTheDayRepo.getRandomFactOfTheDay(tagIds)).thenReturn(Optional.of(factOfTheDay));
-        when(modelMapper.map(factTranslation, FactOfTheDayTranslationDTO.class)).thenReturn(expectedDto);
+        when(modelMapper.map(factOfTheDay, FactOfTheDayTranslationDTO.class)).thenReturn(expectedDto);
 
         FactOfTheDayTranslationDTO result =
-            factOfTheDayService.getRandomFactOfTheDayByLanguageAndTags(language.getCode(), tagIds);
+            factOfTheDayService.getRandomFactOfTheDayByTags(tagIds);
 
         assertEquals(expectedDto, result);
     }
 
     @Test
     void getRandomFactOfTheDayByLanguageAndTags_factNotFound() {
-        String languageCode = "en";
         Set<Long> tagIds = Set.of(1L, 2L);
 
         when(factOfTheDayRepo.getRandomFactOfTheDay(tagIds)).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class, () -> {
-            factOfTheDayService.getRandomFactOfTheDayByLanguageAndTags(languageCode, tagIds);
+            factOfTheDayService.getRandomFactOfTheDayByTags(tagIds);
         });
     }
 
     @Test
     void getRandomGeneralFactOfTheDay_success() {
-        Language language = ModelUtils.getLanguage();
         List<Tag> tags = List.of(ModelUtils.getTag());
         Set<Long> tagIds = Set.of(1L);
         FactOfTheDay factOfTheDay = ModelUtils.getFactOfTheDay();
-        FactOfTheDayTranslation factTranslation = ModelUtils.getFactOfTheDayTranslation();
         FactOfTheDayTranslationDTO expectedDto = ModelUtils.getFactOfTheDayTranslationDTO();
 
         when(factOfTheDayRepo.getRandomFactOfTheDay(tagIds)).thenReturn(Optional.of(factOfTheDay));
-        when(modelMapper.map(factTranslation, FactOfTheDayTranslationDTO.class)).thenReturn(expectedDto);
+        when(modelMapper.map(factOfTheDay, FactOfTheDayTranslationDTO.class)).thenReturn(expectedDto);
         when(tagsRepo.findTagsByType(FACT_OF_THE_DAY)).thenReturn(tags);
-        when(factOfTheDayService.getRandomFactOfTheDayByLanguageAndTags(language.getCode(), tagIds))
+        when(factOfTheDayService.getRandomFactOfTheDayByTags(tagIds))
             .thenReturn(expectedDto);
 
-        FactOfTheDayTranslationDTO result = factOfTheDayService.getRandomGeneralFactOfTheDay(language.getCode());
+        FactOfTheDayTranslationDTO result = factOfTheDayService.getRandomGeneralFactOfTheDay();
 
         assertEquals(expectedDto, result);
     }
 
     @Test
     void getRandomGeneralFactOfTheDay_noTagsFound() {
-        String languageCode = "en";
-
         when(tagsRepo.findTagsByType(FACT_OF_THE_DAY)).thenReturn(Collections.emptyList());
 
         assertThrows(NotFoundException.class, () -> {
-            factOfTheDayService.getRandomGeneralFactOfTheDay(languageCode);
+            factOfTheDayService.getRandomGeneralFactOfTheDay();
         });
     }
 
     @Test
     void getRandomFactOfTheDayForUser_success() {
-        Language language = ModelUtils.getLanguage();
         String userEmail = "user@example.com";
         Set<Long> tagIds = Set.of(1L);
         FactOfTheDay factOfTheDay = ModelUtils.getFactOfTheDay();
-        FactOfTheDayTranslation factTranslation = ModelUtils.getFactOfTheDayTranslation();
         FactOfTheDayTranslationDTO expectedDto = ModelUtils.getFactOfTheDayTranslationDTO();
 
         when(factOfTheDayRepo.getRandomFactOfTheDay(tagIds)).thenReturn(Optional.of(factOfTheDay));
-        when(modelMapper.map(factTranslation, FactOfTheDayTranslationDTO.class)).thenReturn(expectedDto);
+        when(modelMapper.map(factOfTheDay, FactOfTheDayTranslationDTO.class)).thenReturn(expectedDto);
         when(tagsRepo.findTagsIdByUserHabitsInProgress(userEmail)).thenReturn(tagIds);
-        when(factOfTheDayService.getRandomFactOfTheDayByLanguageAndTags(language.getCode(), tagIds))
+        when(factOfTheDayService.getRandomFactOfTheDayByTags(tagIds))
             .thenReturn(expectedDto);
 
         FactOfTheDayTranslationDTO result =
-            factOfTheDayService.getRandomFactOfTheDayForUser(language.getCode(), userEmail);
+            factOfTheDayService.getRandomFactOfTheDayForUser(userEmail);
 
         assertEquals(expectedDto, result);
     }
 
     @Test
     void getRandomFactOfTheDayForUser_noUserTags() {
-        String languageCode = "en";
         String userEmail = "user@example.com";
 
         when(tagsRepo.findTagsIdByUserHabitsInProgress(userEmail)).thenReturn(Collections.emptySet());
 
-        FactOfTheDayTranslationDTO result = factOfTheDayService.getRandomFactOfTheDayForUser(languageCode, userEmail);
+        FactOfTheDayTranslationDTO result = factOfTheDayService.getRandomFactOfTheDayForUser(userEmail);
 
         assertNull(result);
     }


### PR DESCRIPTION
# GreenCity

## Summary Of Changes :fire:

## Issue Link :clipboard:
[#7616](https://github.com/ita-social-projects/GreenCity/issues/7616)

## Added
* Added support for retrieving multiple translations per fact from the `FactOfTheDay` repository.
* Unit tests for the updated `FactOfTheDayTranslationDTOMapper`.
* Added a new DTO structure to accommodate multilingual content:
  ```json
  {
    "id": 22,
    "factOfTheDayTranslations": [
      {
        "content": "Ми використовуємо 10 мільярдів тонн води по всьому світу.",
        "languageCode": "ua"
      },
      {
        "content": "We use 10 billion tons of water worldwide.",
        "languageCode": "en"
      }
    ]
  }

## Changed
* Modified /fact-of-the-day/random and /fact-of-the-day/random/by-tags to return a single fact with translations.
* Updated FactOfTheDayTranslationDTOMapper to map facts with multiple translations.
* Refactored tests for the endpoints to validate the new response structure.

## Deleted
* Removed logic that fetched separate facts for each language on language switch.

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers