### PR TITLE
[8180] - Removed '303' API Response from 'Add Comment' method

### DIFF
--- a/core/src/main/java/greencity/controller/EcoNewsCommentController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsCommentController.java
@@ -68,8 +68,6 @@ public class EcoNewsCommentController {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = HttpStatuses.CREATED,
             content = @Content(schema = @Schema(implementation = AddCommentDtoResponse.class))),
-        @ApiResponse(responseCode = "303", description = HttpStatuses.SEE_OTHER,
-            content = @Content(examples = @ExampleObject(HttpStatuses.SEE_OTHER))),
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST,
             content = @Content(examples = @ExampleObject(HttpStatuses.BAD_REQUEST))),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED,


### PR DESCRIPTION
Removed the 303 status from Swagger because the endpoint doesn't actually return it, and leaving it in the documentation could be confusing to developers. This will help make the documentation more accurate and understandable. If the server previously used a 303 for redirects, but now immediately returns a response with a newly created comment, this change simplifies integration. It's important that the documentation reflects the actual behavior of the API, so I've updated it accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API responses for the comment creation endpoint to now display only the supported status codes, removing the outdated redirect reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->