### PR TITLE
Remove redundant default value and update `User` class

### DIFF
--- a/dao/src/main/java/greencity/entity/User.java
+++ b/dao/src/main/java/greencity/entity/User.java
@@ -137,10 +137,10 @@ import java.util.Set;
 @Table(name = "users")
 @EqualsAndHashCode(
     exclude = {"verifyEmail", "ownSecurity", "ecoNewsLiked", "refreshTokenKey", "estimates", "restorePasswordEmail",
-        "customShoppingListItems", "eventOrganizerRating", "favoriteEvents", "subscribedEvents"})
+        "customShoppingListItems", "eventOrganizerRating", "favoriteEcoNews", "favoriteEvents", "subscribedEvents"})
 @ToString(
     exclude = {"verifyEmail", "ownSecurity", "refreshTokenKey", "ecoNewsLiked", "estimates", "restorePasswordEmail",
-        "customShoppingListItems", "eventOrganizerRating", "favoriteEvents", "subscribedEvents"})
+        "customShoppingListItems", "eventOrganizerRating", "favoriteEcoNews", "favoriteEvents", "subscribedEvents"})
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/service-api/src/main/java/greencity/dto/econews/EcoNewsGenericDto.java
+++ b/service-api/src/main/java/greencity/dto/econews/EcoNewsGenericDto.java
@@ -55,6 +55,5 @@ public class EcoNewsGenericDto {
 
     private int countOfEcoNews;
 
-    @Builder.Default
-    private boolean isFavorite = false;
+    private boolean isFavorite;
 }


### PR DESCRIPTION
Removed redundant `@Builder.Default` annotation in `EcoNewsGenericDto` for better clarity. Updated the `User` class to include `favoriteEcoNews` in both `EqualsAndHashCode` and `ToString` annotations.