### PR TITLE
Add functionality to change "isCustom" status of a Habit on Admin Panel

### DIFF
--- a/core/src/main/java/greencity/webcontroller/ManagementHabitController.java
+++ b/core/src/main/java/greencity/webcontroller/ManagementHabitController.java
@@ -226,4 +226,22 @@ public class ManagementHabitController {
         managementHabitService.switchIsDeletedStatus(id, newStatus);
         return ResponseEntity.status(HttpStatus.OK).body(id);
     }
+
+    /**
+     * Method toggles the status of a Habit from "isCustom" to true or false.
+     *
+     * @param id {@link HabitDto}'s id.
+     * @return {@link ResponseEntity}.
+     */
+    @Operation(summary = "Toggle the isCustom status of a Habit.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN)
+    })
+    @PatchMapping("/switch-custom-status/{id}")
+    public ResponseEntity<Long> switchIsCustomStatus(@PathVariable("id") Long id, @RequestBody Boolean newStatus) {
+        managementHabitService.switchIsCustomStatus(id, newStatus);
+        return ResponseEntity.status(HttpStatus.OK).body(id);
+    }
 }

--- a/core/src/main/resources/templates/core/management_user_habits.html
+++ b/core/src/main/resources/templates/core/management_user_habits.html
@@ -244,14 +244,10 @@
                                     <td>
                                         <div class="pr" style="width: 27em">[[${translation.description}]]</div>
                                     </td>
-<!--                                    <td class="habit_isCustomHabit" th:text="${habit.isCustomHabit}"></td>-->
                                     <td class="habit_isCustomHabit">
                                         <select th:id="'status-isCustom-'+${habit.id}"
                                                 th:onchange="'toggleStatus('+${habit.id}+', \'/management/habits/switch-custom-status/'+${habit.id}+'\');'"
                                                 class="form-control">
-<!--                                        <select th:id="'status-'+${habit.id}"-->
-<!--                                                th:onchange="'toggleStatus('+${habit.id}+', \'/management/habits/switch-custom-status/'+${habit.id}+'\');'"-->
-<!--                                                class="form-control">-->
                                             <option th:if="${habit.isCustomHabit == null}" th:value="null" th:selected="true">Not Set</option>
                                             <option th:value="true" th:selected="${habit.isCustomHabit == true}">True</option>
                                             <option th:value="false" th:selected="${habit.isCustomHabit == false}">False</option>
@@ -262,9 +258,6 @@
                                         <select th:id="'status-isDeleted-'+${habit.id}"
                                                 th:onchange="'toggleStatus('+${habit.id}+', \'/management/habits/switch-deleted-status/'+${habit.id}+'\');'"
                                                 class="form-control">
-<!--                                        <select th:id="'status-'+${habit.id}"-->
-<!--                                                th:onchange="'toggleStatus('+${habit.id}+', \'/management/habits/switch-deleted-status/'+${habit.id}+'\');'"-->
-<!--                                                class="form-control">-->
                                             <option th:if="${habit.isDeleted == null}" th:value="null" th:selected="true">Not Set</option>
                                             <option th:value="true" th:selected="${habit.isDeleted == true}">True</option>
                                             <option th:value="false" th:selected="${habit.isDeleted == false}">False</option>

--- a/core/src/main/resources/templates/core/management_user_habits.html
+++ b/core/src/main/resources/templates/core/management_user_habits.html
@@ -244,9 +244,27 @@
                                     <td>
                                         <div class="pr" style="width: 27em">[[${translation.description}]]</div>
                                     </td>
-                                    <td class="habit_isCustomHabit" th:text="${habit.isCustomHabit}"></td>
+<!--                                    <td class="habit_isCustomHabit" th:text="${habit.isCustomHabit}"></td>-->
+                                    <td class="habit_isCustomHabit">
+                                        <select th:id="'status-isCustom-'+${habit.id}"
+                                                th:onchange="'toggleStatus('+${habit.id}+', \'/management/habits/switch-custom-status/'+${habit.id}+'\');'"
+                                                class="form-control">
+<!--                                        <select th:id="'status-'+${habit.id}"-->
+<!--                                                th:onchange="'toggleStatus('+${habit.id}+', \'/management/habits/switch-custom-status/'+${habit.id}+'\');'"-->
+<!--                                                class="form-control">-->
+                                            <option th:if="${habit.isCustomHabit == null}" th:value="null" th:selected="true">Not Set</option>
+                                            <option th:value="true" th:selected="${habit.isCustomHabit == true}">True</option>
+                                            <option th:value="false" th:selected="${habit.isCustomHabit == false}">False</option>
+                                        </select>
+                                    </td>
+
                                     <td class="habit_isDeleted">
-                                        <select th:id="'status-'+${habit.id}" th:onchange="'toggleStatus('+${habit.id}+');'" class="form-control">
+                                        <select th:id="'status-isDeleted-'+${habit.id}"
+                                                th:onchange="'toggleStatus('+${habit.id}+', \'/management/habits/switch-deleted-status/'+${habit.id}+'\');'"
+                                                class="form-control">
+<!--                                        <select th:id="'status-'+${habit.id}"-->
+<!--                                                th:onchange="'toggleStatus('+${habit.id}+', \'/management/habits/switch-deleted-status/'+${habit.id}+'\');'"-->
+<!--                                                class="form-control">-->
                                             <option th:if="${habit.isDeleted == null}" th:value="null" th:selected="true">Not Set</option>
                                             <option th:value="true" th:selected="${habit.isDeleted == true}">True</option>
                                             <option th:value="false" th:selected="${habit.isDeleted == false}">False</option>
@@ -865,8 +883,8 @@
     });
 </script>
 <script th:inline="javascript">
-    function toggleStatus(habitId) {
-        const selectElement = document.getElementById('status-' + habitId);
+    function toggleStatus(habitId, endpointUrl) {
+        const selectElement = document.getElementById(event.target.id);
         const selectedValue = selectElement.value;
 
         if (selectedValue === "null") {
@@ -876,7 +894,7 @@
 
         const newStatus = selectedValue === 'true';
 
-        fetch(`/management/habits/switch-deleted-status/${habitId}`, {
+        fetch(endpointUrl, {
             method: 'PATCH',
             headers: {
                 'Content-Type': 'application/json',
@@ -885,7 +903,7 @@
         })
             .then(response => {
                 if (response.ok) {
-                    updateDropdown(habitId, newStatus);
+                    updateDropdown(selectElement.id, newStatus);
                     alert('Status updated successfully');
                 } else {
                     alert('Failed to update status');
@@ -897,8 +915,8 @@
             });
     }
 
-    function updateDropdown(habitId, newStatus) {
-        const selectElement = document.getElementById('status-' + habitId);
+    function updateDropdown(selectElementId, newStatus) {
+        const selectElement = document.getElementById(selectElementId);
 
         selectElement.innerHTML = '';
 

--- a/core/src/test/java/greencity/webcontroller/ManagementHabitControllerTest.java
+++ b/core/src/test/java/greencity/webcontroller/ManagementHabitControllerTest.java
@@ -184,4 +184,17 @@ class ManagementHabitControllerTest {
 
         verify(managementHabitService).switchIsDeletedStatus(habitId, newStatus);
     }
+
+    @Test
+    void switchICustomStatusTest() throws Exception {
+        Long habitId = 1L;
+        Boolean newIsCustomStatus = true;
+
+        this.mockMvc.perform(MockMvcRequestBuilders.patch(habitManagementLink + "/switch-custom-status/" + habitId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(newIsCustomStatus.toString()))
+            .andExpect(status().isOk());
+
+        verify(managementHabitService).switchIsCustomStatus(habitId, newIsCustomStatus);
+    }
 }

--- a/service-api/src/main/java/greencity/service/ManagementHabitService.java
+++ b/service-api/src/main/java/greencity/service/ManagementHabitService.java
@@ -68,4 +68,15 @@ public interface ManagementHabitService {
      * @param newStatus the new `isDeleted` status, {@code true} or {@code false}.
      */
     void switchIsDeletedStatus(Long id, Boolean newStatus);
+
+    /**
+     * Updates the `isCustom` status of a {@code Habit}. If `isCustom` is
+     * {@code null}, it is set to the provided {@code newIsCustomStatus}. Otherwise,
+     * it is updated directly to {@code newIsCustomStatus}.
+     *
+     * @param id                the ID of the {@code Habit} to update.
+     * @param newIsCustomStatus the new `isCustom` status, {@code true} or
+     *                          {@code false}.
+     */
+    void switchIsCustomStatus(Long id, Boolean newIsCustomStatus);
 }

--- a/service/src/main/java/greencity/service/ManagementHabitServiceImpl.java
+++ b/service/src/main/java/greencity/service/ManagementHabitServiceImpl.java
@@ -230,6 +230,17 @@ public class ManagementHabitServiceImpl implements ManagementHabitService {
         habitRepo.save(habit);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void switchIsCustomStatus(Long id, Boolean newIsCustomStatus) {
+        Habit habit = habitRepo.findById(id)
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.HABIT_NOT_FOUND_BY_ID + id));
+        habit.setIsCustomHabit(newIsCustomStatus);
+        habitRepo.save(habit);
+    }
+
     private String getSortModel(Pageable pageable) {
         return pageable.getSort().stream()
             .map(order -> order.getProperty() + "," + order.getDirection())

--- a/service/src/test/java/greencity/service/ManagementHabitServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ManagementHabitServiceImplTest.java
@@ -314,4 +314,30 @@ class ManagementHabitServiceImplTest {
         assertThrows(NotFoundException.class, () -> managementHabitService.switchIsDeletedStatus(habitId, newStatus));
         verify(habitRepo).findById(habitId);
     }
+
+    @Test
+    void switchIsCustomStatusTest() {
+        Habit habit = getHabit();
+        habit.setIsCustomHabit(false);
+        Boolean newIsCustomStatus = true;
+
+        when(habitRepo.findById(anyLong())).thenReturn(Optional.of(habit));
+
+        managementHabitService.switchIsCustomStatus(1L, newIsCustomStatus);
+
+        assertTrue(habit.getIsCustomHabit());
+        verify(habitRepo).save(habit);
+    }
+
+    @Test
+    void switchIsCustomStatusWhenHabitIsNotFoundTest() {
+        Long habitId = 1L;
+        Boolean newIsCustomStatus = false;
+
+        when(habitRepo.findById(habitId)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class,
+            () -> managementHabitService.switchIsCustomStatus(habitId, newIsCustomStatus));
+        verify(habitRepo).findById(habitId);
+    }
 }


### PR DESCRIPTION
# GreenCity PR

## Issue Link :clipboard:
#7910

## Changed
*added endpoint to switch isCustom status of existing Habit in Admin Panel
*Added tests
*Added functionality on UI Admin Page to switch isCustom status of existing Habit
*Improved JS toggleStatus method

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `develop` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers