### PR TITLE
Added sorting functionality to the table on the "Manage Fact of the day" page

### DIFF
--- a/core/src/main/resources/static/management/css/table_Modal_Pagination.css
+++ b/core/src/main/resources/static/management/css/table_Modal_Pagination.css
@@ -364,7 +364,6 @@ table.table tr th:last-child {
 
 table.table th i {
     font-size: 14px;
-    margin: 0 5px;
     cursor: pointer;
 }
 

--- a/core/src/main/resources/static/management/factoftheday/buttonsAJAX.js
+++ b/core/src/main/resources/static/management/factoftheday/buttonsAJAX.js
@@ -262,3 +262,93 @@ function setLanguage(selectedLanguage) {
         row.style.display = (languageCode === selectedLanguage) ? '' : 'none';
     });
 }
+
+function orderByField(fieldName = null, sortOrder = null) {
+    let urlSearch = new URLSearchParams(window.location.search);
+    let sortParams = [];
+    const baseUrl = document.body.getAttribute('data-base-url');
+    urlSearch.forEach((value, key) => {
+        if (key === "sort" && value !== "") {
+            sortParams.push(value);
+        }
+    });
+
+    if (fieldName && sortOrder) {
+        let updated = false;
+
+        for (let i = 0; i < sortParams.length; i++) {
+            let [field, order] = sortParams[i].split(',');
+            if (field === fieldName) {
+                if (order === sortOrder) {
+                    sortParams.splice(i, 1);
+                } else {
+                    sortParams[i] = `${fieldName},${sortOrder}`;
+                }
+                updated = true;
+                break;
+            }
+        }
+
+        if (!updated) {
+            sortParams.push(`${fieldName},${sortOrder}`);
+        }
+
+        urlSearch.delete("sort");
+        sortParams.forEach(param => urlSearch.append("sort", param));
+
+        const url = baseUrl + `?${urlSearch.toString()}`;
+        $.ajax({
+            url: url,
+            type: 'GET',
+            success: function () {
+                window.location.href = url;
+            }
+        });
+    }
+
+    const fieldMapping = {
+        'id': ['id-icon-asc', 'id-icon-desc'],
+        'name': ['name-icon-asc', 'name-icon-desc'],
+        'factOfTheDayTranslations.content': ['content-icon-asc', 'content-icon-desc'],
+        'createDate': ['date-icon-asc', 'date-icon-desc']
+    };
+
+    sortParams.forEach(param => {
+        let [field, order] = param.split(',');
+        const icons = fieldMapping[field];
+        if (icons) {
+            const direction = order.toLowerCase() === 'asc' ? 0 : 1;
+            document.getElementById(icons[direction]).style.color = 'green';
+        }
+    });
+
+    updatePaginationLinks(urlSearch);
+}
+
+function updatePaginationLinks(urlSearch) {
+    const paginationLinks = document.querySelectorAll('.pagination a.page-link');
+
+    paginationLinks.forEach(link => {
+        const url = new URL(link.getAttribute('href'), window.location.origin);
+        const pageParam = url.searchParams.get('page');
+        const queryParam = url.searchParams.get('query');
+
+        urlSearch.delete('page');
+        urlSearch.delete('query');
+
+        url.search = urlSearch.toString();
+
+        if (pageParam) {
+            url.searchParams.set('page', pageParam);
+        }
+        if (queryParam) {
+            url.searchParams.set('query', queryParam);
+        }
+
+        link.setAttribute('href', url.toString());
+    });
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    orderByField();
+});

--- a/core/src/main/resources/templates/core/management_fact_of_the_day.html
+++ b/core/src/main/resources/templates/core/management_fact_of_the_day.html
@@ -24,7 +24,7 @@
     <script th:src="@{/management/factoftheday/buttonsAJAX.js}"></script>
     <script th:src="@{/management/localization/buttonsAJAX.js}"></script>
 </head>
-<body>
+<body th:with="baseUrl='/management/factoftheday/findAll'" th:data-base-url="${baseUrl}">
 <div id="header" th:insert="~{core/header}"></div>
 <div id="sidebar" th:insert="~{core/sidepanel}"></div>
 <div class="main-content">
@@ -60,16 +60,52 @@
                                 <label for="selectAll"></label>
                             </span>
                         </th>
-                        <th rowspan="2" class="mobile-hidden">[[#{greenCity.pages.table.id}]]</th>
-                        <th rowspan="2">[[#{greenCity.pages.table.name}]]</th>
+                        <th rowspan="2" class="mobile-hidden" style="min-width: 70px;">[[#{greenCity.pages.table.id}]]
+                            <span onclick="orderByField('id','asc')">
+                                <i id="id-icon-asc" class="material-icons" data-toggle="tooltip"
+                                   th:title="#{greenCity.pages.table.ascending}">&#xE5D8;</i>
+                            </span>
+                            <span onclick="orderByField('id','desc')">
+                                <i id="id-icon-desc" class="material-icons" data-toggle="tooltip"
+                                   th:title="#{greenCity.pages.table.descending}">&#xE5DB;</i>
+                            </span>
+                        </th>
+                        <th rowspan="2" style="min-width: 100px;">[[#{greenCity.pages.table.name}]]
+                            <span onclick="orderByField('name','asc')">
+                                <i id="name-icon-asc" class="material-icons" data-toggle="tooltip"
+                                   th:title="#{greenCity.pages.table.ascending}">&#xE5D8;</i>
+                            </span>
+                            <span onclick="orderByField('name','desc')">
+                                <i id="name-icon-desc" class="material-icons" data-toggle="tooltip"
+                                   th:title="#{greenCity.pages.table.descending}">&#xE5DB;</i>
+                            </span>
+                        </th>
                         <th colspan="3">[[#{greenCity.pages.table.translations}]]</th>
-                        <th rowspan="2" class="mobile-hidden">[[#{greenCity.pages.table.creation.date}]]</th>
+                        <th rowspan="2" class="mobile-hidden" style="min-width: 150px;">[[#{greenCity.pages.table.creation.date}]]
+                            <span onclick="orderByField('createDate','asc')">
+                                <i id="date-icon-asc" class="material-icons" data-toggle="tooltip"
+                                   th:title="#{greenCity.pages.table.ascending}">&#xE5D8;</i>
+                            </span>
+                            <span onclick="orderByField('createDate','desc')">
+                                <i id="date-icon-desc" class="material-icons" data-toggle="tooltip"
+                                   th:title="#{greenCity.pages.table.descending}">&#xE5DB;</i>
+                            </span>
+                        </th>
                         <th rowspan="2">[[#{greenCity.pages.table.tags}]]</th>
                         <th rowspan="2">[[#{greenCity.pages.table.actions}]]</th>
                     </tr>
                     <tr class="table-secondary">
                         <th class="small-column mobile-hidden">[[#{greenCity.pages.table.translation.id}]]</th>
-                        <th>[[#{greenCity.pages.table.content}]]</th>
+                        <th>[[#{greenCity.pages.table.content}]]
+                            <span onclick="orderByField('factOfTheDayTranslations.content','asc')">
+                                <i id="content-icon-asc" class="material-icons" data-toggle="tooltip"
+                                   th:title="#{greenCity.pages.table.ascending}">&#xE5D8;</i>
+                            </span>
+                            <span onclick="orderByField('factOfTheDayTranslations.content','desc')">
+                                <i id="content-icon-desc" class="material-icons" data-toggle="tooltip"
+                                   th:title="#{greenCity.pages.table.descending}">&#xE5DB;</i>
+                            </span>
+                        </th>
                         <th class="small-column">[[#{greenCity.pages.table.language.code}]]</th>
                     </tr>
                 </thead>
@@ -112,8 +148,8 @@
                             </table>
                         </td>
                         <td>
-                            <a th:href="@{/factoftheday/find(id=${factOfTheDay.getId()})}" class="edit eBtn"><i
-                                    class="material-icons" data-toggle="tooltip" th:title="#{greenCity.pages.edit}">&#xE254;</i></a>
+                            <a class="edit eBtn">
+                                <i class="material-icons" data-toggle="tooltip" th:title="#{greenCity.pages.edit}">&#xE254;</i></a>
                             <a th:href="@{/management/factoftheday/(id=${factOfTheDay.getId()})}"
                                class="delete eDelBtn" data-toggle="modal"><i class="material-icons"
                                                                              data-toggle="tooltip"
@@ -129,15 +165,15 @@
                         th:text="${pageable.getTotalElements()}">25</b> entries
                 </div>
                 <ul class="pagination">
-                    <li class="page-item" th:classappend="${pageable.getCurrentPage()==0?'disabled':''}"><a
-                            th:href="@{findAll(page=${pageable.getCurrentPage()-1}, query=${query})}" class="page-link">Previous</a>
+                    <li class="page-item" th:classappend="${pageable.getCurrentPage()==0?'disabled':''}">
+                        <a th:href="@{${baseUrl}(page=${pageable.getCurrentPage()-1}, query=${query})}" class="page-link">Previous</a>
                     </li>
                     <li class="page-item" th:each="i : ${#numbers.sequence(0,pageable.getTotalPages()-1)}"
-                        th:classappend="${pageable.getCurrentPage()==i?'active':''}"><a
-                            th:href="@{findAll(page=${i}, query=${query})}" class="page-link" th:text="${i+1}">1</a></li>
+                        th:classappend="${pageable.getCurrentPage()==i?'active':''}">
+                        <a th:href="@{${baseUrl}(page=${i}, query=${query})}" class="page-link" th:text="${i+1}">1</a></li>
                     <li class="page-item"
-                        th:classappend="${pageable.getCurrentPage()==pageable.getTotalPages()-1?'disabled':''}"><a
-                            th:href="@{findAll(page=${pageable.getCurrentPage()+1}, query=${query})}"
+                        th:classappend="${pageable.getCurrentPage()==pageable.getTotalPages()-1?'disabled':''}">
+                        <a th:href="@{${baseUrl}(page=${pageable.getCurrentPage()+1}, query=${query})}"
                             class="page-link">Next</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
# GreenCity PR

## Issue Link :clipboard:
[#7729](https://github.com/ita-social-projects/GreenCity/issues/7729)

## Summary Of Changes :fire:
Added sorting functionality to the "Manage Fact of the day" table in the admin panel to enhance data management and usability. Sorting now works across multiple fields including id, name, translations.content, creation date.

## Added
* UI controls (arrows) for sorting in table headers.

## Changed
* Updated pagination logic to retain sorting state across pages.
* Adjusted frontend table component to reflect sorting status visually with icons.

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers