### PR TITLE
Removed ambigious @Profile annotation 

### DIFF
--- a/core/src/main/java/greencity/controller/LogFileController.java
+++ b/core/src/main/java/greencity/controller/LogFileController.java
@@ -17,7 +17,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
@@ -34,7 +33,6 @@ import org.springframework.web.bind.annotation.RestController;
 @Lazy
 @RequiredArgsConstructor
 @RequestMapping("/logs")
-@Profile({"dev", "test"})
 public class LogFileController {
     private final LogFileService logFileService;
     private final DotenvService dotenvService;

--- a/service/src/main/java/greencity/service/DotenvServiceImpl.java
+++ b/service/src/main/java/greencity/service/DotenvServiceImpl.java
@@ -7,7 +7,6 @@ import greencity.exception.exceptions.FunctionalityNotAvailableException;
 import io.github.cdimascio.dotenv.Dotenv;
 import io.github.cdimascio.dotenv.DotenvException;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import java.io.File;
@@ -16,7 +15,6 @@ import java.nio.file.Files;
 
 @Service
 @Lazy
-@Profile({"dev", "test"})
 public class DotenvServiceImpl implements DotenvService {
     private Dotenv dotenv;
     private final PasswordEncoder passwordEncoder;

--- a/service/src/main/java/greencity/service/LogFileServiceImpl.java
+++ b/service/src/main/java/greencity/service/LogFileServiceImpl.java
@@ -11,7 +11,6 @@ import greencity.exception.exceptions.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.logging.LogLevel;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Pageable;
@@ -31,7 +30,6 @@ import java.util.stream.Stream;
 @Service
 @Lazy
 @RequiredArgsConstructor
-@Profile({"dev", "test"})
 public class LogFileServiceImpl implements LogFileService {
     private static final String LOGS_DIRECTORY =
         System.getProperty("user.dir") + File.separator + "logs" + File.separator;


### PR DESCRIPTION
Removed @Profile annotation for `LogFileServiceImpl`, `LogFileController`, `DotenvServiceImpl`;

This annotation set dev and test profiles which are not necessary for current functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Logging and environment configuration functionalities are now accessible in all deployment environments, including production. Previously confined to development and testing, these features are now available across the board, providing enhanced flexibility and consistent operational support in various settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->