### PR TITLE
Added @Lazy annotation to ExportSettingsServiceImpl;

### DIFF
--- a/service/src/main/java/greencity/service/ExportSettingsServiceImpl.java
+++ b/service/src/main/java/greencity/service/ExportSettingsServiceImpl.java
@@ -5,12 +5,14 @@ import greencity.dto.exportsettings.TableRowsDto;
 import greencity.dto.exportsettings.TablesMetadataDto;
 import greencity.repository.ExportSettingsRepo;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.io.InputStream;
 
 @RequiredArgsConstructor
 @Service
+@Lazy
 public class ExportSettingsServiceImpl implements ExportSettingsService {
     private final ExportSettingsRepo exportSettingsRepo;
     private final ExportToFileService exportToFileService;


### PR DESCRIPTION
Inside the `ExportSettingsServiceImpl` is using `DotenvService`.

`DotenvService` is marked with an `@Lazy` annotation. To make it works properly and avoid problem during runtime, `ExportSettingsServiceImpl` also should be annotated as lazy. In this PR added the necessary annotation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted the export settings functionality to initialize only when needed. This improvement optimizes resource usage and overall performance without impacting the application's observable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->