### PR TITLE
change message to secondMessage

### DIFF
--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -860,6 +860,7 @@ public class EventServiceImpl implements EventService {
             .newsId(eventId)
             .newsTitle(event.getTitle())
             .notificationType(NotificationType.EVENT_LIKE)
+            .secondMessageText(event.getTitle())
             .isLike(true)
             .build();
         userNotificationService.createOrUpdateLikeNotification(likeNotificationDto);

--- a/service/src/main/resources/notification.properties
+++ b/service/src/main/resources/notification.properties
@@ -39,7 +39,7 @@ EVENT_NAME_UPDATED=Event {message} was updated. New name is {secondMessage}.
 EVENT_UPDATED_TITLE=Event was updated
 EVENT_UPDATED=Event {message} was updated.
 EVENT_LIKE_TITLE=Your event received a like.
-EVENT_LIKE=Event {message} received a like from {user}.
+EVENT_LIKE=Event «{secondMessage}» received a like from {user}.
 
 FRIEND_REQUEST_ACCEPTED_TITLE=Your friend request was accepted
 FRIEND_REQUEST_ACCEPTED={user} accepted your friend request.


### PR DESCRIPTION
#7662 

Summury of issue
![image](https://github.com/user-attachments/assets/b0d651fe-ef48-4acd-9202-d85c5239b48a)

Changes:
- add secondMessage
- change message to secondMessage in template

Checked on local and now it is redirecting to event which was liked
