### PR TITLE
Handle Missing Notifications with NotFoundException in the Database

### DIFF
--- a/dao/src/main/java/greencity/repository/NotificationRepo.java
+++ b/dao/src/main/java/greencity/repository/NotificationRepo.java
@@ -118,4 +118,14 @@ public interface NotificationRepo extends CustomNotificationRepo, JpaRepository<
         Long targetUserId,
         NotificationType notificationType,
         Long targetId);
+
+    /**
+     * Checks if a notification with the specified ID exists for the specified user.
+     *
+     * @param notificationId the ID of the notification to check
+     * @param targetUserId   the ID of the user for whom the notification belongs
+     * @return true if the notification with the specified ID exists for the user,
+     *         false otherwise
+     */
+    boolean existsByIdAndTargetUserId(Long notificationId, Long targetUserId);
 }

--- a/service/src/main/java/greencity/service/UserNotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/UserNotificationServiceImpl.java
@@ -13,6 +13,13 @@ import greencity.enums.ProjectName;
 import greencity.exception.exceptions.BadRequestException;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.repository.NotificationRepo;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import java.security.Principal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -22,13 +29,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.ResourceBundle;
-import lombok.RequiredArgsConstructor;
-import org.modelmapper.ModelMapper;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Implementation of {@link UserNotificationService}.
@@ -247,6 +247,9 @@ public class UserNotificationServiceImpl implements UserNotificationService {
     @Override
     public void deleteNotification(Principal principal, Long notificationId) {
         Long userId = userService.findByEmail(principal.getName()).getId();
+        if (!notificationRepo.existsByIdAndTargetUserId(notificationId, userId)) {
+            throw new NotFoundException(ErrorMessage.NOTIFICATION_NOT_FOUND_BY_ID + notificationId);
+        }
         notificationRepo.deleteNotificationByIdAndTargetUserId(notificationId, userId);
     }
 

--- a/service/src/test/java/greencity/service/UserNotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/UserNotificationServiceImplTest.java
@@ -249,7 +249,8 @@ class UserNotificationServiceImplTest {
         when(userService.findByEmail("danylo@gmail.com")).thenReturn(testUserVo);
         when(notificationRepo.existsByIdAndTargetUserId(notificationId, testUserVo.getId())).thenReturn(false);
 
-        assertThrows(NotFoundException.class, () -> userNotificationService.deleteNotification(getPrincipal(), notificationId));
+        assertThrows(NotFoundException.class,
+            () -> userNotificationService.deleteNotification(getPrincipal(), notificationId));
     }
 
     @Test

--- a/service/src/test/java/greencity/service/UserNotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/UserNotificationServiceImplTest.java
@@ -16,6 +16,7 @@ import greencity.entity.Notification;
 import greencity.entity.User;
 import greencity.enums.NotificationType;
 import greencity.enums.ProjectName;
+import greencity.exception.exceptions.NotFoundException;
 import greencity.repository.NotificationRepo;
 import java.lang.reflect.Method;
 import java.time.LocalDateTime;
@@ -23,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -231,11 +233,23 @@ class UserNotificationServiceImplTest {
 
     @Test
     void deleteNotificationTest() {
+        Long notificationId = 1L;
         when(userService.findByEmail("danylo@gmail.com")).thenReturn(testUserVo);
+        when(notificationRepo.existsByIdAndTargetUserId(notificationId, testUserVo.getId())).thenReturn(true);
 
-        userNotificationService.deleteNotification(getPrincipal(), 1L);
+        userNotificationService.deleteNotification(getPrincipal(), notificationId);
 
         verify(userService).findByEmail("danylo@gmail.com");
+        verify(notificationRepo).existsByIdAndTargetUserId(notificationId, testUserVo.getId());
+    }
+
+    @Test
+    void deleteNonExistentNotificationAndGetNotFoundExceptionTest() {
+        Long notificationId = 1L;
+        when(userService.findByEmail("danylo@gmail.com")).thenReturn(testUserVo);
+        when(notificationRepo.existsByIdAndTargetUserId(notificationId, testUserVo.getId())).thenReturn(false);
+
+        assertThrows(NotFoundException.class, () -> userNotificationService.deleteNotification(getPrincipal(), notificationId));
     }
 
     @Test

--- a/service/src/test/java/greencity/service/UserNotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/UserNotificationServiceImplTest.java
@@ -19,6 +19,7 @@ import greencity.enums.ProjectName;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.repository.NotificationRepo;
 import java.lang.reflect.Method;
+import java.security.Principal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -249,8 +250,9 @@ class UserNotificationServiceImplTest {
         when(userService.findByEmail("danylo@gmail.com")).thenReturn(testUserVo);
         when(notificationRepo.existsByIdAndTargetUserId(notificationId, testUserVo.getId())).thenReturn(false);
 
+        Principal principal = getPrincipal();
         assertThrows(NotFoundException.class,
-            () -> userNotificationService.deleteNotification(getPrincipal(), notificationId));
+            () -> userNotificationService.deleteNotification(principal, notificationId));
     }
 
     @Test


### PR DESCRIPTION
# GreenCity PR
Handle Missing Notifications with NotFoundException in the Database

## Issue Link :clipboard:
#7630 

## Summary Of Changes :fire:

## Changes
* Added a new method existsByIdAndTargetUserId in NotificationRepo for checking if the notification exists by notificationId and userId;
* Updated method deleteNotification() in UserNotificationServiceImpl.java by throwing a NotFoundException;
* Updated test cases with previous logic, according to a new one.


# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the dev branch.
- [X] You've successfully built and run the tests locally.
- [X] New or updated unit tests validate the change.
- [X] JIRA/ Github Issue number & title in PR title (ISSUE-#7630)
- [X] This template is filled (above this section).
- [X] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [X] NEED_REVIEW and READY_FOR_REVIEW labels are added.
- [X] All files reviewed before sending to reviewers