### PR TITLE
7808 - Status 400 instead of 403 when try to update comment of another User

### DIFF
--- a/service/src/main/java/greencity/service/CommentServiceImpl.java
+++ b/service/src/main/java/greencity/service/CommentServiceImpl.java
@@ -614,7 +614,7 @@ public class CommentServiceImpl implements CommentService {
             .orElseThrow(() -> new NotFoundException(ErrorMessage.COMMENT_NOT_FOUND_EXCEPTION));
 
         if (!userVO.getId().equals(comment.getUser().getId())) {
-            throw new BadRequestException(ErrorMessage.NOT_A_CURRENT_USER);
+            throw new UserHasNoPermissionToAccessException(ErrorMessage.NOT_A_CURRENT_USER);
         }
 
         comment.setText(commentText);

--- a/service/src/test/java/greencity/service/CommentServiceImplTest.java
+++ b/service/src/test/java/greencity/service/CommentServiceImplTest.java
@@ -825,10 +825,10 @@ class CommentServiceImplTest {
         when(commentRepo.findByIdAndStatusNot(commentId, CommentStatus.DELETED))
             .thenReturn(Optional.of(comment));
 
-        BadRequestException badRequestException =
-            assertThrows(BadRequestException.class,
+        UserHasNoPermissionToAccessException noAccessException =
+            assertThrows(UserHasNoPermissionToAccessException.class,
                 () -> commentService.update(editedText, commentId, userVO));
-        assertEquals(ErrorMessage.NOT_A_CURRENT_USER, badRequestException.getMessage());
+        assertEquals(ErrorMessage.NOT_A_CURRENT_USER, noAccessException.getMessage());
 
         verify(commentRepo).findByIdAndStatusNot(commentId, CommentStatus.DELETED);
     }


### PR DESCRIPTION
#7808 

- [x] The system returns status 403 and the message "You can't perform actions with the data of other user" when user try to update comment of another user