### PR TITLE
Prevent Organizer from Receiving Notifications on Their Own Events (#7664)

### DIFF
--- a/service/src/main/java/greencity/service/CommentServiceImpl.java
+++ b/service/src/main/java/greencity/service/CommentServiceImpl.java
@@ -89,7 +89,9 @@ public class CommentServiceImpl implements CommentService {
     @Transactional
     public AddCommentDtoResponse save(ArticleType articleType, Long articleId,
         AddCommentDtoRequest addCommentDtoRequest, MultipartFile[] images, UserVO userVO, Locale locale) {
-        if (getArticleAuthor(articleType, articleId) == null) {
+
+        final User articleAuthor = getArticleAuthor(articleType, articleId);
+        if (articleAuthor == null) {
             throw new NotFoundException("Article author not found");
         }
 
@@ -136,7 +138,9 @@ public class CommentServiceImpl implements CommentService {
             commentRepo.save(comment), AddCommentDtoResponse.class);
         addCommentDtoResponse.setAuthor(modelMapper.map(userVO, CommentAuthorDto.class));
 
-        createCommentNotification(articleType, articleId, comment, userVO, locale);
+        if (!articleAuthor.getId().equals(userVO.getId())) {
+            createCommentNotification(articleType, articleId, comment, userVO, locale);
+        }
         sendNotificationToTaggedUser(modelMapper.map(comment, CommentVO.class), articleType, locale);
 
         return addCommentDtoResponse;

--- a/service/src/test/java/greencity/service/CommentServiceImplTest.java
+++ b/service/src/test/java/greencity/service/CommentServiceImplTest.java
@@ -158,10 +158,10 @@ class CommentServiceImplTest {
         commentService.save(ArticleType.HABIT, 1L, addCommentDtoRequest, images, userVO, Locale.of("en"));
         assertEquals(CommentStatus.ORIGINAL, comment.getStatus());
 
-        verify(habitRepo, times(5)).findById(anyLong());
+        verify(habitRepo, times(3)).findById(anyLong());
         verify(commentRepo).save(any(Comment.class));
         verify(commentRepo).findById(anyLong());
-        verify(userRepo, times(3)).findById(anyLong());
+        verify(userRepo, times(2)).findById(anyLong());
         verify(modelMapper).map(userVO, CommentAuthorDto.class);
         verify(modelMapper).map(userVO, User.class);
         verify(modelMapper).map(addCommentDtoRequest, Comment.class);
@@ -203,10 +203,10 @@ class CommentServiceImplTest {
         commentService.save(ArticleType.HABIT, 1L, addCommentDtoRequest, images, userVO, Locale.of("en"));
         assertEquals(CommentStatus.ORIGINAL, comment.getStatus());
 
-        verify(habitRepo, times(5)).findById(anyLong());
+        verify(habitRepo, times(3)).findById(anyLong());
         verify(commentRepo).save(any(Comment.class));
         verify(commentRepo).findById(anyLong());
-        verify(userRepo, times(3)).findById(anyLong());
+        verify(userRepo, times(2)).findById(anyLong());
         verify(modelMapper).map(userVO, CommentAuthorDto.class);
         verify(modelMapper).map(userVO, User.class);
         verify(modelMapper).map(addCommentDtoRequest, Comment.class);
@@ -245,10 +245,10 @@ class CommentServiceImplTest {
         commentService.save(ArticleType.ECO_NEWS, 1L, addCommentDtoRequest, images, userVO, Locale.of("en"));
         assertEquals(CommentStatus.ORIGINAL, comment.getStatus());
 
-        verify(econewsRepo, times(5)).findById(anyLong());
+        verify(econewsRepo, times(3)).findById(anyLong());
         verify(commentRepo).save(any(Comment.class));
         verify(commentRepo).findById(anyLong());
-        verify(userRepo, times(3)).findById(anyLong());
+        verify(userRepo, times(2)).findById(anyLong());
         verify(modelMapper).map(userVO, CommentAuthorDto.class);
         verify(modelMapper).map(userVO, User.class);
         verify(modelMapper).map(addCommentDtoRequest, Comment.class);
@@ -285,10 +285,10 @@ class CommentServiceImplTest {
         commentService.save(ArticleType.EVENT, 1L, addCommentDtoRequest, images, userVO, Locale.of("en"));
         assertEquals(CommentStatus.ORIGINAL, comment.getStatus());
 
-        verify(eventRepo, times(5)).findById(anyLong());
+        verify(eventRepo, times(3)).findById(anyLong());
         verify(commentRepo).save(any(Comment.class));
         verify(commentRepo).findById(anyLong());
-        verify(userRepo, times(3)).findById(anyLong());
+        verify(userRepo, times(2)).findById(anyLong());
         verify(modelMapper).map(userVO, CommentAuthorDto.class);
         verify(modelMapper).map(userVO, User.class);
         verify(modelMapper).map(addCommentDtoRequest, Comment.class);


### PR DESCRIPTION
# GreenCity PR
Organizer does not receive notifications about own comments
## Summary Of Changes 
Added a check to verify if the person who left the comment is not the owner of the Event. Modified some tests to align with the code.
## Issue link
#7664