### PR TITLE
add images validation on POST /events

### DIFF
--- a/core/src/main/java/greencity/annotations/ImageArrayValidation.java
+++ b/core/src/main/java/greencity/annotations/ImageArrayValidation.java
@@ -13,11 +13,11 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 public @interface ImageArrayValidation {
     /**
-     * Defines the message that will be showed when the input data is not valid.
+     * Defines the message that will be shown when the input data is not valid.
      *
      * @return message
      */
-    String message() default "Download PNG or JPEG or GIF only. Max size of 10Mb each.";
+    String message() default "Upload %s only. Max size of %s each.";
 
     /**
      * Let you select to split the annotations into different groups to apply
@@ -34,4 +34,11 @@ public @interface ImageArrayValidation {
      * @return payload
      */
     Class<? extends Payload>[] payload() default {};
+
+    /**
+     * Array of valid content MIME types.
+     *
+     * @return Valid content types
+     */
+    String[] allowedTypes() default {"image/jpeg", "image/png", "image/jpg", "image/gif"};
 }

--- a/core/src/main/java/greencity/controller/EventController.java
+++ b/core/src/main/java/greencity/controller/EventController.java
@@ -2,6 +2,7 @@ package greencity.controller;
 
 import greencity.annotations.ApiPageableWithoutSort;
 import greencity.annotations.CurrentUser;
+import greencity.annotations.ImageArrayValidation;
 import greencity.annotations.ValidEventDtoRequest;
 import greencity.constant.ErrorMessage;
 import greencity.constant.HttpStatuses;
@@ -79,7 +80,8 @@ public class EventController {
         @Parameter(description = SwaggerExampleModel.ADD_EVENT,
             required = true) @ValidEventDtoRequest @RequestPart AddEventDtoRequest addEventDtoRequest,
         @Parameter(hidden = true) Principal principal,
-        @RequestPart(required = false) @Nullable MultipartFile[] images) {
+        @RequestPart(required = false) @Nullable @ImageArrayValidation(
+            allowedTypes = {"image/jpeg", "image/png", "image/jpg"}) MultipartFile[] images) {
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(eventService.save(addEventDtoRequest, principal.getName(), images));
     }


### PR DESCRIPTION
#7821

- Add validation annotation on POST /events
- Refactore ImageArrayValidator to be more readable
- Add allowedTypes() to annotation to make it more reusable
- Small changes in tests 
- Small java doc fix of past participle form of vert to show 

*File is pdf
![image](https://github.com/user-attachments/assets/adb6715a-c0f3-4b06-9803-c27c9f2e3b98)
