### PR TITLE
Wrong length validation of event title field

### DIFF
--- a/core/src/main/java/greencity/controller/EventController.java
+++ b/core/src/main/java/greencity/controller/EventController.java
@@ -28,10 +28,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import java.nio.charset.Charset;
 import java.security.Principal;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -51,6 +53,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import static greencity.constant.SwaggerExampleModel.UPDATE_EVENT;
 
+@Slf4j
 @Validated
 @RestController
 @RequestMapping("/events")

--- a/core/src/main/java/greencity/controller/EventController.java
+++ b/core/src/main/java/greencity/controller/EventController.java
@@ -28,7 +28,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
-import java.nio.charset.Charset;
 import java.security.Principal;
 import java.util.List;
 import java.util.Set;

--- a/service-api/pom.xml
+++ b/service-api/pom.xml
@@ -102,5 +102,11 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.3.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.18.1</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/service-api/src/main/java/greencity/annotations/DecodedSize.java
+++ b/service-api/src/main/java/greencity/annotations/DecodedSize.java
@@ -1,0 +1,24 @@
+package greencity.annotations;
+
+import greencity.validator.DecodedSizeValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = DecodedSizeValidator.class)
+@Target({ElementType.METHOD,ElementType.FIELD,ElementType.ANNOTATION_TYPE, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DecodedSize {
+    String message() default "Size must be between {min} and {max} after decoding";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    int min() default 0;
+
+    int max() default Integer.MAX_VALUE;
+}

--- a/service-api/src/main/java/greencity/annotations/DecodedSize.java
+++ b/service-api/src/main/java/greencity/annotations/DecodedSize.java
@@ -9,7 +9,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Constraint(validatedBy = DecodedSizeValidator.class)
-@Target({ElementType.METHOD,ElementType.FIELD,ElementType.ANNOTATION_TYPE, ElementType.PARAMETER})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DecodedSize {
     String message() default "Size must be between {min} and {max} after decoding";

--- a/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
+++ b/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
@@ -1,6 +1,7 @@
 package greencity.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import greencity.annotations.DecodedSize;
 import jakarta.validation.constraints.NotBlank;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
@@ -21,7 +22,7 @@ import java.util.List;
 public class AddEventDtoRequest {
     @NotEmpty
     @NotBlank
-    @Size(min = 1, max = 70)
+    @DecodedSize(min = 1, max = 70)
     private String title;
 
     @NotEmpty

--- a/service-api/src/main/java/greencity/validator/DecodedSizeValidator.java
+++ b/service-api/src/main/java/greencity/validator/DecodedSizeValidator.java
@@ -1,0 +1,30 @@
+package greencity.validator;
+
+import greencity.annotations.DecodedSize;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.jsoup.parser.Parser;
+
+public class DecodedSizeValidator implements ConstraintValidator<DecodedSize, String> {
+    private int max;
+    private int min;
+
+
+    @Override
+    public void initialize(DecodedSize constraintAnnotation) {
+        this.max = constraintAnnotation.max();
+        this.min = constraintAnnotation.min();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        String decodedString = Parser.unescapeEntities(value,true);
+        int length = decodedString.length();
+
+        return length >= min && length <= max;
+    }
+}

--- a/service-api/src/main/java/greencity/validator/DecodedSizeValidator.java
+++ b/service-api/src/main/java/greencity/validator/DecodedSizeValidator.java
@@ -9,7 +9,6 @@ public class DecodedSizeValidator implements ConstraintValidator<DecodedSize, St
     private int max;
     private int min;
 
-
     @Override
     public void initialize(DecodedSize constraintAnnotation) {
         this.max = constraintAnnotation.max();
@@ -22,7 +21,7 @@ public class DecodedSizeValidator implements ConstraintValidator<DecodedSize, St
             return true;
         }
 
-        String decodedString = Parser.unescapeEntities(value,true);
+        String decodedString = Parser.unescapeEntities(value, true);
         int length = decodedString.length();
 
         return length >= min && length <= max;

--- a/service-api/src/test/java/greencity/validator/DecodedSizeValidatorTest.java
+++ b/service-api/src/test/java/greencity/validator/DecodedSizeValidatorTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mockito;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DecodedSizeValidatorTest {
+class DecodedSizeValidatorTest {
 
     private final DecodedSizeValidator validator = new DecodedSizeValidator();
 

--- a/service-api/src/test/java/greencity/validator/DecodedSizeValidatorTest.java
+++ b/service-api/src/test/java/greencity/validator/DecodedSizeValidatorTest.java
@@ -1,0 +1,41 @@
+package greencity.validator;
+
+import greencity.annotations.DecodedSize;
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mockito;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DecodedSizeValidatorTest {
+
+    private final DecodedSizeValidator validator = new DecodedSizeValidator();
+
+    @ParameterizedTest
+    @CsvSource({
+        "'', 0, 10, true",
+        "'abc', 1, 3, true",
+        "'abc', 0, 3, true",
+        "'abc', 1, 2, false",
+        "'abc', 2, 4, true",
+        "'a&b&c', 3, 5, true",
+        "'a&b&c', 0, 2, false",
+        "'a&lt;&gt;&amp;', 0, 9, true",
+        "'a&lt;&gt;&amp;', 0, 3, false",
+        "'Hello &lt;world&gt;', 0, 20, true",
+        "'Hello &lt;world&gt;', 0, 12, false"
+    })
+    void testDecodedSizeValidator(String input, int min, int max, boolean expectedValidity) {
+        DecodedSize annotation = Mockito.mock(DecodedSize.class);
+        Mockito.when(annotation.min()).thenReturn(min);
+        Mockito.when(annotation.max()).thenReturn(max);
+
+        validator.initialize(annotation);
+
+        boolean isValid = validator.isValid(input, Mockito.mock(ConstraintValidatorContext.class));
+        boolean condition = expectedValidity == isValid;
+        assertTrue(condition,
+            String.format("For input '%s' with min %d and max %d, expected %b but got %b", input, min, max,
+                expectedValidity, isValid));
+    }
+}

--- a/service-api/src/test/java/greencity/validator/DecodedSizeValidatorTest.java
+++ b/service-api/src/test/java/greencity/validator/DecodedSizeValidatorTest.java
@@ -23,7 +23,8 @@ class DecodedSizeValidatorTest {
         "'a&lt;&gt;&amp;', 0, 9, true",
         "'a&lt;&gt;&amp;', 0, 3, false",
         "'Hello &lt;world&gt;', 0, 20, true",
-        "'Hello &lt;world&gt;', 0, 12, false"
+        "'Hello &lt;world&gt;', 0, 12, false",
+        "null, 0, 10, true",
     })
     void testDecodedSizeValidator(String input, int min, int max, boolean expectedValidity) {
         DecodedSize annotation = Mockito.mock(DecodedSize.class);

--- a/service-api/src/test/java/greencity/validator/DecodedSizeValidatorTest.java
+++ b/service-api/src/test/java/greencity/validator/DecodedSizeValidatorTest.java
@@ -24,7 +24,7 @@ class DecodedSizeValidatorTest {
         "'a&lt;&gt;&amp;', 0, 3, false",
         "'Hello &lt;world&gt;', 0, 20, true",
         "'Hello &lt;world&gt;', 0, 12, false",
-        "null, 0, 10, true",
+        ", 0, 0, true",
     })
     void testDecodedSizeValidator(String input, int min, int max, boolean expectedValidity) {
         DecodedSize annotation = Mockito.mock(DecodedSize.class);


### PR DESCRIPTION
#7826 

original title user typed : A7@3j#T9!м&5д*L4з$W8п^C1q%2b(6к)R0?X|Я~[V]Z{Ф}P<67>h-_+G7!№;%

what we actually get on backend:
``` 
[2024-11-29 20:25:19] INFO greencity.controller.EventController     :92   A7@3j#T9!м&amp;5д*L4з$W8п^C1q%2b(6к)R0?X|Я~[V]Z{Ф}P&lt;67&gt;h-_+G7!№;%
[2024-11-29 20:25:19] INFO greencity.controller.EventController     :95   Current JVM encoding: UTF-8
[2024-11-29 20:25:19] INFO greencity.controller.EventController     :98   Length using length(): 71
[2024-11-29 20:25:19] INFO greencity.controller.EventController     :101  Number of characters using codePointCount(): 71
```
- `&` has been converted to `&amp;`
- `<` has been converted to `&lt;`
- `>` has been converted to `&gt;`

*We are converting this to protect us from XSS attacks as far as I understand

and because we are getting String with converted `&`, `<`, `>` size is bigger that in original string, so we need to decode to the original String and check it size. 