### PR TITLE
remove unnecessary search by query

### DIFF
--- a/core/src/main/java/greencity/webcontroller/ManagementSocialNetworkImagesController.java
+++ b/core/src/main/java/greencity/webcontroller/ManagementSocialNetworkImagesController.java
@@ -44,18 +44,15 @@ public class ManagementSocialNetworkImagesController {
     /**
      * Method that returns management page with all {@link SocialNetworkImageVO}.
      *
-     * @param query    Query for searching related data
      * @param model    Model that will be configured and returned to user.
      * @param pageable {@link Pageable}.
      * @return View template path {@link String}.
      * @author Orest Mamchuk
      */
     @GetMapping
-    public String getAllSocialNetworkImages(@RequestParam(required = false, name = "query") String query, Model model,
+    public String getAllSocialNetworkImages(Model model,
         @Parameter(hidden = true) Pageable pageable) {
-        PageableDto<SocialNetworkImageResponseDTO> socialNetworkImages = query == null || query.isEmpty()
-            ? socialNetworkImageService.findAll(pageable)
-            : socialNetworkImageService.searchBy(pageable, query);
+        PageableDto<SocialNetworkImageResponseDTO> socialNetworkImages = socialNetworkImageService.findAll(pageable);
         model.addAttribute("pageable", socialNetworkImages);
         return "core/management_social_network_images";
     }

--- a/core/src/main/resources/templates/core/management_social_network_images.html
+++ b/core/src/main/resources/templates/core/management_social_network_images.html
@@ -37,25 +37,13 @@
                             <h2>[[#{greenCity.social.page.h}]]</h2>
                         </div>
                         <div class="col-sm-6">
-                                <span class="search-box-right">
-                                    <form class="form-inline searching" action="/management/socialnetworkimages"
-                                          method="get">
-                                        <!--<i class="material-icons"></i>-->
-                                        <img alt="search" id="btnSearchImage"
-                                             src="/img/search.png">
-                                        <input type="text" name="query" id="inputSearch" class="form-control"
-                                               placeholder="Search…">
-                                    </form>
-                                </span>
                             <a href="#addSocialNetworkImagesModal" id="addSocialNetworkImagesBtn"
                                class="btn btn-secondary"
                                data-toggle="modal">
-                                <!--<i class="material-icons">&#xE147;</i>-->
                                 <div>[[#{greenCity.social.page.add.social}]]</div>
                             </a>
                             <a href="#deleteAllSelectedModal" id="btnDelete" class="btn btn-remove disabled"
                                data-toggle="modal">
-                                <!--<i class="material-icons">&#xE15C;</i>-->
                                 <div>[[#{greenCity.pages.delete}]]</div>
                             </a>
                         </div>

--- a/core/src/test/java/greencity/webcontroller/ManagementSocialNetworkImagesControllerTest.java
+++ b/core/src/test/java/greencity/webcontroller/ManagementSocialNetworkImagesControllerTest.java
@@ -71,24 +71,6 @@ class ManagementSocialNetworkImagesControllerTest {
     }
 
     @Test
-    void getAllSocialNetworkImagesSearchByQueryTest() throws Exception {
-        Pageable pageable = PageRequest.of(0, 10);
-        List<SocialNetworkImageResponseDTO> socialNetworkImageResponseDTOS =
-            Collections.singletonList(new SocialNetworkImageResponseDTO());
-        PageableDto<SocialNetworkImageResponseDTO> socialNetworkImageResponsePageableDto =
-            new PageableDto<>(socialNetworkImageResponseDTOS, 2, 0, 3);
-        when(socialNetworkImageService.searchBy(pageable, "query")).thenReturn(socialNetworkImageResponsePageableDto);
-        this.mockMvc.perform(get(managementSocialNetworkImagesLink + "?query=query")
-            .param("page", "0")
-            .param("size", "10"))
-            .andExpect(view().name("core/management_social_network_images"))
-            .andExpect(model().attribute("pageable", socialNetworkImageResponsePageableDto))
-            .andExpect(status().isOk());
-
-        verify(socialNetworkImageService).searchBy(pageable, "query");
-    }
-
-    @Test
     void save() throws Exception {
         SocialNetworkImageRequestDTO socialNetworkImageRequestDTO = new SocialNetworkImageRequestDTO();
         Gson gson = new Gson();

--- a/service-api/src/main/java/greencity/service/SocialNetworkImageService.java
+++ b/service-api/src/main/java/greencity/service/SocialNetworkImageService.java
@@ -32,15 +32,6 @@ public interface SocialNetworkImageService {
     PageableDto<SocialNetworkImageResponseDTO> findAll(Pageable pageable);
 
     /**
-     * Method for getting User by search query.
-     *
-     * @param paging {@link Pageable}.
-     * @param query  query to search,
-     * @return PageableDto of {@link SocialNetworkImageResponseDTO} instances.
-     */
-    PageableDto<SocialNetworkImageResponseDTO> searchBy(Pageable paging, String query);
-
-    /**
      * Method for deleting the {@link SocialNetworkImageVO} instance by its id.
      *
      * @param id - {@link SocialNetworkImageVO} instance id which will be deleted.

--- a/service/src/main/java/greencity/service/SocialNetworkImageServiceImpl.java
+++ b/service/src/main/java/greencity/service/SocialNetworkImageServiceImpl.java
@@ -25,7 +25,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import javax.imageio.ImageIO;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -88,24 +87,6 @@ public class SocialNetworkImageServiceImpl implements SocialNetworkImageService 
             pages.getTotalElements(),
             pages.getPageable().getPageNumber(),
             pages.getTotalPages());
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @author Orest Mamchuk
-     */
-    @Override
-    public PageableDto<SocialNetworkImageResponseDTO> searchBy(Pageable paging, String query) {
-        Page<SocialNetworkImage> page = socialNetworkImageRepo.searchBy(paging, query);
-        List<SocialNetworkImageResponseDTO> socialNetworkImageResponseDTOS = page.stream()
-            .map(socialNetworkImage -> modelMapper.map(socialNetworkImage, SocialNetworkImageResponseDTO.class))
-            .collect(Collectors.toList());
-        return new PageableDto<>(
-            socialNetworkImageResponseDTOS,
-            page.getTotalElements(),
-            page.getPageable().getPageNumber(),
-            page.getTotalPages());
     }
 
     /**

--- a/service/src/test/java/greencity/service/SocialNetworkImageServiceImplTest.java
+++ b/service/src/test/java/greencity/service/SocialNetworkImageServiceImplTest.java
@@ -173,28 +173,4 @@ class SocialNetworkImageServiceImplTest {
         verify(modelMapper, times(mockImages.size()))
             .map(any(SocialNetworkImage.class), eq(SocialNetworkImageResponseDTO.class));
     }
-
-    @Test
-    void testSearchBy() {
-        Pageable pageable = mock(Pageable.class);
-        String query = "test";
-        List<SocialNetworkImage> mockImages = Collections.singletonList(new SocialNetworkImage());
-        List<SocialNetworkImageResponseDTO> expectedDTOs =
-            Collections.singletonList(new SocialNetworkImageResponseDTO());
-        Page<SocialNetworkImage> mockPage = new PageImpl<>(mockImages, pageable, 1);
-
-        when(socialNetworkImageRepo.searchBy(pageable, query)).thenReturn(mockPage);
-        when(modelMapper.map(any(SocialNetworkImage.class), eq(SocialNetworkImageResponseDTO.class)))
-            .thenReturn(expectedDTOs.get(0));
-
-        PageableDto<SocialNetworkImageResponseDTO> result = socialNetworkImageService.searchBy(pageable, query);
-
-        assertEquals(expectedDTOs.get(0), result.getPage().get(0));
-        assertEquals(mockPage.getTotalElements(), result.getTotalElements());
-        assertEquals(mockPage.getTotalPages(), result.getTotalPages());
-
-        verify(socialNetworkImageRepo).searchBy(pageable, query);
-        verify(modelMapper, times(mockImages.size()))
-            .map(any(SocialNetworkImage.class), eq(SocialNetworkImageResponseDTO.class));
-    }
 }


### PR DESCRIPTION
Since there are only 3 fields for social network images: id, host path, image path; there are no logical fields to be searched by query through saved images. So search field was deleted from html page as well as corresponding methods.