### PR TITLE
Update EcoNewsController to handle null principal

### DIFF
--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -35,11 +35,13 @@ import jakarta.validation.Valid;
 import java.security.Principal;
 import java.util.List;
 import java.util.Locale;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -201,9 +203,11 @@ public class EcoNewsController {
         @RequestParam(required = false, name = "author-id") Long authorId,
         @Parameter(description = "Search for favorite news") @RequestParam(required = false, name = "favorite",
             defaultValue = "false") boolean favorite,
-        @Parameter(hidden = true) Principal principal) {
+        @AuthenticationPrincipal Principal principal) {
+        String userEmail = principal != null ? principal.getName() : null;
+
         return ResponseEntity.status(HttpStatus.OK).body(
-            ecoNewsService.find(page, tags, title, authorId, favorite, principal.getName()));
+            ecoNewsService.find(page, tags, title, authorId, favorite, userEmail));
     }
 
     /**

--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -35,7 +35,6 @@ import jakarta.validation.Valid;
 import java.security.Principal;
 import java.util.List;
 import java.util.Locale;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;

--- a/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
+++ b/core/src/test/java/greencity/controller/EcoNewsControllerTest.java
@@ -140,11 +140,10 @@ class EcoNewsControllerTest {
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
 
         mockMvc.perform(get(ecoNewsLink + "?page=0")
-            .principal(principal)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
 
-        verify(ecoNewsService).find(pageable, null, null, null, false, principal.getName());
+        verify(ecoNewsService).find(pageable, null, null, null, false, null);
     }
 
     @Test
@@ -154,11 +153,10 @@ class EcoNewsControllerTest {
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
 
         mockMvc.perform(get(ecoNewsLink + "?author-id=1&page=1")
-            .principal(principal)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
 
-        verify(ecoNewsService).find(pageable, null, null, 1L, false, principal.getName());
+        verify(ecoNewsService).find(pageable, null, null, 1L, false, null);
     }
 
     @Test


### PR DESCRIPTION
Refactored the EcoNewsController to use `@AuthenticationPrincipal` for better security context management. Updated test cases to adjust for the changes and removed redundant principal to userEmail conversion.