### PR TITLE
Added @Lazy annotation to ExportSettingsController;

### DIFF
--- a/core/src/main/java/greencity/controller/ExportSettingsController.java
+++ b/core/src/main/java/greencity/controller/ExportSettingsController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 @RequiredArgsConstructor
 @RestController
 @Validated
+@Lazy
 @RequestMapping("/export/settings")
 public class ExportSettingsController {
     private final ExportSettingsService exportSettingsService;


### PR DESCRIPTION
Added `@Lazy` annotation to `ExportSettingsController` cause it is part of lazy functionality which is using `DotenvService` features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Optimized the export settings functionality so it loads on demand, enhancing resource efficiency and overall performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->