### PR TITLE
remove open ai api key from ClusterExternalSecret.yaml and greencity.yaml

### DIFF
--- a/greencity-chart/templates/ClusterExternalSecret.yaml
+++ b/greencity-chart/templates/ClusterExternalSecret.yaml
@@ -274,8 +274,4 @@ spec:
       remoteRef:
         key: DOMAIN-NAME
 
-    - secretKey: OPEN-AI-API-KEY
-      remoteRef:
-        key: OPEN-AI-API-KEY
-
 {{- end }}

--- a/greencity-chart/templates/greencity.yaml
+++ b/greencity-chart/templates/greencity.yaml
@@ -258,12 +258,6 @@ spec:
               name: {{ .Values.externalSecret.secretName }}
               key: GOOGLE-API-KEY
 
-        - name: OPEN_AI_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.externalSecret.secretName }}
-              key: OPEN-AI-API-KEY
-
         ports:
         - containerPort: 8080
           name: tomcat


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed an external secret reference previously used for an API key.
	- Removed the corresponding environment variable from the deployment configuration to streamline secret management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->