### PR TITLE
Changed dynamic content localization in notifications

### DIFF
--- a/service/src/main/java/greencity/service/CommentServiceImpl.java
+++ b/service/src/main/java/greencity/service/CommentServiceImpl.java
@@ -53,7 +53,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -316,18 +315,10 @@ public class CommentServiceImpl implements CommentService {
      */
     private void createCommentNotification(ArticleType articleType, Long articleId, UserVO userVO, Locale locale) {
         UserVO receiver = modelMapper.map(getArticleAuthor(articleType, articleId), UserVO.class);
-        String message = null;
-        ResourceBundle bundle = ResourceBundle.getBundle("notification",
-            Locale.forLanguageTag(locale.getLanguage()),
-            ResourceBundle.Control.getNoFallbackControl(ResourceBundle.Control.FORMAT_DEFAULT));
         long commentsCount = notificationRepo
             .countActionUsersByTargetUserIdAndNotificationTypeAndTargetIdAndViewedIsFalse(receiver.getId(),
                 getNotificationType(articleType, CommentActionType.COMMENT), articleId);
-        if (commentsCount >= 1) {
-            message = (commentsCount + 1) + " " + bundle.getString("COMMENTS");
-        } else if (commentsCount == 0) {
-            message = bundle.getString("COMMENT");
-        }
+        String message = (commentsCount >= 1) ? (commentsCount + 1) + " COMMENTS" : "COMMENT";
         userNotificationService.createNotification(
             receiver,
             userVO,
@@ -374,21 +365,13 @@ public class CommentServiceImpl implements CommentService {
      */
     private void createCommentReplyNotification(ArticleType articleType, Long articleId, Comment comment,
         UserVO sender, UserVO receiver, Locale locale) {
-        ResourceBundle bundle = ResourceBundle.getBundle("notification",
-            Locale.forLanguageTag(locale.getLanguage()),
-            ResourceBundle.Control.getNoFallbackControl(ResourceBundle.Control.FORMAT_DEFAULT));
         long replyCount = notificationRepo
             .countUnviewedRepliesByTargetAndParent(
                 receiver.getId(),
                 getNotificationType(articleType, CommentActionType.COMMENT_REPLY),
                 articleId,
                 comment.getParentComment().getId());
-        String message;
-        if (replyCount >= 1) {
-            message = (replyCount + 1) + " " + bundle.getString("REPLIES");
-        } else {
-            message = bundle.getString("REPLY");
-        }
+        String message = (replyCount >= 1) ?  (replyCount + 1) + " REPLIES" : "REPLY";
         userNotificationService.createNotification(
             receiver,
             sender,

--- a/service/src/main/java/greencity/service/CommentServiceImpl.java
+++ b/service/src/main/java/greencity/service/CommentServiceImpl.java
@@ -371,7 +371,7 @@ public class CommentServiceImpl implements CommentService {
                 getNotificationType(articleType, CommentActionType.COMMENT_REPLY),
                 articleId,
                 comment.getParentComment().getId());
-        String message = (replyCount >= 1) ?  (replyCount + 1) + " REPLIES" : "REPLY";
+        String message = (replyCount >= 1) ? (replyCount + 1) + " REPLIES" : "REPLY";
         userNotificationService.createNotification(
             receiver,
             sender,

--- a/service/src/main/java/greencity/service/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/NotificationServiceImpl.java
@@ -39,6 +39,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import static greencity.utils.NotificationUtils.resolveTimesInEnglish;
 import static greencity.utils.NotificationUtils.resolveTimesInUkrainian;
+import static greencity.utils.NotificationUtils.isMessageLocalizationRequired;
+import static greencity.utils.NotificationUtils.localizeMessage;
 
 @Slf4j
 @Service
@@ -349,8 +351,9 @@ public class NotificationServiceImpl implements NotificationService {
     private ScheduledEmailMessage createScheduledEmailMessage(Notification notification, String language) {
         ResourceBundle bundle = ResourceBundle.getBundle("notification", Locale.forLanguageTag(language),
             ResourceBundle.Control.getNoFallbackControl(ResourceBundle.Control.FORMAT_DEFAULT));
-        String subject = bundle.getString(notification.getNotificationType() + "_TITLE");
-        String bodyTemplate = bundle.getString(notification.getNotificationType().toString());
+        String notificationType = notification.getNotificationType().toString();
+        String subject = bundle.getString(notificationType + "_TITLE");
+        String bodyTemplate = bundle.getString(notificationType);
         String actionUserText;
         long actionUsersSize = notification.getActionUsers().stream().distinct().toList().size();
         if (actionUsersSize > 1) {
@@ -361,6 +364,9 @@ public class NotificationServiceImpl implements NotificationService {
             actionUserText = "";
         }
         String customMessage = notification.getCustomMessage() != null ? notification.getCustomMessage() : "";
+        if (!customMessage.isEmpty() && isMessageLocalizationRequired(notificationType)) {
+            customMessage = localizeMessage(customMessage, bundle);
+        }
         String secondMessage = notification.getSecondMessage() != null ? notification.getSecondMessage() : "";
         int messagesCount = notification.getActionUsers().size();
         String times = language.equals("ua")

--- a/service/src/main/java/greencity/service/UserNotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/UserNotificationServiceImpl.java
@@ -34,6 +34,8 @@ import java.util.Optional;
 import java.util.ResourceBundle;
 import static greencity.utils.NotificationUtils.resolveTimesInEnglish;
 import static greencity.utils.NotificationUtils.resolveTimesInUkrainian;
+import static greencity.utils.NotificationUtils.isMessageLocalizationRequired;
+import static greencity.utils.NotificationUtils.localizeMessage;
 
 /**
  * Implementation of {@link UserNotificationService}.
@@ -467,30 +469,5 @@ public class UserNotificationServiceImpl implements UserNotificationService {
             .secondMessage(secondMessageText)
             .emailSent(false)
             .build();
-    }
-
-    private boolean isMessageLocalizationRequired(String notificationType) {
-        return switch (notificationType) {
-            case "ECONEWS_COMMENT_REPLY", "ECONEWS_COMMENT",
-                 "EVENT_COMMENT_REPLY", "EVENT_COMMENT",
-                 "HABIT_COMMENT", "HABIT_COMMENT_REPLY" -> true;
-            default -> false;
-        };
-    }
-
-    private String localizeMessage(String message, ResourceBundle bundle) {
-        if (message.contains("REPLIES")) {
-            message = message.replace("REPLIES", bundle.getString("REPLIES"));
-        }
-        if (message.contains("REPLY")) {
-            message = message.replace("REPLY", bundle.getString("REPLY"));
-        }
-        if (message.contains("COMMENTS")) {
-            message = message.replace("COMMENTS", bundle.getString("COMMENTS"));
-        }
-        if (message.contains("COMMENT")) {
-            message = message.replace("COMMENT", bundle.getString("COMMENT"));
-        }
-        return message;
     }
 }

--- a/service/src/main/java/greencity/utils/NotificationUtils.java
+++ b/service/src/main/java/greencity/utils/NotificationUtils.java
@@ -6,6 +6,11 @@ import java.util.ResourceBundle;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class NotificationUtils {
+    private static final String REPLIES = "REPLIES";
+    private static final String REPLY = "REPLY";
+    private static final String COMMENTS = "COMMENTS";
+    private static final String COMMENT = "COMMENT";
+
     public static String resolveTimesInEnglish(final int number) {
         return switch (number) {
             case 1 -> "";
@@ -44,17 +49,17 @@ public class NotificationUtils {
     }
 
     public static String localizeMessage(String message, ResourceBundle bundle) {
-        if (message.contains("REPLIES")) {
-            message = message.replace("REPLIES", bundle.getString("REPLIES"));
+        if (message.contains(REPLIES)) {
+            message = message.replace(REPLIES, bundle.getString(REPLIES));
         }
-        if (message.contains("REPLY")) {
-            message = message.replace("REPLY", bundle.getString("REPLY"));
+        if (message.contains(REPLY)) {
+            message = message.replace(REPLY, bundle.getString(REPLY));
         }
-        if (message.contains("COMMENTS")) {
-            message = message.replace("COMMENTS", bundle.getString("COMMENTS"));
+        if (message.contains(COMMENTS)) {
+            message = message.replace(COMMENTS, bundle.getString(COMMENTS));
         }
-        if (message.contains("COMMENT")) {
-            message = message.replace("COMMENT", bundle.getString("COMMENT"));
+        if (message.contains(COMMENT)) {
+            message = message.replace(COMMENT, bundle.getString(COMMENT));
         }
         return message;
     }

--- a/service/src/main/java/greencity/utils/NotificationUtils.java
+++ b/service/src/main/java/greencity/utils/NotificationUtils.java
@@ -2,6 +2,7 @@ package greencity.utils;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import java.util.ResourceBundle;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class NotificationUtils {
@@ -31,5 +32,30 @@ public class NotificationUtils {
             case 2, 3, 4 -> number + " рази";
             default -> number + " разів";
         };
+    }
+
+    public static boolean isMessageLocalizationRequired(String notificationType) {
+        return switch (notificationType) {
+            case "ECONEWS_COMMENT_REPLY", "ECONEWS_COMMENT",
+                 "EVENT_COMMENT_REPLY", "EVENT_COMMENT",
+                 "HABIT_COMMENT", "HABIT_COMMENT_REPLY" -> true;
+            default -> false;
+        };
+    }
+
+    public static String localizeMessage(String message, ResourceBundle bundle) {
+        if (message.contains("REPLIES")) {
+            message = message.replace("REPLIES", bundle.getString("REPLIES"));
+        }
+        if (message.contains("REPLY")) {
+            message = message.replace("REPLY", bundle.getString("REPLY"));
+        }
+        if (message.contains("COMMENTS")) {
+            message = message.replace("COMMENTS", bundle.getString("COMMENTS"));
+        }
+        if (message.contains("COMMENT")) {
+            message = message.replace("COMMENT", bundle.getString("COMMENT"));
+        }
+        return message;
     }
 }

--- a/service/src/main/java/greencity/utils/NotificationUtils.java
+++ b/service/src/main/java/greencity/utils/NotificationUtils.java
@@ -37,8 +37,8 @@ public class NotificationUtils {
     public static boolean isMessageLocalizationRequired(String notificationType) {
         return switch (notificationType) {
             case "ECONEWS_COMMENT_REPLY", "ECONEWS_COMMENT",
-                 "EVENT_COMMENT_REPLY", "EVENT_COMMENT",
-                 "HABIT_COMMENT", "HABIT_COMMENT_REPLY" -> true;
+                "EVENT_COMMENT_REPLY", "EVENT_COMMENT",
+                "HABIT_COMMENT", "HABIT_COMMENT_REPLY" -> true;
             default -> false;
         };
     }

--- a/service/src/main/resources/notification.properties
+++ b/service/src/main/resources/notification.properties
@@ -1,6 +1,6 @@
 USERS=users
 
-COMMENT=comment
+COMMENT=a comment
 COMMENTS=comments
 
 REPLY=a reply

--- a/service/src/test/java/greencity/utils/NotificationUtilsTest.java
+++ b/service/src/test/java/greencity/utils/NotificationUtilsTest.java
@@ -4,9 +4,15 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import java.util.stream.Stream;
+import java.util.ResourceBundle;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class NotificationUtilsTest {
+    private static final ResourceBundle uaBundle = ResourceBundle.getBundle("notification_ua");
+    private static final ResourceBundle defaultBundle = ResourceBundle.getBundle("notification");
+
     @ParameterizedTest(name = "Test resolveTimeInUkrainian with input {0}")
     @MethodSource("provideUkrainianTestCases")
     void testResolveTimeInUkrainian(int input, String expected) {
@@ -47,5 +53,65 @@ class NotificationUtilsTest {
             Arguments.of(5, "5 times"),
             Arguments.of(11, "11 times"),
             Arguments.of(21, "21 times"));
+    }
+
+    @ParameterizedTest(name = "Test isMessageLocalizationRequired for valid notification type {0}")
+    @MethodSource("provideValidNotificationTypes")
+    void isMessageLocalizationRequiredForValidNotificationTypeTest(String notificationType) {
+        assertTrue(NotificationUtils.isMessageLocalizationRequired(notificationType));
+    }
+
+    private static Stream<String> provideValidNotificationTypes() {
+        return Stream.of(
+            "ECONEWS_COMMENT_REPLY", "ECONEWS_COMMENT",
+            "EVENT_COMMENT_REPLY", "EVENT_COMMENT",
+            "HABIT_COMMENT", "HABIT_COMMENT_REPLY"
+        );
+    }
+
+    @ParameterizedTest(name = "Test isMessageLocalizationRequired for invalid notification type {0}")
+    @MethodSource("provideInvalidNotificationTypes")
+    void isMessageLocalizationRequiredForInvalidNotificationTypeTest(String notificationType) {
+        assertFalse(NotificationUtils.isMessageLocalizationRequired(notificationType));
+    }
+
+    private static Stream<String> provideInvalidNotificationTypes() {
+        return Stream.of(
+            "ECONEWS_LIKE", "EVENT_COMMENT_LIKE", "HABIT_COMMENT_USER_TAG"
+        );
+    }
+
+    @ParameterizedTest(name = "Test localizeMessage for input {0}")
+    @MethodSource("provideUkrainianLocalizationTestCases")
+    void localizeMessageInUaTest(String input, String expected) {
+        String localizedMessage = NotificationUtils.localizeMessage(input, uaBundle);
+        assertEquals(expected, localizedMessage);
+    }
+
+    private static Stream<Arguments> provideUkrainianLocalizationTestCases() {
+        return Stream.of(
+            Arguments.of("COMMENT", "коментар"),
+            Arguments.of("5 COMMENTS", "5 коментарів"),
+            Arguments.of("REPLY", "відповідь"),
+            Arguments.of("2 REPLIES", "2 відповіді"),
+            Arguments.of("comment", "comment")
+        );
+    }
+
+    @ParameterizedTest(name = "Test localizeMessage for input {0}")
+    @MethodSource("provideDefaultLocalizationTestCases")
+    void localizeMessageInDefaultTest(String input, String expected) {
+        String localizedMessage = NotificationUtils.localizeMessage(input, defaultBundle);
+        assertEquals(expected, localizedMessage);
+    }
+
+    private static Stream<Arguments> provideDefaultLocalizationTestCases() {
+        return Stream.of(
+            Arguments.of("COMMENT", "a comment"),
+            Arguments.of("5 COMMENTS", "5 comments"),
+            Arguments.of("REPLY", "a reply"),
+            Arguments.of("2 REPLIES", "2 replies"),
+            Arguments.of("comment", "comment")
+        );
     }
 }

--- a/service/src/test/java/greencity/utils/NotificationUtilsTest.java
+++ b/service/src/test/java/greencity/utils/NotificationUtilsTest.java
@@ -65,8 +65,7 @@ class NotificationUtilsTest {
         return Stream.of(
             "ECONEWS_COMMENT_REPLY", "ECONEWS_COMMENT",
             "EVENT_COMMENT_REPLY", "EVENT_COMMENT",
-            "HABIT_COMMENT", "HABIT_COMMENT_REPLY"
-        );
+            "HABIT_COMMENT", "HABIT_COMMENT_REPLY");
     }
 
     @ParameterizedTest(name = "Test isMessageLocalizationRequired for invalid notification type {0}")
@@ -77,8 +76,7 @@ class NotificationUtilsTest {
 
     private static Stream<String> provideInvalidNotificationTypes() {
         return Stream.of(
-            "ECONEWS_LIKE", "EVENT_COMMENT_LIKE", "HABIT_COMMENT_USER_TAG"
-        );
+            "ECONEWS_LIKE", "EVENT_COMMENT_LIKE", "HABIT_COMMENT_USER_TAG");
     }
 
     @ParameterizedTest(name = "Test localizeMessage for input {0}")
@@ -94,8 +92,7 @@ class NotificationUtilsTest {
             Arguments.of("5 COMMENTS", "5 коментарів"),
             Arguments.of("REPLY", "відповідь"),
             Arguments.of("2 REPLIES", "2 відповіді"),
-            Arguments.of("comment", "comment")
-        );
+            Arguments.of("comment", "comment"));
     }
 
     @ParameterizedTest(name = "Test localizeMessage for input {0}")
@@ -111,7 +108,6 @@ class NotificationUtilsTest {
             Arguments.of("5 COMMENTS", "5 comments"),
             Arguments.of("REPLY", "a reply"),
             Arguments.of("2 REPLIES", "2 replies"),
-            Arguments.of("comment", "comment")
-        );
+            Arguments.of("comment", "comment"));
     }
 }


### PR DESCRIPTION
### Issue Link
[#7968 ](https://github.com/ita-social-projects/GreenCity/issues/7968)

### Summary of change
**Now** a user can see the amount of comments or replies in other language than English:

![image](https://github.com/user-attachments/assets/72962c64-6bb5-4646-a168-53a667094271)

**Before:** 

![image](https://github.com/user-attachments/assets/f1fe3c8d-ded7-4051-adfc-614db71c83a9)
