### PR TITLE
7678 favorite eco news

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -274,6 +274,7 @@ public class SecurityConfig {
                     FRIENDS + "/{userId}/all-user-friends",
                     FRIENDS + "/user-data-as-friend/{friendId}",
                     FRIENDS,
+                    ECO_NEWS + "/favorites",
                     NOTIFICATIONS,
                     HABIT_ASSIGN_ID + "/friends/habit-duration-info")
                 .hasAnyRole(USER, ADMIN, MODERATOR, UBS_EMPLOYEE)
@@ -316,6 +317,7 @@ public class SecurityConfig {
                     "/habit/custom",
                     "/custom/shopping-list-items/{userId}/{habitId}/custom-shopping-list-items",
                     FRIENDS + "/{friendId}",
+                    ECO_NEWS + "/{ecoNewsId}/favorites",
                     "/habit/assign/{habitId}/invite",
                     "place/v2/save")
                 .hasAnyRole(USER, ADMIN, MODERATOR, UBS_EMPLOYEE)
@@ -370,6 +372,7 @@ public class SecurityConfig {
                     "/user/{userId}/userFriend/{friendId}",
                     "/habit/assign/delete/{habitAssignId}",
                     "/habit/delete/{customHabitId}",
+                    ECO_NEWS + "/{ecoNewsId}/favorites",
                     FRIENDS,
                     FRIENDS + "/{friendId}",
                     FRIENDS + "/{friendId}/cancelRequest",

--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -274,7 +274,6 @@ public class SecurityConfig {
                     FRIENDS + "/{userId}/all-user-friends",
                     FRIENDS + "/user-data-as-friend/{friendId}",
                     FRIENDS,
-                    ECO_NEWS + "/favorites",
                     NOTIFICATIONS,
                     HABIT_ASSIGN_ID + "/friends/habit-duration-info")
                 .hasAnyRole(USER, ADMIN, MODERATOR, UBS_EMPLOYEE)

--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -199,12 +199,11 @@ public class EcoNewsController {
             required = false) List<String> tags,
         @RequestParam(required = false) String title,
         @RequestParam(required = false, name = "author-id") Long authorId,
-        @Parameter(description = "Search for favorite news")
-        @RequestParam(required = false, name = "favorite", defaultValue = "false") boolean favorite,
+        @Parameter(description = "Search for favorite news") @RequestParam(required = false, name = "favorite",
+            defaultValue = "false") boolean favorite,
         @Parameter(hidden = true) Principal principal) {
         return ResponseEntity.status(HttpStatus.OK).body(
-                ecoNewsService.find(page, tags, title, authorId, favorite, principal.getName())
-        );
+            ecoNewsService.find(page, tags, title, authorId, favorite, principal.getName()));
     }
 
     /**

--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -128,23 +128,6 @@ public class EcoNewsController {
     }
 
     /**
-     * Method for getting a list of user's favorite eco news.
-     */
-    @Operation(summary = "Get a list of user's favorite eco news")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED,
-            content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED))),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND,
-            content = @Content(examples = @ExampleObject(HttpStatuses.NOT_FOUND)))
-    })
-    @GetMapping("/favorites")
-    public ResponseEntity<List<EcoNewsDto>> getFavorites(@Parameter(hidden = true) Principal principal) {
-        List<EcoNewsDto> favorites = ecoNewsService.getFavorites(principal.getName());
-        return ResponseEntity.ok(favorites);
-    }
-
-    /**
      * Method for updating {@link EcoNewsVO}.
      *
      * @param updateEcoNewsDto - dto for {@link EcoNewsVO} entity.
@@ -215,8 +198,13 @@ public class EcoNewsController {
         @Parameter(description = "Tags to filter (if do not input tags get all)") @RequestParam(
             required = false) List<String> tags,
         @RequestParam(required = false) String title,
-        @RequestParam(required = false, name = "author-id") Long authorId) {
-        return ResponseEntity.status(HttpStatus.OK).body(ecoNewsService.find(page, tags, title, authorId));
+        @RequestParam(required = false, name = "author-id") Long authorId,
+        @Parameter(description = "Search for favorite news")
+        @RequestParam(required = false, name = "favorite", defaultValue = "false") boolean favorite,
+        @Parameter(hidden = true) Principal principal) {
+        return ResponseEntity.status(HttpStatus.OK).body(
+                ecoNewsService.find(page, tags, title, authorId, favorite, principal.getName())
+        );
     }
 
     /**

--- a/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
+++ b/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
@@ -124,25 +124,29 @@ class EcoNewsControllerTest {
         int pageNumber = 1;
         int pageSize = 20;
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
-        String userEmail = "user@example.com";
+        Principal principal = () -> "user@example.com";
 
         mockMvc.perform(get(ecoNewsLink + "?favorite=true&page=1")
-            .header("email", userEmail))
-            .andExpect(status().isOk());
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
 
-        verify(ecoNewsService).find(pageable, null, null, null, true, userEmail);
+        verify(ecoNewsService).find(pageable, null, null, null, true, principal.getName());
     }
 
     @Test
     void findAllTest() throws Exception {
-        int pageNumber = 1;
+        int pageNumber = 0;
         int pageSize = 20;
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        Principal principal = () -> "defaultUser";
 
-        mockMvc.perform(get(ecoNewsLink + "?page=1"))
-            .andExpect(status().isOk());
+        mockMvc.perform(get(ecoNewsLink + "?page=0")
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
 
-        verify(ecoNewsService).find(pageable, null, null, null, false, null);
+        verify(ecoNewsService).find(pageable, null, null, null, false, "defaultUser");
     }
 
     @Test
@@ -150,11 +154,14 @@ class EcoNewsControllerTest {
         int pageNumber = 1;
         int pageSize = 20;
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        Principal principal = () -> "defaultUser";
 
-        mockMvc.perform(get(ecoNewsLink + "?author-id=1&page=1"))
-            .andExpect(status().isOk());
+        mockMvc.perform(get(ecoNewsLink + "?author-id=1&page=1")
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
 
-        verify(ecoNewsService).find(pageable, null, null, 1L, false, null);
+        verify(ecoNewsService).find(pageable, null, null, 1L, false, "defaultUser");
     }
 
     @Test

--- a/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
+++ b/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
@@ -10,6 +10,8 @@ import greencity.converters.UserArgumentResolver;
 import greencity.dto.econews.AddEcoNewsDtoRequest;
 import greencity.dto.econews.EcoNewsDto;
 import greencity.dto.user.UserVO;
+import greencity.entity.EcoNews;
+import greencity.entity.User;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.exception.handler.CustomExceptionHandler;
 import greencity.service.EcoNewsService;
@@ -17,8 +19,13 @@ import greencity.service.TagsService;
 import greencity.service.UserService;
 
 import java.security.Principal;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +33,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.*;
 
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -34,6 +42,8 @@ import org.mockito.quality.Strictness;
 import org.modelmapper.ModelMapper;
 import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
@@ -124,6 +134,36 @@ class EcoNewsControllerTest {
     }
 
     @Test
+    void findFavoritesTest() {
+        // Arrange
+        int pageNumber = 0;
+        int pageSize = 10;
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        String email = "user@example.com";
+
+        // Mocking the user
+        User user = new User();
+        user.setId(1L);
+        when(userRepo.findByEmail(email)).thenReturn(Optional.of(user));
+
+        // Mocking the ecoNews page
+        EcoNews ecoNews = new EcoNews();
+        Page<EcoNews> ecoNewsPage = new PageImpl<>(Collections.singletonList(ecoNews), pageable, 1);
+
+        when(ecoNewsRepo.findAll(any(), any(Pageable.class))).thenReturn(ecoNewsPage);
+        when(modelMapper.map(any(), eq(EcoNewsDto.class))).thenReturn(new EcoNewsDto());
+
+        // Act
+        PageableAdvancedDto<EcoNewsDto> result = ecoNewsService.find(pageable, null, null, null, true, email);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        verify(ecoNewsRepo, times(1)).findAll(any(), any(Pageable.class));
+        verify(modelMapper, times(1)).map(any(), eq(EcoNewsDto.class));
+    }
+
+    @Test
     void findAllTest() throws Exception {
         int pageNumber = 1;
         int pageSize = 20;
@@ -132,7 +172,7 @@ class EcoNewsControllerTest {
         mockMvc.perform(get(ecoNewsLink + "?page=1"))
             .andExpect(status().isOk());
 
-        verify(ecoNewsService).find(pageable, null, null, null);
+        verify(ecoNewsService).find(pageable, null, null, null, false, null);
     }
 
     @Test
@@ -144,7 +184,27 @@ class EcoNewsControllerTest {
         mockMvc.perform(get(ecoNewsLink + "?author-id=1&page=1"))
             .andExpect(status().isOk());
 
-        verify(ecoNewsService).find(pageable, null, null, 1L);
+        verify(ecoNewsService).find(pageable, null, null, 1L, false, null);
+    }
+
+    @Test
+    void getPredicateTest() {
+        // Arrange
+        CriteriaBuilder cb = mock(CriteriaBuilder.class);
+        Root<EcoNews> root = mock(Root.class);
+
+        // Mocking the user
+        User user = new User();
+        user.setId(1L);
+
+        when(userRepo.findByEmail(anyString())).thenReturn(Optional.of(user));
+
+        // Calling the actual method
+        Predicate predicate = ecoNewsService.getPredicate(root, cb, null, null, null, true, "user@example.com");
+
+        // Verifying the result
+        assertNotNull(predicate);
+        verify(root).join("followers");
     }
 
     @Test

--- a/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
+++ b/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
@@ -5,14 +5,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import static greencity.ModelUtils.getPrincipal;
 import static greencity.ModelUtils.getUserVO;
 
-
 import greencity.converters.UserArgumentResolver;
 import greencity.dto.econews.AddEcoNewsDtoRequest;
 import greencity.dto.user.UserVO;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.exception.handler.CustomExceptionHandler;
-import greencity.repository.EcoNewsRepo;
-import greencity.repository.UserRepo;
 import greencity.service.EcoNewsService;
 import greencity.service.TagsService;
 import greencity.service.UserService;
@@ -130,8 +127,8 @@ class EcoNewsControllerTest {
         String userEmail = "user@example.com";
 
         mockMvc.perform(get(ecoNewsLink + "?favorite=true&page=1")
-                        .header("email", userEmail))
-                .andExpect(status().isOk());
+            .header("email", userEmail))
+            .andExpect(status().isOk());
 
         verify(ecoNewsService).find(pageable, null, null, null, true, userEmail);
     }

--- a/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
+++ b/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
@@ -127,9 +127,9 @@ class EcoNewsControllerTest {
         Principal principal = () -> "user@example.com";
 
         mockMvc.perform(get(ecoNewsLink + "?favorite=true&page=1")
-                        .principal(principal)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
+            .principal(principal)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
 
         verify(ecoNewsService).find(pageable, null, null, null, true, principal.getName());
     }
@@ -142,9 +142,9 @@ class EcoNewsControllerTest {
         Principal principal = () -> "defaultUser";
 
         mockMvc.perform(get(ecoNewsLink + "?page=0")
-                        .principal(principal)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
+            .principal(principal)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
 
         verify(ecoNewsService).find(pageable, null, null, null, false, "defaultUser");
     }
@@ -157,9 +157,9 @@ class EcoNewsControllerTest {
         Principal principal = () -> "defaultUser";
 
         mockMvc.perform(get(ecoNewsLink + "?author-id=1&page=1")
-                        .principal(principal)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
+            .principal(principal)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
 
         verify(ecoNewsService).find(pageable, null, null, 1L, false, "defaultUser");
     }

--- a/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
+++ b/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
@@ -58,11 +58,7 @@ class EcoNewsControllerTest {
     @Mock
     private TagsService tagsService;
     @Mock
-    private EcoNewsRepo ecoNewsRepo;
-    @Mock
     private UserService userService;
-    @Mock
-    private  UserRepo userRepo;
     @Mock
     private ModelMapper modelMapper;
     @Mock

--- a/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
+++ b/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
@@ -144,7 +144,7 @@ class EcoNewsControllerTest {
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
 
-        verify(ecoNewsService).find(pageable, null, null, null, false, "test@gmail.com");
+        verify(ecoNewsService).find(pageable, null, null, null, false, principal.getName());
     }
 
     @Test
@@ -158,7 +158,7 @@ class EcoNewsControllerTest {
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
 
-        verify(ecoNewsService).find(pageable, null, null, 1L, false, "test@gmail.com");
+        verify(ecoNewsService).find(pageable, null, null, 1L, false, principal.getName());
     }
 
     @Test

--- a/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
+++ b/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
@@ -124,7 +124,6 @@ class EcoNewsControllerTest {
         int pageNumber = 1;
         int pageSize = 20;
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
-        Principal principal = () -> "user@example.com";
 
         mockMvc.perform(get(ecoNewsLink + "?favorite=true&page=1")
             .principal(principal)
@@ -139,14 +138,13 @@ class EcoNewsControllerTest {
         int pageNumber = 0;
         int pageSize = 20;
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
-        Principal principal = () -> "defaultUser";
 
         mockMvc.perform(get(ecoNewsLink + "?page=0")
             .principal(principal)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
 
-        verify(ecoNewsService).find(pageable, null, null, null, false, "defaultUser");
+        verify(ecoNewsService).find(pageable, null, null, null, false, "test@gmail.com");
     }
 
     @Test
@@ -154,14 +152,13 @@ class EcoNewsControllerTest {
         int pageNumber = 1;
         int pageSize = 20;
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
-        Principal principal = () -> "defaultUser";
 
         mockMvc.perform(get(ecoNewsLink + "?author-id=1&page=1")
             .principal(principal)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
 
-        verify(ecoNewsService).find(pageable, null, null, 1L, false, "defaultUser");
+        verify(ecoNewsService).find(pageable, null, null, 1L, false, "test@gmail.com");
     }
 
     @Test

--- a/service-api/src/main/java/greencity/service/EcoNewsService.java
+++ b/service-api/src/main/java/greencity/service/EcoNewsService.java
@@ -54,7 +54,14 @@ public interface EcoNewsService {
      * @param title title to search.
      * @return PageableDto with {@link EcoNewsDto} instance.
      */
-    PageableAdvancedDto<EcoNewsGenericDto> find(Pageable page, List<String> tags, String title, Long authorId);
+    PageableAdvancedDto<EcoNewsGenericDto> find(
+            Pageable page,
+            List<String> tags,
+            String title,
+            Long authorId,
+            boolean favorite,
+            String email
+    );
 
     /**
      * Method for getting the {@link EcoNewsVO} instance by its id.
@@ -154,14 +161,6 @@ public interface EcoNewsService {
      * @param email     - user email.
      */
     void removeFromFavorites(Long ecoNewsId, String email);
-
-    /**
-     * Method for getting a list of user's favorite eco news.
-     *
-     * @param email - user email.
-     * @return list of {@link EcoNewsDto} instances.
-     */
-    List<EcoNewsDto> getFavorites(String email);
 
     /**
      * Find {@link EcoNewsVO} for management.

--- a/service-api/src/main/java/greencity/service/EcoNewsService.java
+++ b/service-api/src/main/java/greencity/service/EcoNewsService.java
@@ -55,13 +55,12 @@ public interface EcoNewsService {
      * @return PageableDto with {@link EcoNewsDto} instance.
      */
     PageableAdvancedDto<EcoNewsGenericDto> find(
-            Pageable page,
-            List<String> tags,
-            String title,
-            Long authorId,
-            boolean favorite,
-            String email
-    );
+        Pageable page,
+        List<String> tags,
+        String title,
+        Long authorId,
+        boolean favorite,
+        String email);
 
     /**
      * Method for getting the {@link EcoNewsVO} instance by its id.

--- a/service/src/main/java/greencity/service/EcoNewsServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsServiceImpl.java
@@ -150,19 +150,19 @@ public class EcoNewsServiceImpl implements EcoNewsService {
      */
     @Override
     public PageableAdvancedDto<EcoNewsGenericDto> find(
-            Pageable page,
-            List<String> tags,
-            String title,
-            Long authorId,
-            boolean favorite,
-            String email
-    ) {
+        Pageable page,
+        List<String> tags,
+        String title,
+        Long authorId,
+        boolean favorite,
+        String email) {
         return CollectionUtils.isEmpty(tags) && StringUtils.isEmpty(title) && authorId == null && !favorite
             ? buildPageableAdvancedGenericDto(ecoNewsRepo.findAll(
                 PageRequest.of(page.getPageNumber(), page.getPageSize(),
                     Sort.by(Sort.Direction.DESC, "creationDate"))))
             : buildPageableAdvancedGenericDto(ecoNewsRepo.findAll(
-                (root, query, criteriaBuilder) -> getPredicate(root, criteriaBuilder, tags, title, authorId, favorite, email),
+                (root, query, criteriaBuilder) -> getPredicate(root, criteriaBuilder, tags, title, authorId, favorite,
+                    email),
                 PageRequest.of(page.getPageNumber(), page.getPageSize(),
                     Sort.by(Sort.Direction.DESC, "creationDate"))));
     }
@@ -715,14 +715,13 @@ public class EcoNewsServiceImpl implements EcoNewsService {
     }
 
     Predicate getPredicate(
-            Root<EcoNews> root,
-            CriteriaBuilder criteriaBuilder,
-            List<String> tags,
-            String title,
-            Long authorId,
-            boolean favorite,
-            String email
-    ) {
+        Root<EcoNews> root,
+        CriteriaBuilder criteriaBuilder,
+        List<String> tags,
+        String title,
+        Long authorId,
+        boolean favorite,
+        String email) {
         List<Predicate> predicates = new ArrayList<>();
         if (CollectionUtils.isNotEmpty(tags)) {
             predicates.add(predicateForTags(criteriaBuilder, root, tags));
@@ -758,13 +757,13 @@ public class EcoNewsServiceImpl implements EcoNewsService {
                 criteriaBuilder.lower(ecoNewsTag.get(ECO_NEWS_TAG_TRANSLATION).get(ECO_NEWS_TAG_TRANSLATION_NAME)),
                 "%" + partOfSearchingText.toLowerCase() + "%"))));
         return predicateList.size() == 1
-                ? predicateList.getFirst()
-                : criteriaBuilder.or(predicateList.toArray(new Predicate[0]));
+            ? predicateList.getFirst()
+            : criteriaBuilder.or(predicateList.toArray(new Predicate[0]));
     }
 
     private User getUserByEmail(String email) {
         return userRepo.findByEmail(email)
-                .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_EMAIL + email));
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_EMAIL + email));
     }
 
     /**

--- a/service/src/main/java/greencity/service/EcoNewsServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsServiceImpl.java
@@ -162,7 +162,7 @@ public class EcoNewsServiceImpl implements EcoNewsService {
                 PageRequest.of(page.getPageNumber(), page.getPageSize(),
                     Sort.by(Sort.Direction.DESC, "creationDate"))))
             : buildPageableAdvancedGenericDto(ecoNewsRepo.findAll(
-                (root, query, criteriaBuilder) -> getPredicate(root, criteriaBuilder, tags, title, authorId, email),
+                (root, query, criteriaBuilder) -> getPredicate(root, criteriaBuilder, tags, title, authorId, favorite, email),
                 PageRequest.of(page.getPageNumber(), page.getPageSize(),
                     Sort.by(Sort.Direction.DESC, "creationDate"))));
     }

--- a/service/src/test/java/greencity/service/EcoNewsServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EcoNewsServiceImplTest.java
@@ -41,7 +41,11 @@ import greencity.repository.EcoNewsRepo;
 import greencity.repository.EcoNewsSearchRepo;
 import greencity.repository.RatingPointsRepo;
 import greencity.repository.UserRepo;
-import jakarta.persistence.criteria.*;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.MalformedURLException;
 import java.time.LocalDateTime;
@@ -73,9 +77,22 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.multipart.MultipartFile;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(SpringExtension.class)
 class EcoNewsServiceImplTest {

--- a/service/src/test/java/greencity/service/EcoNewsServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EcoNewsServiceImplTest.java
@@ -656,7 +656,7 @@ class EcoNewsServiceImplTest {
         when(criteriaBuilder.and(any())).thenReturn(mock(Predicate.class));
         when(criteriaBuilder.equal(any(), any())).thenReturn(mock(Predicate.class));
 
-        ecoNewsService.getPredicate(root, criteriaBuilder, tags, "1", 1L);
+        ecoNewsService.getPredicate(root, criteriaBuilder, tags, "1", 1L, false, "user@example.com");
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
 
@@ -666,7 +666,7 @@ class EcoNewsServiceImplTest {
 
         when(ecoNewsRepo.findAll(any(Specification.class), any(Pageable.class))).thenReturn(page);
 
-        ecoNewsService.find(pageable, tags, "1", 1L);
+        ecoNewsService.find(pageable, tags, "1", 1L, false, "user@example.com");
         verify(ecoNewsRepo, times(1)).findAll(any(Specification.class), any(Pageable.class));
     }
 
@@ -676,7 +676,7 @@ class EcoNewsServiceImplTest {
         List<EcoNews> ecoNewsList = Collections.singletonList(ModelUtils.getEcoNews());
         Page<EcoNews> page = new PageImpl<>(ecoNewsList, pageable, ecoNewsList.size());
         when(ecoNewsRepo.findAll(any(Pageable.class))).thenReturn(page);
-        ecoNewsService.find(pageable, null, null, null);
+        ecoNewsService.find(pageable, null, null, null, false, "user@example.com");
         verify(ecoNewsRepo, times(1)).findAll(any(Pageable.class));
     }
 
@@ -937,54 +937,5 @@ class EcoNewsServiceImplTest {
         assertEquals(ErrorMessage.ECO_NEW_NOT_IN_FAVORITES, exception.getMessage());
         verify(ecoNewsRepo).findById(1L);
         verify(userRepo).findByEmail(TestConst.EMAIL);
-    }
-
-    @Test
-    void getFavorites_ShouldReturnListOfFavoriteEcoNewsDto() {
-        User user = ModelUtils.getUser();
-        EcoNews ecoNews1 = ModelUtils.getEcoNews();
-        EcoNews ecoNews2 = ModelUtils.getEcoNews();
-
-        ecoNews1.setId(1L);
-        ecoNews2.setId(2L);
-
-        user.setFavoriteEcoNews(new HashSet<>(List.of(ecoNews1, ecoNews2)));
-
-        when(userRepo.findByEmail(TestConst.EMAIL)).thenReturn(Optional.of(user));
-        when(modelMapper.map(ecoNews1, EcoNewsDto.class)).thenReturn(ModelUtils.getEcoNewsDto());
-        when(modelMapper.map(ecoNews2, EcoNewsDto.class)).thenReturn(ModelUtils.getEcoNewsDto());
-
-        List<EcoNewsDto> favorites = ecoNewsService.getFavorites(TestConst.EMAIL);
-
-        assertEquals(2, favorites.size());
-        verify(userRepo).findByEmail(TestConst.EMAIL);
-        verify(modelMapper).map(ecoNews1, EcoNewsDto.class);
-        verify(modelMapper).map(ecoNews2, EcoNewsDto.class);
-    }
-
-    @Test
-    void getFavorites_ShouldThrowExceptionIfUserNotFound() {
-        when(userRepo.findByEmail(TestConst.EMAIL)).thenReturn(Optional.empty());
-
-        NotFoundException exception = assertThrows(NotFoundException.class, () ->
-                ecoNewsService.getFavorites(TestConst.EMAIL));
-
-        assertEquals(ErrorMessage.USER_NOT_FOUND_BY_EMAIL + TestConst.EMAIL, exception.getMessage());
-        verify(userRepo).findByEmail(TestConst.EMAIL);
-        verifyNoInteractions(modelMapper);
-    }
-
-    @Test
-    void getFavorites_ShouldReturnEmptyListIfNoFavorites() {
-        User user = ModelUtils.getUser();
-        user.setFavoriteEcoNews(new HashSet<>());
-
-        when(userRepo.findByEmail(TestConst.EMAIL)).thenReturn(Optional.of(user));
-
-        List<EcoNewsDto> favorites = ecoNewsService.getFavorites(TestConst.EMAIL);
-
-        assertTrue(favorites.isEmpty());
-        verify(userRepo).findByEmail(TestConst.EMAIL);
-        verifyNoInteractions(modelMapper);
     }
 }


### PR DESCRIPTION
**_Favorites Filter Enabled:_**

When the Favorites filter is enabled, the user should receive only their favorite EcoNews entries.
If the user performs a search query (e.g., by title), the results will include only those favorite news entries whose titles match the search query.

`Important`: Even if non-favorite EcoNews entries have the same title as favorites, only favorites should be shown in the results.

**_Favorites Filter Disabled (General Search):_**

If the Favorites filter is not enabled, the search query will be performed across all available EcoNews entries, returning both favorite and non-favorite news based on the search criteria (e.g., matching title).