### PR TITLE
small fix 🤏

### DIFF
--- a/dao/src/main/java/greencity/entity/HabitInvitation.java
+++ b/dao/src/main/java/greencity/entity/HabitInvitation.java
@@ -35,6 +35,14 @@ public class HabitInvitation {
     @JoinColumn(name = "invitee_habit_assign_id", nullable = false)
     private HabitAssign inviteeHabitAssign;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "inviter_id", nullable = false)
+    private User inviter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invitee_id", nullable = false)
+    private User invitee;
+
     @Enumerated(EnumType.STRING)
     private HabitInvitationStatus status;
 }

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -255,4 +255,5 @@
     <include file="db/changelog/logs/ch-habits-users-dislikes-table.xml"/>
     <include file="db/changelog/logs/сh-update-habit-invitation-statuses.xml"/>
     <include file="db/changelog/logs/ch-remove-duplicates-from-habit-invitations.xml"/>
+    <include file="db/changelog/logs/ch-add-invitee-id-and-inviter-id-to-habit-invite-table.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-add-invitee-id-and-inviter-id-to-habit-invite-table.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-add-invitee-id-and-inviter-id-to-habit-invite-table.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="add-inviter-invitee-user-columns" author="Ivan Holotsvan">
+        <addColumn tableName="habit_invitations">
+            <column name="inviter_id" type="BIGINT"/>
+            <column name="invitee_id" type="BIGINT"/>
+        </addColumn>
+
+        <addForeignKeyConstraint
+                baseTableName="habit_invitations"
+                baseColumnNames="inviter_id"
+                referencedTableName="users"
+                referencedColumnNames="id"
+                constraintName="fk_habit_invitations_inviter_user"/>
+
+        <addForeignKeyConstraint
+                baseTableName="habit_invitations"
+                baseColumnNames="invitee_id"
+                referencedTableName="users"
+                referencedColumnNames="id"
+                constraintName="fk_habit_invitations_invitee_user"/>
+    </changeSet>
+
+    <changeSet id="populate-inviter-invitee-user-columns" author="Ivan Holotsvan">
+        <sql>
+            UPDATE habit_invitations hi
+            SET inviter_id = ha.user_id
+                FROM habit_assign ha
+            WHERE hi.inviter_habit_assign_id = ha.id
+              AND hi.inviter_id IS NULL;
+        </sql>
+
+        <sql>
+            UPDATE habit_invitations hi
+            SET invitee_id = ha.user_id
+                FROM habit_assign ha
+            WHERE hi.invitee_habit_assign_id = ha.id
+              AND hi.invitee_id IS NULL;
+        </sql>
+    </changeSet>
+
+    <changeSet id="make-inviter-invitee-columns-not-null" author="Ivan Holotsvan">
+        <addNotNullConstraint tableName="habit_invitations" columnName="inviter_id"/>
+        <addNotNullConstraint tableName="habit_invitations" columnName="invitee_id"/>
+    </changeSet>
+</databaseChangeLog>

--- a/service/src/main/java/greencity/service/HabitAssignServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitAssignServiceImpl.java
@@ -1646,6 +1646,8 @@ public class HabitAssignServiceImpl implements HabitAssignService {
         return HabitInvitation.builder()
             .inviteeHabitAssign(inviteeHabitAssign)
             .inviterHabitAssign(inviterHabitAssign)
+            .inviter(inviterHabitAssign.getUser())
+            .invitee(inviteeHabitAssign.getUser())
             .status(HabitInvitationStatus.PENDING)
             .build();
     }


### PR DESCRIPTION
I have forgotten that columns inviter_id, invitee_id are only in my local db 😅
+ liquibase changeset to add columns that was mentioned earlier, map invites that was created before to fill this new fields 
+ add check that User friends who have such habit in progress also would be "disabled" to invite (before if we was trying to invite firend who have habit in progress we was getting an error).

User B has assigned “Compost Organic wastes”
User A has Invited “User C” to “Compost Organic wastes”

![image](https://github.com/user-attachments/assets/61d8912b-4a15-49c4-9a31-b27e8f2b4c49)

User B is disabled because he already has this habit in progress
User C is disabled because he was invited by user A


User A didn't invite anyone to habit
![image](https://github.com/user-attachments/assets/07efaff0-b573-43c9-816e-f6fc49110a51)


User A invited user C to habit
![image](https://github.com/user-attachments/assets/f16092e5-1758-4121-9bdd-a38a8ad71546)
 