### PR TITLE
Bugfix #7847 - Fixed incorrect behavior for saving the Event without a place but with a link.

### DIFF
--- a/service/src/main/java/greencity/mapping/events/EventDateLocationDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/events/EventDateLocationDtoMapper.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.modelmapper.AbstractConverter;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Class that used by {@link ModelMapper} to map {@link Event} into
@@ -38,5 +40,17 @@ public class EventDateLocationDtoMapper extends AbstractConverter<EventDateLocat
             eventDateLocation.setAddress(mapper.convert(eventDateLocationDto.getCoordinates()));
         }
         return eventDateLocation;
+    }
+
+    /**
+     * Method that build {@link List} of {@link EventDateLocation} from {@link List}
+     * of {@link EventDateLocationDto}.
+     *
+     * @param eventDateLocationDtoList {@link List} of {@link EventDateLocationDto}
+     *
+     * @return {@link List} of {@link EventDateLocation}
+     */
+    public List<EventDateLocation> mapAllToList(List<EventDateLocationDto> eventDateLocationDtoList) {
+        return eventDateLocationDtoList.stream().map(this::convert).collect(Collectors.toList());
     }
 }

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -631,7 +631,7 @@ public class EventServiceImpl implements EventService {
             AddressDto coordinates = eventDateLocationDto.getCoordinates();
             EventType eventType = getEventType(eventDateLocationDtoMapper.mapAllToList(eventDateLocationDtos));
 
-            if (EventType.ONLINE.equals(eventType)) {
+            if (EventType.ONLINE == eventType) {
                 return true;
             }
             if (Objects.isNull(coordinates) || Objects.isNull(coordinates.getLatitude())

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -39,6 +39,7 @@ import greencity.enums.TagType;
 import greencity.exception.exceptions.BadRequestException;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.exception.exceptions.UserHasNoPermissionToAccessException;
+import greencity.mapping.events.EventDateLocationDtoMapper;
 import greencity.rating.RatingCalculation;
 import greencity.repository.EventRepo;
 import greencity.repository.RatingPointsRepo;
@@ -116,6 +117,7 @@ public class EventServiceImpl implements EventService {
     private static final String DEFAULT_TITLE_IMAGE_PATH = AppConstant.DEFAULT_EVENT_IMAGES;
     private final EventRepo eventRepo;
     private final ModelMapper modelMapper;
+    private final EventDateLocationDtoMapper eventDateLocationDtoMapper;
     private final RestClient restClient;
     private final FileService fileService;
     private final TagsService tagService;
@@ -627,7 +629,11 @@ public class EventServiceImpl implements EventService {
     public boolean validateCoordinates(List<EventDateLocationDto> eventDateLocationDtos) {
         for (EventDateLocationDto eventDateLocationDto : eventDateLocationDtos) {
             AddressDto coordinates = eventDateLocationDto.getCoordinates();
+            EventType eventType = getEventType(eventDateLocationDtoMapper.mapAllToList(eventDateLocationDtos));
 
+            if (EventType.ONLINE.equals(eventType)) {
+                return true;
+            }
             if (Objects.isNull(coordinates) || Objects.isNull(coordinates.getLatitude())
                 || Objects.isNull(coordinates.getLongitude())) {
                 return false;

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -1887,11 +1887,11 @@ public class ModelUtils {
         dates.add(new EventDateLocation(1L, event,
             ZonedDateTime.of(2000, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
             ZonedDateTime.of(2000, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
-            getAddress(), null));
+            null, "http://somelink.com"));
         dates.add(new EventDateLocation(2L, event,
             ZonedDateTime.of(2002, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
             ZonedDateTime.of(2002, 2, 1, 1, 1, 1, 1, ZoneId.systemDefault()),
-            null, "url/"));
+            null, "http://somelink.com"));
         event.setDates(dates);
         event.setTags(List.of(getEventTag()));
         return event;
@@ -3233,4 +3233,16 @@ public class ModelUtils {
         return List.of(invalidDto1, invalidDto2);
     }
 
+    public static EventDateLocationDto getEventDateLocationDtoWithLinkAndCoordinates() {
+        return EventDateLocationDto.builder()
+            .id(1L)
+            .startDate(ZonedDateTime.now())
+            .finishDate(ZonedDateTime.now().plusDays(2L))
+            .onlineLink("https://someevents.com")
+            .coordinates(AddressDto.builder()
+                .latitude(50.1234)
+                .latitude(30.1234)
+                .build())
+            .build();
+    }
 }

--- a/service/src/test/java/greencity/mapping/events/EventDateLocationDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/events/EventDateLocationDtoMapperTest.java
@@ -56,9 +56,9 @@ class EventDateLocationDtoMapperTest {
         List<EventDateLocationDto> eventDateLocationDtoList = List.of(eventDateLocationDto);
 
         EventDateLocation dto = EventDateLocation.builder().id(eventDateLocationDto.getId())
-                .startDate(eventDateLocationDto.getStartDate()).finishDate(eventDateLocationDto.getFinishDate())
-                .address(addressDtoMapper.convert(eventDateLocationDto.getCoordinates()))
-                .onlineLink(eventDateLocationDto.getOnlineLink()).build();
+            .startDate(eventDateLocationDto.getStartDate()).finishDate(eventDateLocationDto.getFinishDate())
+            .address(addressDtoMapper.convert(eventDateLocationDto.getCoordinates()))
+            .onlineLink(eventDateLocationDto.getOnlineLink()).build();
 
         List<EventDateLocation> expectedList = List.of(dto);
         assertEquals(expectedList, mapper.mapAllToList(eventDateLocationDtoList));

--- a/service/src/test/java/greencity/mapping/events/EventDateLocationDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/events/EventDateLocationDtoMapperTest.java
@@ -1,5 +1,6 @@
 package greencity.mapping.events;
 
+import greencity.ModelUtils;
 import greencity.dto.event.EventDateLocationDto;
 import greencity.entity.event.EventDateLocation;
 import org.junit.jupiter.api.Test;
@@ -7,8 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Spy;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-
-import static greencity.ModelUtils.*;
+import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -21,12 +21,12 @@ class EventDateLocationDtoMapperTest {
 
     @Test
     void convert() {
-        EventDateLocation expected = getEventDateLocation();
+        EventDateLocation expected = ModelUtils.getEventDateLocation();
         EventDateLocationDto dto = EventDateLocationDto.builder()
             .id(expected.getId())
             .startDate(expected.getStartDate())
             .finishDate(expected.getFinishDate())
-            .coordinates(getAddressDto())
+            .coordinates(ModelUtils.getAddressDto())
             .build();
         EventDateLocation actual = mapper.convert(dto);
         assertEquals(expected.getId(), actual.getId());
@@ -36,7 +36,7 @@ class EventDateLocationDtoMapperTest {
 
     @Test
     void convertWithoutAddress() {
-        EventDateLocation expected = getEventDateLocation();
+        EventDateLocation expected = ModelUtils.getEventDateLocation();
         expected.setAddress(null);
         EventDateLocationDto dto = EventDateLocationDto.builder()
             .id(expected.getId())
@@ -47,5 +47,20 @@ class EventDateLocationDtoMapperTest {
         assertEquals(expected.getId(), actual.getId());
         assertEquals(expected.getStartDate(), actual.getStartDate());
         assertNull(actual.getAddress());
+    }
+
+    @Test
+    void mapAllToListWithValidEventDateLocationDtoTest() {
+        EventDateLocationDto eventDateLocationDto = ModelUtils.getEventDateLocationDtoWithLinkAndCoordinates();
+
+        List<EventDateLocationDto> eventDateLocationDtoList = List.of(eventDateLocationDto);
+
+        EventDateLocation dto = EventDateLocation.builder().id(eventDateLocationDto.getId())
+                .startDate(eventDateLocationDto.getStartDate()).finishDate(eventDateLocationDto.getFinishDate())
+                .address(addressDtoMapper.convert(eventDateLocationDto.getCoordinates()))
+                .onlineLink(eventDateLocationDto.getOnlineLink()).build();
+
+        List<EventDateLocation> expectedList = List.of(dto);
+        assertEquals(expectedList, mapper.mapAllToList(eventDateLocationDtoList));
     }
 }

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -168,7 +168,8 @@ class EventServiceImplTest {
         when(modelMapper.map(ModelUtils.getAddressLatLngResponse(), AddressDto.class)).thenReturn(build);
         when(eventRepo.findFavoritesAmongEventIds(eventIds, user.getId())).thenReturn(List.of(event));
         when(eventRepo.findSubscribedAmongEventIds(eventIds, user.getId())).thenReturn(List.of());
-        when(eventDateLocationDtoMapper.mapAllToList(addEventDtoRequest.getDatesLocations())).thenReturn(event.getDates());
+        when(eventDateLocationDtoMapper.mapAllToList(addEventDtoRequest.getDatesLocations()))
+            .thenReturn(event.getDates());
 
         EventDto resultEventDto = eventService.save(addEventDtoRequest, user.getEmail(), null);
         assertEquals(eventDto, resultEventDto);
@@ -216,9 +217,10 @@ class EventServiceImplTest {
         EventDto eventDto = ModelUtils.getEventDtoWithoutAddress();
         MultipartFile[] multipartFiles = ModelUtils.getMultipartFiles();
 
-        when(eventDateLocationDtoMapper.mapAllToList(addEventDtoRequest.getDatesLocations())).thenReturn(event.getDates());
+        when(eventDateLocationDtoMapper.mapAllToList(addEventDtoRequest.getDatesLocations()))
+            .thenReturn(event.getDates());
         when(googleApiService.getResultFromGeoCodeByCoordinates(any()))
-                .thenReturn(ModelUtils.getAddressLatLngResponse());
+            .thenReturn(ModelUtils.getAddressLatLngResponse());
         when(modelMapper.map(ModelUtils.getAddressLatLngResponse(), AddressDto.class)).thenReturn(addressDto);
         when(modelMapper.map(addEventDtoRequest, Event.class)).thenReturn(event);
         when(restClient.findByEmail(anyString())).thenReturn(testUserVo);
@@ -233,7 +235,7 @@ class EventServiceImplTest {
         when(fileService.upload(multipartFiles[1])).thenReturn("/url2");
 
         assertEquals(eventDto,
-                eventService.save(addEventDtoRequest, ModelUtils.getUser().getEmail(), multipartFiles));
+            eventService.save(addEventDtoRequest, ModelUtils.getUser().getEmail(), multipartFiles));
     }
 
     @Test


### PR DESCRIPTION
# GreenCity PR
## Issue Link 📋
https://github.com/ita-social-projects/GreenCity/issues/7847

## Added

- Added test for EventServiceImpl for saving online events;
- Added method _mapAllToList_ into EventDateLocationDtoMapper class;
- Added necessary test in EventDateLocationDtoMapperTest class;
- Added _getEventDateLocationDtoWithLinkAndCoordinates_ method into ModelUtils class in service module;

## Changed

- Changed functionality for validation coordinates for online events in _validateCoordinates_ method in the EventServiceImpl class;

## Summary Of Changes 🔥
Improvement according to task https://github.com/ita-social-projects/GreenCity/issues/7847;
Now if you try to save an online event the coordinates are not necessary as it was before. If the event is OFFLINE or ONLINE_OFFLINE, coordinates should be passed.