### PR TITLE
Bugfix/6957/fix update response event method

### DIFF
--- a/core/src/main/java/greencity/controller/EventsController.java
+++ b/core/src/main/java/greencity/controller/EventsController.java
@@ -105,7 +105,8 @@ public class EventsController {
     @PutMapping(value = "/update",
         consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_UTF8_VALUE})
     public ResponseEntity<EventDto> update(
-        @ApiParam(required = true, value = SwaggerExampleModel.UPDATE_EVENT) @RequestPart UpdateEventDto eventDto,
+        @ApiParam(required = true,
+            value = SwaggerExampleModel.UPDATE_EVENT) @ValidEventDtoRequest @RequestPart UpdateEventDto eventDto,
         @ApiIgnore Principal principal,
         @RequestPart(required = false) @Nullable MultipartFile[] images) {
         return ResponseEntity.status(HttpStatus.OK).body(

--- a/core/src/main/java/greencity/validator/EventDtoRequestValidator.java
+++ b/core/src/main/java/greencity/validator/EventDtoRequestValidator.java
@@ -34,7 +34,7 @@ public class EventDtoRequestValidator implements ConstraintValidator<ValidEventD
             }
 
             for (var eventDateLocationDto : eventDateLocationDtos) {
-                if (!validateEventDateLocation(eventDateLocationDto, context)) {
+                if (!isValidEventDateLocation(eventDateLocationDto, context)) {
                     return false;
                 }
 
@@ -63,7 +63,7 @@ public class EventDtoRequestValidator implements ConstraintValidator<ValidEventD
             List<EventDateLocationDto> eventDateLocationDtos = updateEventDto.getDatesLocations();
 
             for (var eventDateLocationDto : eventDateLocationDtos) {
-                if (!validateEventDateLocation(eventDateLocationDto, context)) {
+                if (!isValidEventDateLocation(eventDateLocationDto, context)) {
                     return false;
                 }
             }
@@ -74,7 +74,7 @@ public class EventDtoRequestValidator implements ConstraintValidator<ValidEventD
         return false;
     }
 
-    private boolean validateEventDateLocation(EventDateLocationDto eventDateLocationDto,
+    private boolean isValidEventDateLocation(EventDateLocationDto eventDateLocationDto,
         ConstraintValidatorContext context) {
         if (eventDateLocationDto.getStartDate() == null) {
             context.buildConstraintViolationWithTemplate(ErrorMessage.EMPTY_START_DATE)

--- a/core/src/main/java/greencity/validator/EventDtoRequestValidator.java
+++ b/core/src/main/java/greencity/validator/EventDtoRequestValidator.java
@@ -6,49 +6,89 @@ import greencity.constant.ValidationConstants;
 import greencity.dto.event.AddEventDtoRequest;
 import greencity.dto.event.AddressDto;
 import greencity.dto.event.EventDateLocationDto;
+import greencity.dto.event.UpdateEventDto;
 import greencity.exception.exceptions.EventDtoValidationException;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.time.ZonedDateTime;
+import java.util.List;
 
 import static greencity.validator.UrlValidator.isUrlValid;
 
-import java.time.ZonedDateTime;
-import java.util.List;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-
-public class EventDtoRequestValidator implements ConstraintValidator<ValidEventDtoRequest, AddEventDtoRequest> {
+public class EventDtoRequestValidator implements ConstraintValidator<ValidEventDtoRequest, Object> {
     @Override
     public void initialize(ValidEventDtoRequest constraintAnnotation) {
         // Initializes the validator in preparation for #isValid calls
     }
 
     @Override
-    public boolean isValid(AddEventDtoRequest value, ConstraintValidatorContext context) {
-        List<EventDateLocationDto> eventDateLocationDtos = value.getDatesLocations();
+    public boolean isValid(Object value, ConstraintValidatorContext context) {
+        if (value instanceof AddEventDtoRequest) {
+            AddEventDtoRequest addEventDtoRequest = (AddEventDtoRequest) value;
+            List<EventDateLocationDto> eventDateLocationDtos = addEventDtoRequest.getDatesLocations();
 
-        if (eventDateLocationDtos == null || eventDateLocationDtos.isEmpty()
-            || eventDateLocationDtos.size() > ValidationConstants.MAX_EVENT_DATES_AMOUNT) {
-            throw new EventDtoValidationException(ErrorMessage.WRONG_COUNT_OF_EVENT_DATES);
+            if (eventDateLocationDtos == null || eventDateLocationDtos.isEmpty()
+                || eventDateLocationDtos.size() > ValidationConstants.MAX_EVENT_DATES_AMOUNT) {
+                throw new EventDtoValidationException(ErrorMessage.WRONG_COUNT_OF_EVENT_DATES);
+            }
+
+            for (var eventDateLocationDto : eventDateLocationDtos) {
+                if (!validateEventDateLocation(eventDateLocationDto, context)) {
+                    return false;
+                }
+
+                if (eventDateLocationDto.getStartDate().isBefore(ZonedDateTime.now())
+                    || eventDateLocationDto.getStartDate().isAfter(eventDateLocationDto.getFinishDate())) {
+                    throw new EventDtoValidationException(ErrorMessage.EVENT_START_DATE_AFTER_FINISH_DATE_OR_IN_PAST);
+                }
+
+                AddressDto addressDto = eventDateLocationDto.getCoordinates();
+                String onlineLink = eventDateLocationDto.getOnlineLink();
+                if (onlineLink == null && addressDto == null) {
+                    throw new EventDtoValidationException(ErrorMessage.NO_EVENT_LINK_OR_ADDRESS);
+                }
+                if (onlineLink != null) {
+                    isUrlValid(onlineLink);
+                }
+            }
+
+            if (addEventDtoRequest.getTags().size() > ValidationConstants.MAX_AMOUNT_OF_TAGS) {
+                throw new EventDtoValidationException(ErrorMessage.WRONG_COUNT_OF_TAGS_EXCEPTION);
+            }
+
+            return true;
+        } else if (value instanceof UpdateEventDto) {
+            UpdateEventDto updateEventDto = (UpdateEventDto) value;
+            List<EventDateLocationDto> eventDateLocationDtos = updateEventDto.getDatesLocations();
+
+            for (var eventDateLocationDto : eventDateLocationDtos) {
+                if (!validateEventDateLocation(eventDateLocationDto, context)) {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
-        for (var eventDateLocationDto : eventDateLocationDtos) {
-            if (eventDateLocationDto.getStartDate().isBefore(ZonedDateTime.now())
-                || eventDateLocationDto.getStartDate().isAfter(eventDateLocationDto.getFinishDate())) {
-                throw new EventDtoValidationException(ErrorMessage.EVENT_START_DATE_AFTER_FINISH_DATE_OR_IN_PAST);
-            }
-            AddressDto addressDto = eventDateLocationDto.getCoordinates();
-            String onlineLink = eventDateLocationDto.getOnlineLink();
-            if (onlineLink == null && addressDto == null) {
-                throw new EventDtoValidationException(ErrorMessage.NO_EVENT_LINK_OR_ADDRESS);
-            }
-            if (onlineLink != null) {
-                isUrlValid(onlineLink);
-            }
+        return false;
+    }
+
+    private boolean validateEventDateLocation(EventDateLocationDto eventDateLocationDto,
+        ConstraintValidatorContext context) {
+        if (eventDateLocationDto.getStartDate() == null) {
+            context.buildConstraintViolationWithTemplate(ErrorMessage.EMPTY_START_DATE)
+                .addPropertyNode("startDate")
+                .addConstraintViolation();
+            return false;
         }
 
-        if (value.getTags().size() > ValidationConstants.MAX_AMOUNT_OF_TAGS) {
-            throw new EventDtoValidationException(ErrorMessage.WRONG_COUNT_OF_TAGS_EXCEPTION);
+        if (eventDateLocationDto.getFinishDate() == null) {
+            context.buildConstraintViolationWithTemplate(ErrorMessage.EMPTY_FINISH_DATE)
+                .addPropertyNode("finishDate")
+                .addConstraintViolation();
+            return false;
         }
-
         return true;
     }
 }

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -156,6 +156,8 @@ public final class ErrorMessage {
     public static final String USER_HAS_BLOCKED_STATUS = "User has blocked status.";
     public static final String WRONG_DATE_TIME_FORMAT =
         "The date format is wrong. Should matches " + AppConstant.DATE_FORMAT;
+    public static final String EMPTY_START_DATE = "Start date can't be empty";
+    public static final String EMPTY_FINISH_DATE = "Finish date can't be empty";
     public static final String INVALID_DATE_RANGE = "The 'From' date must be earlier than the 'To' date";
     public static final String SELECT_CORRECT_LANGUAGE = "Select correct language: 'en' or 'ua'";
     public static final String INVALID_HABIT_ID = "Invalid habit id ";

--- a/service-api/src/main/java/greencity/dto/event/UpdateEventDto.java
+++ b/service-api/src/main/java/greencity/dto/event/UpdateEventDto.java
@@ -19,7 +19,7 @@ public class UpdateEventDto {
     @Size(min = 20, max = 63206)
     private String description;
 
-    @Max(7)
+    @Size(max = 7)
     private List<EventDateLocationDto> datesLocations;
 
     private String titleImage;


### PR DESCRIPTION
GreenCity PR

Issue Link:
[6957](https://github.com/orgs/ita-social-projects/projects/43/views/1?filterQuery=label%3AAPI&pane=issue&itemId=69330933&issue=ita-social-projects%7CGreenCity%7C6957)

Changes:

    Added logic to validate that startDate and finishDate are not empty when updating an event.
    Added new error messages.
    Fixed the API response to properly handle errors.

Current Behavior:

    The response now indicates when startDate or finishDate are not provided.
    
    
![image](https://github.com/user-attachments/assets/3efbf2c1-17ab-4fe9-b242-854a19314e3f)
