### PR TITLE
Habit invitation statuses null

### DIFF
--- a/dao/src/main/java/greencity/repository/HabitInvitationRepo.java
+++ b/dao/src/main/java/greencity/repository/HabitInvitationRepo.java
@@ -33,4 +33,6 @@ public interface HabitInvitationRepo extends JpaRepository<HabitInvitation, Long
     boolean existsByInviterHabitAssign(HabitAssign inviterHabitAssign);
 
     boolean existsByInviteeHabitAssign(HabitAssign inviteeHabitAssign);
+
+    boolean existsByInviterHabitAssignAndInviteeHabitAssign(HabitAssign inviterHabitAssign, HabitAssign habitAssign);
 }

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -252,4 +252,5 @@
     <include file="db/changelog/logs/ch-events-users-dislike-table.xml"/>
     <include file="db/changelog/logs/сh-add-new-column-to-habit-invites-Holotsvan.xml"/>
     <include file="db/changelog/logs/ch-comments-users-dislike-table.xml"/>
+    <include file="db/changelog/logs/сh-update-habit-invitation-statuses.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -254,4 +254,5 @@
     <include file="db/changelog/logs/ch-comments-users-dislike-table.xml"/>
     <include file="db/changelog/logs/ch-habits-users-dislikes-table.xml"/>
     <include file="db/changelog/logs/сh-update-habit-invitation-statuses.xml"/>
+    <include file="db/changelog/logs/ch-remove-duplicates-from-habit-invitations.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-remove-duplicates-from-habit-invitations.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-remove-duplicates-from-habit-invitations.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet id="remove-duplicate-invites" author="Ivan Holotsvan">
+        <sql>
+            DELETE FROM habit_invitations
+            WHERE ctid NOT IN (
+                SELECT MIN(ctid)
+                FROM habit_invitations
+                GROUP BY inviter_habit_assign_id, invitee_habit_assign_id
+            );
+        </sql>
+    </changeSet>
+
+    <changeSet id="unique-inviter-invitee_assigns" author="Ivan Holotsvan">
+        <addUniqueConstraint
+                tableName="habit_invitations"
+                columnNames="inviter_habit_assign_id, invitee_habit_assign_id"
+                constraintName="unique_inviter_invitee_assigns" />
+    </changeSet>
+</databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/сh-update-habit-invitation-statuses.xml
+++ b/dao/src/main/resources/db/changelog/logs/сh-update-habit-invitation-statuses.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet id="update-habit-invitations-statuses" author="Ivan Holotsvan">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="habit_invitations"/>
+            <tableExists tableName="habit_assign"/>
+            <columnExists tableName="habit_invitations" columnName="status"/>
+        </preConditions>
+
+        <sql>
+            UPDATE habit_invitations
+            SET status = CASE
+                WHEN habit_assign.status = 'INPROGRESS' THEN 'ACCEPTED'
+                WHEN habit_assign.status = 'REQUESTED' THEN 'PENDING'
+            END
+            FROM habit_assign
+            WHERE habit_invitations.invitee_habit_assign_id = habit_assign.id
+            AND habit_invitations.status IS NULL
+            AND habit_assign.status IN ('INPROGRESS','REQUESTED')
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -210,4 +210,5 @@ public class ErrorMessage {
     public static final String CANNOT_REJECT_HABIT_INVITATION = "You can't reject this habit invitation";
     public static final String INVITATION_NOT_FOUND = "Invitation not found";
     public static final String YOU_HAS_ALREADY_ACCEPT_THIS_INVITATION = "Current user already has accepted invitation";
+    public static final String INVITATION_ALREADY_EXIST = "Invitation already exist";
 }

--- a/service/src/main/java/greencity/service/HabitAssignServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitAssignServiceImpl.java
@@ -1461,6 +1461,13 @@ public class HabitAssignServiceImpl implements HabitAssignService {
         HabitAssign inviterHabitAssign = getOrAssignHabitToUser(userVO, habit);
         assignToDoListToUser(habitId, inviterHabitAssign);
 
+        boolean invitationExists = habitInvitationRepo.existsByInviterHabitAssignAndInviteeHabitAssign(
+            inviterHabitAssign, habitAssign);
+
+        if (invitationExists) {
+            throw new IllegalArgumentException(ErrorMessage.INVITATION_ALREADY_EXIST);
+        }
+
         HabitInvitation habitInvitation =
             habitInvitationRepo.save(createHabitInvitation(habitAssign, inviterHabitAssign));
 

--- a/service/src/main/java/greencity/service/HabitInvitationServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitInvitationServiceImpl.java
@@ -125,7 +125,7 @@ public class HabitInvitationServiceImpl implements HabitInvitationService {
 
     private List<HabitAssign> getHabitAssignsWhoIHaveInvited(Long currentUserId, Long habitAssignId) {
         return habitInvitationRepo.findByInviterHabitAssignId(habitAssignId).stream()
-            .filter(hi -> hi.getStatus().equals(HabitInvitationStatus.ACCEPTED))
+            .filter(hi -> HabitInvitationStatus.ACCEPTED.equals(hi.getStatus()))
             .map(HabitInvitation::getInviteeHabitAssign)
             .filter(habitAssign -> !habitAssign.getUser().getId().equals(currentUserId))
             .collect(Collectors.toList());


### PR DESCRIPTION
After adding reject/accept functionality invitations before has status null which was causing 500 status code because of null pointer

map habit assigns by habit_invitee_habit_assign_id and depeding on habit assign status set PENDING or ACCEPTED

+ user coudl send multiple invites and invitaion was duplicating in table, so remove duplicates, add unique constratint, add exception on second invitation of user to the same habit