### PR TITLE
Bugfix/7818 7819 event error messages

### DIFF
--- a/core/src/main/java/greencity/annotations/ValidEventDtoRequest.java
+++ b/core/src/main/java/greencity/annotations/ValidEventDtoRequest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 public @interface ValidEventDtoRequest {
     /**
-     * Defines the message that will be showed when the input data is not valid.
+     * Defines the message that will be shown when the input data is not valid.
      *
      * @return message
      */

--- a/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
+++ b/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
@@ -490,7 +490,7 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
      * @return a {@code ResponseEntity} message
      */
     @ExceptionHandler(UnsupportedSortException.class)
-    public final ResponseEntity<Object> handleUnsuportedSortException(
+    public final ResponseEntity<Object> handleUnsupportedSortException(
         UnsupportedSortException ex, WebRequest request) {
         ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
         log.warn(ex.getMessage(), ex);

--- a/core/src/main/java/greencity/validator/EventDtoRequestValidator.java
+++ b/core/src/main/java/greencity/validator/EventDtoRequestValidator.java
@@ -14,6 +14,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import static greencity.validator.UrlValidator.isUrlValid;
 
@@ -60,7 +61,7 @@ public class EventDtoRequestValidator
         }
 
         dates.stream()
-            .filter(date -> date.getStartDate() == null || date.getFinishDate() == null)
+            .filter(date -> Objects.isNull(date.getStartDate()) || Objects.isNull(date.getFinishDate()))
             .findAny()
             .ifPresent(date -> {
                 throw new EventDtoValidationException(ErrorMessage.INVALID_DATE);

--- a/service-api/src/main/java/greencity/dto/event/AbstractEventDateLocationDto.java
+++ b/service-api/src/main/java/greencity/dto/event/AbstractEventDateLocationDto.java
@@ -11,12 +11,10 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @Data
 public abstract class AbstractEventDateLocationDto {
-    @NotEmpty
-    @NotNull
+    @NotNull(message = "Start date must not be null or empty")
     private ZonedDateTime startDate;
 
-    @NotEmpty
-    @NotNull
+    @NotNull(message = "Finish date must not be null or empty")
     private ZonedDateTime finishDate;
 
     private String onlineLink;

--- a/service-api/src/main/java/greencity/dto/event/AbstractEventDateLocationDto.java
+++ b/service-api/src/main/java/greencity/dto/event/AbstractEventDateLocationDto.java
@@ -1,6 +1,5 @@
 package greencity.dto.event;
 
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.ZonedDateTime;
 import lombok.Data;

--- a/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
+++ b/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
@@ -12,8 +12,6 @@ import lombok.Setter;
 import lombok.Builder;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
-import org.springframework.validation.annotation.Validated;
-
 import java.util.List;
 
 @NoArgsConstructor

--- a/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
+++ b/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
@@ -2,6 +2,7 @@ package greencity.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import greencity.annotations.DecodedSize;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
@@ -11,6 +12,8 @@ import lombok.Setter;
 import lombok.Builder;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
+import org.springframework.validation.annotation.Validated;
+
 import java.util.List;
 
 @NoArgsConstructor
@@ -29,6 +32,7 @@ public class AddEventDtoRequest {
     private String description;
 
     @NotEmpty
+    @Valid
     private List<EventDateLocationDto> datesLocations;
 
     @NotEmpty

--- a/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
+++ b/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
@@ -20,12 +20,10 @@ import java.util.List;
 @Builder
 @EqualsAndHashCode
 public class AddEventDtoRequest {
-    @NotEmpty
     @NotBlank
     @DecodedSize(min = 1, max = 70)
     private String title;
 
-    @NotEmpty
     @NotBlank
     @Size(min = 20, max = 63206)
     private String description;


### PR DESCRIPTION
#7818 

Removed redundant NotEmpty annotations from the title and description fields in AddEventDtoRequest, as they were duplicating the functionality of NotBlank.

#7819 

Validation for startDate and finishDate

Request:
```json
{
"title":"Eco",
"description":"Our city is our house, clearness is the useful approach",
"open":true,
"datesLocations":[
{
"startDate":"",
"finishDate":"",
"coordinates":{
"latitude":49.166565,
"longitude": 26.576463
},
"onlineLink":"http://google.com"
}
],
"tags":["Social"]
}
```
Response Before:
![image](https://github.com/user-attachments/assets/4e92d722-3eae-4a54-b61d-0d8aea6ad34c)

Response After:
![image](https://github.com/user-attachments/assets/e5c53ee8-c08a-4a3e-b091-54cb8c5e449e)
