### PR TITLE
Bugfix #7319 - Fixed incorrect saving for HabitTranslation for ua fields.

### DIFF
--- a/service-api/src/main/java/greencity/constant/AppConstant.java
+++ b/service-api/src/main/java/greencity/constant/AppConstant.java
@@ -14,6 +14,7 @@ public class AppConstant {
     public static final String AUTHORIZATION = "Authorization";
     public static final String ROLE = "role";
     public static final String DEFAULT_LANGUAGE_CODE = "en";
+    public static final String LANGUAGE_CODE_UA = "ua";
     public static final String DEFAULT_SOCIAL_NETWORK_IMAGE_HOST_PATH = "img/default_social_network_icon.png";
     public static final Integer MAX_NUMBER_OF_HABIT_ASSIGNS_FOR_USER = 6;
     public static final int MIN_DAYS_DURATION = 7;

--- a/service-api/src/main/java/greencity/dto/habit/CustomHabitDtoRequest.java
+++ b/service-api/src/main/java/greencity/dto/habit/CustomHabitDtoRequest.java
@@ -14,9 +14,11 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import org.springframework.validation.annotation.Validated;
 import java.util.List;
 import java.util.Set;
 
+@Validated
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -29,6 +31,7 @@ public class CustomHabitDtoRequest {
     @NotNull(message = ServiceValidationConstants.HABIT_COMPLEXITY)
     private Integer complexity;
     private Integer defaultDuration;
+    @Valid
     private List<HabitTranslationDto> habitTranslations;
     private String image;
     private List<CustomToDoListItemResponseDto> customToDoListItemDto;

--- a/service-api/src/main/java/greencity/dto/habittranslation/HabitTranslationDto.java
+++ b/service-api/src/main/java/greencity/dto/habittranslation/HabitTranslationDto.java
@@ -1,6 +1,7 @@
 package greencity.dto.habittranslation;
 
 import java.io.Serializable;
+import jakarta.validation.constraints.NotBlank;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -15,9 +16,12 @@ import lombok.Builder;
 @EqualsAndHashCode
 @Builder
 public class HabitTranslationDto implements Serializable {
+    @NotBlank
     private String description;
     private String habitItem;
+    @NotBlank
     private String languageCode;
+    @NotBlank
     private String name;
     private String descriptionUa;
     private String nameUa;

--- a/service/src/main/java/greencity/mapping/HabitTranslationMapper.java
+++ b/service/src/main/java/greencity/mapping/HabitTranslationMapper.java
@@ -1,7 +1,9 @@
 package greencity.mapping;
 
+import greencity.constant.AppConstant;
 import greencity.dto.habittranslation.HabitTranslationDto;
 import greencity.entity.HabitTranslation;
+import org.apache.commons.lang3.ObjectUtils;
 import org.modelmapper.AbstractConverter;
 import org.springframework.stereotype.Component;
 import java.util.List;
@@ -30,21 +32,12 @@ public class HabitTranslationMapper extends AbstractConverter<HabitTranslationDt
      */
     public HabitTranslation convertUa(HabitTranslationDto habitTranslationDto) {
         HabitTranslation habitTranslation = new HabitTranslation();
-        if (habitTranslationDto.getNameUa() == null) {
-            habitTranslation.setName(habitTranslationDto.getName());
-        } else {
-            habitTranslation.setName(habitTranslationDto.getNameUa());
-        }
-        if (habitTranslationDto.getDescriptionUa() == null) {
-            habitTranslation.setDescription(habitTranslationDto.getDescription());
-        } else {
-            habitTranslation.setDescription(habitTranslationDto.getDescriptionUa());
-        }
-        if (habitTranslationDto.getHabitItemUa() == null) {
-            habitTranslation.setHabitItem(habitTranslationDto.getHabitItem());
-        } else {
-            habitTranslation.setHabitItem(habitTranslationDto.getHabitItemUa());
-        }
+        habitTranslation
+            .setName(ObjectUtils.defaultIfNull(habitTranslationDto.getNameUa(), habitTranslationDto.getName()));
+        habitTranslation.setDescription(
+            ObjectUtils.defaultIfNull(habitTranslationDto.getDescriptionUa(), habitTranslationDto.getDescription()));
+        habitTranslation.setHabitItem(
+            ObjectUtils.defaultIfNull(habitTranslationDto.getHabitItemUa(), habitTranslationDto.getHabitItem()));
 
         return habitTranslation;
     }
@@ -73,7 +66,7 @@ public class HabitTranslationMapper extends AbstractConverter<HabitTranslationDt
      * @author Chernenko Vitaliy
      */
     public List<HabitTranslation> mapAllToList(List<HabitTranslationDto> dtoList, String language) {
-        if (language.equals("ua")) {
+        if (AppConstant.LANGUAGE_CODE_UA.equals(language)) {
             return dtoList.stream().map(this::convertUa).collect(Collectors.toList());
         }
         return dtoList.stream().map(this::convert).collect(Collectors.toList());

--- a/service/src/main/java/greencity/mapping/HabitTranslationMapper.java
+++ b/service/src/main/java/greencity/mapping/HabitTranslationMapper.java
@@ -19,6 +19,37 @@ public class HabitTranslationMapper extends AbstractConverter<HabitTranslationDt
     }
 
     /**
+     * Additional method that build {@link HabitTranslation} from
+     * {@link HabitTranslationDto} but from nameUa, descriptionUa, habitItemUa
+     * fields if they not null.
+     *
+     * @param habitTranslationDto {@link HabitTranslationDto}
+     * @return {@link HabitTranslation}
+     *
+     * @author Chernenko Vitaliy
+     */
+    public HabitTranslation convertUa(HabitTranslationDto habitTranslationDto) {
+        HabitTranslation habitTranslation = new HabitTranslation();
+        if (habitTranslationDto.getNameUa() == null) {
+            habitTranslation.setName(habitTranslationDto.getName());
+        } else {
+            habitTranslation.setName(habitTranslationDto.getNameUa());
+        }
+        if (habitTranslationDto.getDescriptionUa() == null) {
+            habitTranslation.setDescription(habitTranslationDto.getDescription());
+        } else {
+            habitTranslation.setDescription(habitTranslationDto.getDescriptionUa());
+        }
+        if (habitTranslationDto.getHabitItemUa() == null) {
+            habitTranslation.setHabitItem(habitTranslationDto.getHabitItem());
+        } else {
+            habitTranslation.setHabitItem(habitTranslationDto.getHabitItemUa());
+        }
+
+        return habitTranslation;
+    }
+
+    /**
      * Method that build {@link List} of {@link HabitTranslation} from {@link List}
      * of {@link HabitTranslationDto}.
      *
@@ -27,6 +58,24 @@ public class HabitTranslationMapper extends AbstractConverter<HabitTranslationDt
      * @author Lilia Mokhnatska
      */
     public List<HabitTranslation> mapAllToList(List<HabitTranslationDto> dtoList) {
+        return dtoList.stream().map(this::convert).collect(Collectors.toList());
+    }
+
+    /**
+     * Method that build {@link List} of {@link HabitTranslation} from {@link List}
+     * of {@link HabitTranslationDto} and {@link String} language.
+     *
+     * @param dtoList  {@link List} of {@link HabitTranslationDto}
+     * @param language {@link String}
+     *
+     * @return {@link List} of {@link HabitTranslation}
+     *
+     * @author Chernenko Vitaliy
+     */
+    public List<HabitTranslation> mapAllToList(List<HabitTranslationDto> dtoList, String language) {
+        if (language.equals("ua")) {
+            return dtoList.stream().map(this::convertUa).collect(Collectors.toList());
+        }
         return dtoList.stream().map(this::convert).collect(Collectors.toList());
     }
 }

--- a/service/src/main/java/greencity/service/HabitServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitServiceImpl.java
@@ -491,21 +491,26 @@ public class HabitServiceImpl implements HabitService {
     }
 
     private void saveHabitTranslationListsToHabitTranslationRepo(CustomHabitDtoRequest habitDto, Habit habit) {
-        List<HabitTranslation> habitTranslationListForUa = mapHabitTranslationFromAddCustomHabitDtoRequest(habitDto);
+        final String UA = "ua";
+        final String EN = "en";
+        List<HabitTranslation> habitTranslationListForUa =
+            mapHabitTranslationFromAddCustomHabitDtoRequest(habitDto, UA);
         habitTranslationListForUa.forEach(habitTranslation -> habitTranslation.setHabit(habit));
         habitTranslationListForUa.forEach(habitTranslation -> habitTranslation.setLanguage(
-            languageRepo.findByCode("ua").orElseThrow(NoSuchElementException::new)));
+            languageRepo.findByCode(UA).orElseThrow(NoSuchElementException::new)));
         habitTranslationRepo.saveAll(habitTranslationListForUa);
 
-        List<HabitTranslation> habitTranslationListForEn = mapHabitTranslationFromAddCustomHabitDtoRequest(habitDto);
+        List<HabitTranslation> habitTranslationListForEn =
+            mapHabitTranslationFromAddCustomHabitDtoRequest(habitDto, EN);
         habitTranslationListForEn.forEach(habitTranslation -> habitTranslation.setHabit(habit));
         habitTranslationListForEn.forEach(habitTranslation -> habitTranslation.setLanguage(
-            languageRepo.findByCode("en").orElseThrow(NoSuchElementException::new)));
+            languageRepo.findByCode(EN).orElseThrow(NoSuchElementException::new)));
         habitTranslationRepo.saveAll(habitTranslationListForEn);
     }
 
-    private List<HabitTranslation> mapHabitTranslationFromAddCustomHabitDtoRequest(CustomHabitDtoRequest habitDto) {
-        return habitTranslationMapper.mapAllToList(habitDto.getHabitTranslations());
+    private List<HabitTranslation> mapHabitTranslationFromAddCustomHabitDtoRequest(CustomHabitDtoRequest habitDto,
+        String language) {
+        return habitTranslationMapper.mapAllToList(habitDto.getHabitTranslations(), language);
     }
 
     private void setTagsIdsToHabit(CustomHabitDtoRequest habitDto, Habit habit) {

--- a/service/src/main/java/greencity/service/HabitServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitServiceImpl.java
@@ -491,20 +491,18 @@ public class HabitServiceImpl implements HabitService {
     }
 
     private void saveHabitTranslationListsToHabitTranslationRepo(CustomHabitDtoRequest habitDto, Habit habit) {
-        final String UA = "ua";
-        final String EN = "en";
         List<HabitTranslation> habitTranslationListForUa =
-            mapHabitTranslationFromAddCustomHabitDtoRequest(habitDto, UA);
+            mapHabitTranslationFromAddCustomHabitDtoRequest(habitDto, AppConstant.LANGUAGE_CODE_UA);
         habitTranslationListForUa.forEach(habitTranslation -> habitTranslation.setHabit(habit));
         habitTranslationListForUa.forEach(habitTranslation -> habitTranslation.setLanguage(
-            languageRepo.findByCode(UA).orElseThrow(NoSuchElementException::new)));
+            languageRepo.findByCode(AppConstant.LANGUAGE_CODE_UA).orElseThrow(NoSuchElementException::new)));
         habitTranslationRepo.saveAll(habitTranslationListForUa);
 
         List<HabitTranslation> habitTranslationListForEn =
-            mapHabitTranslationFromAddCustomHabitDtoRequest(habitDto, EN);
+            mapHabitTranslationFromAddCustomHabitDtoRequest(habitDto, AppConstant.DEFAULT_LANGUAGE_CODE);
         habitTranslationListForEn.forEach(habitTranslation -> habitTranslation.setHabit(habit));
         habitTranslationListForEn.forEach(habitTranslation -> habitTranslation.setLanguage(
-            languageRepo.findByCode(EN).orElseThrow(NoSuchElementException::new)));
+            languageRepo.findByCode(AppConstant.DEFAULT_LANGUAGE_CODE).orElseThrow(NoSuchElementException::new)));
         habitTranslationRepo.saveAll(habitTranslationListForEn);
     }
 

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -276,9 +276,12 @@ public class ModelUtils {
     public static ZonedDateTime zonedDateTime = ZonedDateTime.now();
     public static LocalDateTime localDateTime = LocalDateTime.now();
     public static String habitTranslationName = "use shopper";
+    public static String habitTranslationNameUa = "Назва звички українською";
     public static String habitTranslationDescription = "Description";
+    public static String habitTranslationDescriptionUa = "Опис звички українською";
     public static String toDoListText = "buy a shopper";
     public static String habitItem = "Item";
+    public static String habitItemUa = "Айтем звички українською";
     public static String habitDefaultImage = "img/habit-default.png";
     public static AddEventDtoRequest addEventDtoRequest = AddEventDtoRequest.builder()
         .datesLocations(List.of(EventDateLocationDto.builder()
@@ -2574,6 +2577,18 @@ public class ModelUtils {
             .description(habitTranslationDescription)
             .habitItem(habitItem)
             .name(habitTranslationName)
+            .build();
+    }
+
+    public static HabitTranslationDto getHabitTranslationDtoEnAndUa() {
+        return HabitTranslationDto.builder()
+            .description(habitTranslationDescription)
+            .habitItem(habitItem)
+            .name(habitTranslationName)
+            .languageCode("en")
+            .nameUa(habitTranslationNameUa)
+            .descriptionUa(habitTranslationDescriptionUa)
+            .habitItemUa(habitItemUa)
             .build();
     }
 

--- a/service/src/test/java/greencity/mapping/HabitTranslationMapperTests.java
+++ b/service/src/test/java/greencity/mapping/HabitTranslationMapperTests.java
@@ -14,8 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
 class HabitTranslationMapperTests {
-    private final String UA = "ua";
-    private final String EN = "en";
     @InjectMocks
     private HabitTranslationMapper habitTranslationMapper;
 
@@ -69,7 +67,7 @@ class HabitTranslationMapperTests {
             .build();
         List<HabitTranslation> expectedList = List.of(expected);
 
-        assertEquals(expectedList, habitTranslationMapper.mapAllToList(habitTranslationDtoList, EN));
+        assertEquals(expectedList, habitTranslationMapper.mapAllToList(habitTranslationDtoList, "en"));
     }
 
     @Test
@@ -84,6 +82,6 @@ class HabitTranslationMapperTests {
             .build();
         List<HabitTranslation> expectedList = List.of(expected);
 
-        assertEquals(expectedList, habitTranslationMapper.mapAllToList(habitTranslationDtoList, UA));
+        assertEquals(expectedList, habitTranslationMapper.mapAllToList(habitTranslationDtoList, "ua"));
     }
 }

--- a/service/src/test/java/greencity/mapping/HabitTranslationMapperTests.java
+++ b/service/src/test/java/greencity/mapping/HabitTranslationMapperTests.java
@@ -1,13 +1,13 @@
 package greencity.mapping;
 
 import greencity.ModelUtils;
+import greencity.constant.AppConstant;
 import greencity.dto.habittranslation.HabitTranslationDto;
 import greencity.entity.HabitTranslation;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -30,7 +30,7 @@ class HabitTranslationMapperTests {
     }
 
     @Test
-    void convertUaWithValidHabitTranslationDtoSucceeds() {
+    void convertUaWithValidHabitTranslationDtoSucceedsTest() {
         HabitTranslationDto habitTranslationDto = ModelUtils.getHabitTranslationDtoEnAndUa();
 
         HabitTranslation expected = HabitTranslation.builder()
@@ -56,7 +56,7 @@ class HabitTranslationMapperTests {
     }
 
     @Test
-    void mapAllToListWithEnLanguageReturnsList() {
+    void mapAllToListWithEnLanguageReturnsListTest() {
         HabitTranslationDto habitTranslationDto = ModelUtils.getHabitTranslationDtoEnAndUa();
         List<HabitTranslationDto> habitTranslationDtoList = List.of(habitTranslationDto);
 
@@ -67,11 +67,11 @@ class HabitTranslationMapperTests {
             .build();
         List<HabitTranslation> expectedList = List.of(expected);
 
-        assertEquals(expectedList, habitTranslationMapper.mapAllToList(habitTranslationDtoList, "en"));
+        assertEquals(expectedList, habitTranslationMapper.mapAllToList(habitTranslationDtoList, AppConstant.DEFAULT_LANGUAGE_CODE));
     }
 
     @Test
-    void mapAllToListWithUaLanguageReturnsList() {
+    void mapAllToListWithUaLanguageReturnsListTest() {
         HabitTranslationDto habitTranslationDto = ModelUtils.getHabitTranslationDtoEnAndUa();
         List<HabitTranslationDto> habitTranslationDtoList = List.of(habitTranslationDto);
 
@@ -82,6 +82,21 @@ class HabitTranslationMapperTests {
             .build();
         List<HabitTranslation> expectedList = List.of(expected);
 
-        assertEquals(expectedList, habitTranslationMapper.mapAllToList(habitTranslationDtoList, "ua"));
+        assertEquals(expectedList, habitTranslationMapper.mapAllToList(habitTranslationDtoList, AppConstant.LANGUAGE_CODE_UA));
+    }
+
+    @Test
+    void mapAllToListWithUaCodeButEmptyUaFieldsReturnListTest() {
+        HabitTranslationDto habitTranslationDto = ModelUtils.getHabitTranslationDto();
+        List<HabitTranslationDto> habitTranslationDtoList = List.of(habitTranslationDto);
+
+        HabitTranslation expected = HabitTranslation.builder()
+                .description(habitTranslationDto.getDescription())
+                .habitItem(habitTranslationDto.getHabitItem())
+                .name(habitTranslationDto.getName())
+                .build();
+        List<HabitTranslation> expectedList = List.of(expected);
+
+        assertEquals(expectedList, habitTranslationMapper.mapAllToList(habitTranslationDtoList, AppConstant.LANGUAGE_CODE_UA));
     }
 }

--- a/service/src/test/java/greencity/mapping/HabitTranslationMapperTests.java
+++ b/service/src/test/java/greencity/mapping/HabitTranslationMapperTests.java
@@ -14,6 +14,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
 class HabitTranslationMapperTests {
+    private final String UA = "ua";
+    private final String EN = "en";
     @InjectMocks
     private HabitTranslationMapper habitTranslationMapper;
 
@@ -30,6 +32,18 @@ class HabitTranslationMapperTests {
     }
 
     @Test
+    void convertUaWithValidHabitTranslationDtoSucceeds() {
+        HabitTranslationDto habitTranslationDto = ModelUtils.getHabitTranslationDtoEnAndUa();
+
+        HabitTranslation expected = HabitTranslation.builder()
+            .description(habitTranslationDto.getDescriptionUa())
+            .habitItem(habitTranslationDto.getHabitItemUa())
+            .name(habitTranslationDto.getNameUa())
+            .build();
+        assertEquals(expected, habitTranslationMapper.convertUa(habitTranslationDto));
+    }
+
+    @Test
     void mapAllToListTest() {
         HabitTranslationDto habitTranslationDto = ModelUtils.getHabitTranslationDto();
         List<HabitTranslationDto> habitTranslationDtoList = List.of(ModelUtils.getHabitTranslationDto());
@@ -41,5 +55,35 @@ class HabitTranslationMapperTests {
             .build();
         List<HabitTranslation> expectedList = List.of(expected);
         assertEquals(expectedList, habitTranslationMapper.mapAllToList(habitTranslationDtoList));
+    }
+
+    @Test
+    void mapAllToListWithEnLanguageReturnsList() {
+        HabitTranslationDto habitTranslationDto = ModelUtils.getHabitTranslationDtoEnAndUa();
+        List<HabitTranslationDto> habitTranslationDtoList = List.of(habitTranslationDto);
+
+        HabitTranslation expected = HabitTranslation.builder()
+            .description(habitTranslationDto.getDescription())
+            .habitItem(habitTranslationDto.getHabitItem())
+            .name(habitTranslationDto.getName())
+            .build();
+        List<HabitTranslation> expectedList = List.of(expected);
+
+        assertEquals(expectedList, habitTranslationMapper.mapAllToList(habitTranslationDtoList, EN));
+    }
+
+    @Test
+    void mapAllToListWithUaLanguageReturnsList() {
+        HabitTranslationDto habitTranslationDto = ModelUtils.getHabitTranslationDtoEnAndUa();
+        List<HabitTranslationDto> habitTranslationDtoList = List.of(habitTranslationDto);
+
+        HabitTranslation expected = HabitTranslation.builder()
+            .description(habitTranslationDto.getDescriptionUa())
+            .habitItem(habitTranslationDto.getHabitItemUa())
+            .name(habitTranslationDto.getNameUa())
+            .build();
+        List<HabitTranslation> expectedList = List.of(expected);
+
+        assertEquals(expectedList, habitTranslationMapper.mapAllToList(habitTranslationDtoList, UA));
     }
 }

--- a/service/src/test/java/greencity/mapping/HabitTranslationMapperTests.java
+++ b/service/src/test/java/greencity/mapping/HabitTranslationMapperTests.java
@@ -67,7 +67,8 @@ class HabitTranslationMapperTests {
             .build();
         List<HabitTranslation> expectedList = List.of(expected);
 
-        assertEquals(expectedList, habitTranslationMapper.mapAllToList(habitTranslationDtoList, AppConstant.DEFAULT_LANGUAGE_CODE));
+        assertEquals(expectedList,
+            habitTranslationMapper.mapAllToList(habitTranslationDtoList, AppConstant.DEFAULT_LANGUAGE_CODE));
     }
 
     @Test
@@ -82,7 +83,8 @@ class HabitTranslationMapperTests {
             .build();
         List<HabitTranslation> expectedList = List.of(expected);
 
-        assertEquals(expectedList, habitTranslationMapper.mapAllToList(habitTranslationDtoList, AppConstant.LANGUAGE_CODE_UA));
+        assertEquals(expectedList,
+            habitTranslationMapper.mapAllToList(habitTranslationDtoList, AppConstant.LANGUAGE_CODE_UA));
     }
 
     @Test
@@ -91,12 +93,13 @@ class HabitTranslationMapperTests {
         List<HabitTranslationDto> habitTranslationDtoList = List.of(habitTranslationDto);
 
         HabitTranslation expected = HabitTranslation.builder()
-                .description(habitTranslationDto.getDescription())
-                .habitItem(habitTranslationDto.getHabitItem())
-                .name(habitTranslationDto.getName())
-                .build();
+            .description(habitTranslationDto.getDescription())
+            .habitItem(habitTranslationDto.getHabitItem())
+            .name(habitTranslationDto.getName())
+            .build();
         List<HabitTranslation> expectedList = List.of(expected);
 
-        assertEquals(expectedList, habitTranslationMapper.mapAllToList(habitTranslationDtoList, AppConstant.LANGUAGE_CODE_UA));
+        assertEquals(expectedList,
+            habitTranslationMapper.mapAllToList(habitTranslationDtoList, AppConstant.LANGUAGE_CODE_UA));
     }
 }

--- a/service/src/test/java/greencity/service/HabitServiceImplTest.java
+++ b/service/src/test/java/greencity/service/HabitServiceImplTest.java
@@ -619,7 +619,9 @@ class HabitServiceImplTest {
         when(userRepo.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
         when(habitRepo.save(customHabitMapper.convert(addCustomHabitDtoRequest))).thenReturn(habit);
         when(tagsRepo.findById(20L)).thenReturn(Optional.of(tag));
-        when(habitTranslationMapper.mapAllToList(List.of(habitTranslationDto)))
+        when(habitTranslationMapper.mapAllToList(List.of(habitTranslationDto), "ua"))
+            .thenReturn(List.of(habitTranslationUa));
+        when(habitTranslationMapper.mapAllToList(List.of(habitTranslationDto), "en"))
             .thenReturn(List.of(habitTranslationUa));
         when(languageRepo.findByCode("ua")).thenReturn(Optional.of(languageUa));
         when(languageRepo.findByCode("en")).thenReturn(Optional.of(languageEn));
@@ -641,7 +643,8 @@ class HabitServiceImplTest {
         verify(habitRepo).save(customHabitMapper.convert(addCustomHabitDtoRequest));
         verify(customHabitMapper, times(3)).convert(addCustomHabitDtoRequest);
         verify(tagsRepo).findById(20L);
-        verify(habitTranslationMapper, times(2)).mapAllToList(List.of(habitTranslationDto));
+        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDto), "ua");
+        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDto), "en");
         verify(languageRepo, times(2)).findByCode(anyString());
         verify(customToDoListItemRepo).findAllByUserIdAndHabitId(1L, 1L);
         verify(customToDoListMapper).mapAllToList(anyList());
@@ -692,8 +695,10 @@ class HabitServiceImplTest {
         when(languageRepo.findByCode("ua")).thenReturn(Optional.of(languageUa));
         when(languageRepo.findByCode("en")).thenReturn(Optional.of(languageEn));
         when(customToDoListItemRepo.findAllByUserIdAndHabitId(1L, 1L)).thenReturn(List.of(customToDoListItem));
-        when(customToDoListMapper.mapAllToList(List.of(customToDoListItemResponseDto)))
-            .thenReturn(List.of(customToDoListItem));
+        when(habitTranslationMapper.mapAllToList(List.of(habitTranslationDto), "ua"))
+            .thenReturn(List.of(habitTranslationUa));
+        when(habitTranslationMapper.mapAllToList(List.of(habitTranslationDto), "en"))
+            .thenReturn(List.of(habitTranslationUa));
         when(modelMapper.map(habit, CustomHabitDtoResponse.class)).thenReturn(addCustomHabitDtoResponse);
         when(customToDoListResponseDtoMapper.mapAllToList(List.of(customToDoListItem)))
             .thenReturn(List.of(customToDoListItemResponseDto));
@@ -709,7 +714,8 @@ class HabitServiceImplTest {
         verify(habitRepo).save(customHabitMapper.convert(addCustomHabitDtoRequest));
         verify(customHabitMapper, times(3)).convert(addCustomHabitDtoRequest);
         verify(tagsRepo).findById(20L);
-        verify(habitTranslationMapper, times(2)).mapAllToList(List.of(habitTranslationDto));
+        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDto), "ua");
+        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDto), "en");
         verify(languageRepo, times(2)).findByCode(anyString());
         verify(customToDoListItemRepo).findAllByUserIdAndHabitId(1L, 1L);
         verify(customToDoListMapper).mapAllToList(anyList());
@@ -755,7 +761,9 @@ class HabitServiceImplTest {
         when(userRepo.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
         when(habitRepo.save(customHabitMapper.convert(addCustomHabitDtoRequest))).thenReturn(habit);
         when(tagsRepo.findById(20L)).thenReturn(Optional.of(tag));
-        when(habitTranslationMapper.mapAllToList(List.of(habitTranslationDto)))
+        when(habitTranslationMapper.mapAllToList(List.of(habitTranslationDto), "ua"))
+            .thenReturn(List.of(habitTranslationUa));
+        when(habitTranslationMapper.mapAllToList(List.of(habitTranslationDto), "en"))
             .thenReturn(List.of(habitTranslationUa));
         when(languageRepo.findByCode("ua")).thenReturn(Optional.of(languageUa));
         when(languageRepo.findByCode("en")).thenReturn(Optional.of(languageEn));
@@ -777,7 +785,8 @@ class HabitServiceImplTest {
         verify(habitRepo).save(customHabitMapper.convert(addCustomHabitDtoRequest));
         verify(customHabitMapper, times(3)).convert(addCustomHabitDtoRequest);
         verify(tagsRepo).findById(20L);
-        verify(habitTranslationMapper, times(2)).mapAllToList(List.of(habitTranslationDto));
+        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDto), "ua");
+        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDto), "en");
         verify(languageRepo, times(2)).findByCode(anyString());
         verify(customToDoListItemRepo).findAllByUserIdAndHabitId(1L, 1L);
         verify(customToDoListMapper).mapAllToList(anyList());
@@ -807,7 +816,9 @@ class HabitServiceImplTest {
         when(userRepo.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
         when(habitRepo.save(customHabitMapper.convert(addCustomHabitDtoRequest))).thenReturn(habit);
         when(tagsRepo.findById(20L)).thenReturn(Optional.of(tag));
-        when(habitTranslationMapper.mapAllToList(List.of(habitTranslationDto)))
+        when(habitTranslationMapper.mapAllToList(addCustomHabitDtoRequest.getHabitTranslations(), "ua"))
+            .thenReturn(List.of(habitTranslation));
+        when(habitTranslationMapper.mapAllToList(addCustomHabitDtoRequest.getHabitTranslations(), "en"))
             .thenReturn(List.of(habitTranslation));
         when(languageRepo.findByCode("ua")).thenReturn(Optional.empty());
 
@@ -818,7 +829,8 @@ class HabitServiceImplTest {
         verify(habitRepo).save(customHabitMapper.convert(addCustomHabitDtoRequest));
         verify(customHabitMapper, times(3)).convert(addCustomHabitDtoRequest);
         verify(tagsRepo).findById(20L);
-        verify(habitTranslationMapper).mapAllToList(addCustomHabitDtoRequest.getHabitTranslations());
+        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDto), "ua");
+        verify(habitTranslationMapper, times(0)).mapAllToList(List.of(habitTranslationDto), "en");
         verify(languageRepo).findByCode(anyString());
     }
 
@@ -842,7 +854,9 @@ class HabitServiceImplTest {
         when(userRepo.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
         when(habitRepo.save(customHabitMapper.convert(addCustomHabitDtoRequest))).thenReturn(habit);
         when(tagsRepo.findById(20L)).thenReturn(Optional.of(tag));
-        when(habitTranslationMapper.mapAllToList(List.of(habitTranslationDto)))
+        when(habitTranslationMapper.mapAllToList(addCustomHabitDtoRequest.getHabitTranslations(), "ua"))
+            .thenReturn(List.of(habitTranslationUa));
+        when(habitTranslationMapper.mapAllToList(addCustomHabitDtoRequest.getHabitTranslations(), "en"))
             .thenReturn(List.of(habitTranslationUa));
         when(languageRepo.findByCode("ua")).thenReturn(Optional.of(languageUa));
         when(languageRepo.findByCode("en")).thenReturn(Optional.empty());
@@ -855,7 +869,8 @@ class HabitServiceImplTest {
         verify(customHabitMapper, times(3)).convert(addCustomHabitDtoRequest);
         verify(tagsRepo).findById(20L);
 
-        verify(habitTranslationMapper, times(2)).mapAllToList(addCustomHabitDtoRequest.getHabitTranslations());
+        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDto), "ua");
+        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDto), "en");
         verify(languageRepo, times(2)).findByCode(anyString());
     }
 


### PR DESCRIPTION
# GreenCity PR
## Issue Link 📋
https://github.com/ita-social-projects/GreenCity/issues/7319

## Added

- Added _getHabitTranslationDtoEnAndUa_ method in ModelUtils; 
- Added `@NotBlank` annotation in HabitTranslationDto for description, languageCode and name fields; 
- Added `@Valid `annotation for validation HabitTranslationDto into CustomHabitDtoRequest;
- Added _convertUa_() and _mapAllToList_() methods into HabitTranslationMapper; 
- Added necessary tests in HabitTranslationMapperTests;

## Changed

- Changed functionality  of method saveHabitTranslationListsToHabitTranslationRepo in HabitServiceImpl;
- Modified tests according to change in method _saveHabitTranslationListsToHabitTranslationRepo_ in HabitServiceImplTests;

## Summary Of Changes 🔥
Improvement according to task https://github.com/ita-social-projects/GreenCity/issues/7319;
Fixed main functionality of saving HabitTranslation in HabitServiceImpl;