### PR TITLE
Fixed sorting of users in friends service

### DIFF
--- a/dao/src/main/java/greencity/repository/impl/CustomUserRepoImpl.java
+++ b/dao/src/main/java/greencity/repository/impl/CustomUserRepoImpl.java
@@ -26,17 +26,17 @@ public class CustomUserRepoImpl implements CustomUserRepo {
         List<User> users) {
         Objects.requireNonNull(users);
 
+        if (users.isEmpty()) {
+            return Collections.emptyList();
+        }
+
         TypedQuery<UserFriendDto> query = entityManager
             .createNamedQuery("User.fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser",
                 UserFriendDto.class);
         query.setParameter("userId", userId);
 
-        List<Long> userIds;
-        if (users.isEmpty()) {
-            userIds = Collections.singletonList(-1L);
-        } else {
-            userIds = users.stream().map(User::getId).collect(Collectors.toList());
-        }
+        List<Long> userIds = users.stream().map(User::getId).collect(Collectors.toList());
+
         query.setParameter("users", userIds);
 
         List<UserFriendDto> resultList = query.getResultList();

--- a/dao/src/main/java/greencity/repository/impl/CustomUserRepoImpl.java
+++ b/dao/src/main/java/greencity/repository/impl/CustomUserRepoImpl.java
@@ -3,13 +3,13 @@ package greencity.repository.impl;
 import greencity.dto.friends.UserFriendDto;
 import greencity.entity.User;
 import greencity.repository.CustomUserRepo;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 

--- a/dao/src/main/java/greencity/repository/impl/CustomUserRepoImpl.java
+++ b/dao/src/main/java/greencity/repository/impl/CustomUserRepoImpl.java
@@ -3,6 +3,7 @@ package greencity.repository.impl;
 import greencity.dto.friends.UserFriendDto;
 import greencity.entity.User;
 import greencity.repository.CustomUserRepo;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import jakarta.persistence.EntityManager;
@@ -29,12 +30,22 @@ public class CustomUserRepoImpl implements CustomUserRepo {
             .createNamedQuery("User.fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser",
                 UserFriendDto.class);
         query.setParameter("userId", userId);
+
+        List<Long> userIds;
         if (users.isEmpty()) {
-            query.setParameter("users", Collections.singletonList(-1L));
+            userIds = Collections.singletonList(-1L);
         } else {
-            List<Long> userIds = users.stream().map(User::getId).collect(Collectors.toList());
-            query.setParameter("users", userIds);
+            userIds = users.stream().map(User::getId).collect(Collectors.toList());
         }
-        return query.getResultList();
+        query.setParameter("users", userIds);
+
+        List<UserFriendDto> resultList = query.getResultList();
+        Map<Long, UserFriendDto> resultMap = resultList.stream()
+            .collect(Collectors.toMap(UserFriendDto::getId, dto -> dto));
+
+        return userIds.stream()
+            .map(resultMap::get)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
     }
 }

--- a/dao/src/test/java/greencity/repository/impl/CustomUserRepoImplTest.java
+++ b/dao/src/test/java/greencity/repository/impl/CustomUserRepoImplTest.java
@@ -13,6 +13,8 @@ import jakarta.persistence.TypedQuery;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -63,5 +65,43 @@ class CustomUserRepoImplTest {
 
         assertThrows(NullPointerException.class,
             () -> customUserRepo.fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser(userId, null));
+    }
+
+    @Test
+    void fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUserPreservesOrderTest() {
+        long userId = 1L;
+        long user1Id = 10L;
+        long user2Id = 20L;
+        long user3Id = 30L;
+
+        User user1 = ModelUtils.getUser();
+        user1.setId(user1Id);
+        User user2 = ModelUtils.getUser();
+        user2.setId(user2Id);
+        User user3 = ModelUtils.getUser();
+        user3.setId(user3Id);
+        List<User> users = List.of(user1, user2, user3);
+
+        TypedQuery<UserFriendDto> query = mock(TypedQuery.class);
+        when(entityManager.createNamedQuery("User.fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser",
+            UserFriendDto.class)).thenReturn(query);
+
+        UserFriendDto friend1 = new UserFriendDto();
+        friend1.setId(user2Id);
+        UserFriendDto friend2 = new UserFriendDto();
+        friend2.setId(user3Id);
+        UserFriendDto friend3 = new UserFriendDto();
+        friend3.setId(user1Id);
+        when(query.getResultList()).thenReturn(List.of(friend1, friend2, friend3));
+
+        List<UserFriendDto> result = customUserRepo.fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser(userId, users);
+
+        verify(query).setParameter("userId", userId);
+        verify(query).setParameter("users", List.of(10L, 20L, 30L));
+
+        assertEquals(3, result.size());
+        assertEquals(10L, result.get(0).getId());
+        assertEquals(20L, result.get(1).getId());
+        assertEquals(30L, result.get(2).getId());
     }
 }

--- a/dao/src/test/java/greencity/repository/impl/CustomUserRepoImplTest.java
+++ b/dao/src/test/java/greencity/repository/impl/CustomUserRepoImplTest.java
@@ -94,7 +94,8 @@ class CustomUserRepoImplTest {
         friend3.setId(user1Id);
         when(query.getResultList()).thenReturn(List.of(friend1, friend2, friend3));
 
-        List<UserFriendDto> result = customUserRepo.fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser(userId, users);
+        List<UserFriendDto> result =
+            customUserRepo.fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser(userId, users);
 
         verify(query).setParameter("userId", userId);
         verify(query).setParameter("users", List.of(10L, 20L, 30L));

--- a/dao/src/test/java/greencity/repository/impl/CustomUserRepoImplTest.java
+++ b/dao/src/test/java/greencity/repository/impl/CustomUserRepoImplTest.java
@@ -10,15 +10,18 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class CustomUserRepoImplTest {
@@ -48,15 +51,13 @@ class CustomUserRepoImplTest {
     void fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUserWhenUserListIsEmptyTest() {
         long userId = 1L;
         List<User> users = List.of();
-        TypedQuery<UserFriendDto> query = mock(TypedQuery.class);
 
-        when(entityManager.createNamedQuery("User.fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser",
-            UserFriendDto.class)).thenReturn(query);
+        List<UserFriendDto> result =
+            customUserRepo.fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser(userId, users);
 
-        customUserRepo.fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser(userId, users);
+        verify(entityManager, never()).createNamedQuery(anyString(), eq(UserFriendDto.class));
 
-        verify(query).setParameter("userId", userId);
-        verify(query).setParameter("users", Collections.singletonList(-1L));
+        assertTrue(result.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
### GreenCity PR
### Issue Link 📋
#8043
### Issue summary
After calling fillListOfUserWithCountOfMutualFriendsAndChatIdForCurrentUser() previous order of users was lost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced user mutual friends retrieval method with improved query handling and result processing.

- **Tests**
	- Added a new test to verify preservation of user order when retrieving mutual friends.
	- Modified existing test to ensure no query is created when the user list is empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->