### PR TITLE
Feature #8102 - Get environment variables

### DIFF
--- a/core/src/main/java/greencity/controller/ExportSettingsController.java
+++ b/core/src/main/java/greencity/controller/ExportSettingsController.java
@@ -1,6 +1,7 @@
 package greencity.controller;
 
 import greencity.constant.HttpStatuses;
+import greencity.dto.exportsettings.EnvironmentDto;
 import greencity.dto.exportsettings.TableParamsRequestDto;
 import greencity.dto.exportsettings.TableRowsDto;
 import greencity.dto.exportsettings.TablesMetadataDto;
@@ -103,5 +104,24 @@ public class ExportSettingsController {
             .headers(headers)
             .body(new InputStreamResource(
                 exportSettingsService.getExcelFileAsResource(tableParams, secretKey)));
+    }
+
+    /**
+     * Method for receiving all environment variables use in the app.
+     *
+     * @return dto {@link EnvironmentDto}
+     */
+    @Operation(summary = "Get all environment variables")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK,
+            content = @Content(schema = @Schema(implementation = EnvironmentDto.class))),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED,
+            content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED))),
+        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN,
+            content = @Content(examples = @ExampleObject(HttpStatuses.FORBIDDEN))),
+    })
+    @GetMapping("/env")
+    public ResponseEntity<EnvironmentDto> getEnvVariables(@RequestHeader String secretKey) {
+        return ResponseEntity.ok(exportSettingsService.getEnvironmentVariables(secretKey));
     }
 }

--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -26,6 +26,7 @@ import greencity.dto.event.EventInformationDto;
 import greencity.dto.event.EventResponseDto;
 import greencity.dto.event.UpdateEventDateLocationDto;
 import greencity.dto.event.UpdateEventRequestDto;
+import greencity.dto.exportsettings.EnvironmentDto;
 import greencity.dto.exportsettings.TableParamsRequestDto;
 import greencity.dto.favoriteplace.FavoritePlaceDto;
 import greencity.dto.filter.FilterDiscountDto;
@@ -700,5 +701,11 @@ public class ModelUtils {
             "",
             "application/json",
             objectMapper.writeValueAsBytes(dto));
+    }
+
+    public static EnvironmentDto getEnvironmentDto() {
+        Map<String, String> env = new HashMap<>();
+        env.put("TEST_ENV_NAME", "TEST_ENV_VALUE");
+        return new EnvironmentDto(env);
     }
 }

--- a/core/src/test/java/greencity/controller/ExportSettingsControllerTest.java
+++ b/core/src/test/java/greencity/controller/ExportSettingsControllerTest.java
@@ -3,9 +3,11 @@ package greencity.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import greencity.ModelUtils;
 import greencity.constant.ErrorMessage;
+import greencity.dto.exportsettings.EnvironmentDto;
 import greencity.dto.exportsettings.TableParamsRequestDto;
 import greencity.dto.exportsettings.TableRowsDto;
 import greencity.dto.exportsettings.TablesMetadataDto;
+import greencity.exception.exceptions.BadSecretKeyException;
 import greencity.exception.exceptions.DatabaseMetadataException;
 import greencity.exception.handler.CustomExceptionHandler;
 import greencity.service.ExportSettingsService;
@@ -42,6 +44,7 @@ class ExportSettingsControllerTest {
     private static final int LIMIT = tableParams.limit();
     private static final int OFFSET = tableParams.offset();
     private static final String SECRET_KEY = "SomeSecretKey";
+    private static final String NOT_VALID_SECRET_KEY = "NotValidSecretKey";
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final ErrorAttributes errorAttributes = new DefaultErrorAttributes();
     private final TableParamsRequestDto tableParamsWithNotValidTableName =
@@ -242,5 +245,28 @@ class ExportSettingsControllerTest {
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
             .andReturn();
+    }
+
+    @Test
+    public void getEnvVariablesWithValidSecretKeyTest() throws Exception {
+        EnvironmentDto environmentDto = ModelUtils.getEnvironmentDto();
+        when(exportSettingsService.getEnvironmentVariables(SECRET_KEY)).thenReturn(environmentDto);
+        String expectedJson = objectMapper.writeValueAsString(environmentDto);
+
+        mockMvc.perform(get(SETTINGS_CONTROLLER_LINK + "/env")
+            .header("secretKey", SECRET_KEY)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().json(expectedJson));
+    }
+
+    @Test
+    public void getEnvVariablesWithNotValidSecretKeyTest() throws Exception {
+        when(exportSettingsService.getEnvironmentVariables(NOT_VALID_SECRET_KEY)).thenThrow(new BadSecretKeyException(ErrorMessage.BAD_SECRET_KEY));
+
+        mockMvc.perform(get(SETTINGS_CONTROLLER_LINK + "/env")
+                        .header("secretKey", NOT_VALID_SECRET_KEY)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
     }
 }

--- a/core/src/test/java/greencity/controller/ExportSettingsControllerTest.java
+++ b/core/src/test/java/greencity/controller/ExportSettingsControllerTest.java
@@ -248,7 +248,7 @@ class ExportSettingsControllerTest {
     }
 
     @Test
-    public void getEnvVariablesWithValidSecretKeyTest() throws Exception {
+    void getEnvVariablesWithValidSecretKeyTest() throws Exception {
         EnvironmentDto environmentDto = ModelUtils.getEnvironmentDto();
         when(exportSettingsService.getEnvironmentVariables(SECRET_KEY)).thenReturn(environmentDto);
         String expectedJson = objectMapper.writeValueAsString(environmentDto);
@@ -261,7 +261,7 @@ class ExportSettingsControllerTest {
     }
 
     @Test
-    public void getEnvVariablesWithNotValidSecretKeyTest() throws Exception {
+    void getEnvVariablesWithNotValidSecretKeyTest() throws Exception {
         when(exportSettingsService.getEnvironmentVariables(NOT_VALID_SECRET_KEY)).thenThrow(new BadSecretKeyException(ErrorMessage.BAD_SECRET_KEY));
 
         mockMvc.perform(get(SETTINGS_CONTROLLER_LINK + "/env")

--- a/service-api/src/main/java/greencity/dto/exportsettings/EnvironmentDto.java
+++ b/service-api/src/main/java/greencity/dto/exportsettings/EnvironmentDto.java
@@ -2,5 +2,5 @@ package greencity.dto.exportsettings;
 
 import java.util.Map;
 
-public record EnvironmentDto(Map<String, String> environments) {
+public record EnvironmentDto(Map<String, String> variables) {
 }

--- a/service-api/src/main/java/greencity/dto/exportsettings/EnvironmentDto.java
+++ b/service-api/src/main/java/greencity/dto/exportsettings/EnvironmentDto.java
@@ -1,0 +1,6 @@
+package greencity.dto.exportsettings;
+
+import java.util.Map;
+
+public record EnvironmentDto(Map<String, String> environments) {
+}

--- a/service-api/src/main/java/greencity/service/ExportSettingsService.java
+++ b/service-api/src/main/java/greencity/service/ExportSettingsService.java
@@ -1,5 +1,6 @@
 package greencity.service;
 
+import greencity.dto.exportsettings.EnvironmentDto;
 import greencity.dto.exportsettings.TableParamsRequestDto;
 import greencity.dto.exportsettings.TableRowsDto;
 import greencity.dto.exportsettings.TablesMetadataDto;
@@ -8,6 +9,9 @@ import java.io.InputStream;
 public interface ExportSettingsService {
     /**
      * Method for receiving all DB tables short metadata.
+     *
+     * @param secretKey {@link String} is a secret key for getting access to
+     *                  functionality.
      *
      * @return {@link TablesMetadataDto} instance.
      */
@@ -18,6 +22,8 @@ public interface ExportSettingsService {
      *
      * @param tableParams {@link TableParamsRequestDto} dto with params such as
      *                    tableName, limit and offset.
+     * @param secretKey   {@link String} is a secret key for getting access to
+     *                    functionality.
      *
      * @return {@link TableRowsDto} object with metadata.
      */
@@ -29,8 +35,20 @@ public interface ExportSettingsService {
      *
      * @param tableParams {@link TableParamsRequestDto} dto with params such as
      *                    tableName, limit and offset.
+     * @param secretKey   {@link String} is a secret key for getting access to
+     *                    functionality.
      *
      * @return {@link InputStream} InputStream with file.
      */
     InputStream getExcelFileAsResource(TableParamsRequestDto tableParams, String secretKey);
+
+    /**
+     * Method for receiving all environment variables.
+     *
+     * @param secretKey {@link String} is a secret key for getting access to
+     *                  functionality.
+     *
+     * @return {@link EnvironmentDto} instance.
+     */
+    EnvironmentDto getEnvironmentVariables(String secretKey);
 }

--- a/service-api/src/test/java/greencity/dto/exportsettings/EnvironmentDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/exportsettings/EnvironmentDtoTest.java
@@ -15,9 +15,9 @@ class EnvironmentDtoTest {
         EnvironmentDto dto = new EnvironmentDto(envVars);
 
         assertThat(dto).isNotNull();
-        assertThat(dto.environments()).isNotEmpty();
-        assertThat(dto.environments()).containsEntry("JAVA_HOME", "/usr/lib/jvm/java-11-openjdk");
-        assertThat(dto.environments()).containsEntry("APP_ENV", "production");
+        assertThat(dto.variables()).isNotEmpty();
+        assertThat(dto.variables()).containsEntry("JAVA_HOME", "/usr/lib/jvm/java-11-openjdk");
+        assertThat(dto.variables()).containsEntry("APP_ENV", "production");
     }
 
     @Test
@@ -27,6 +27,6 @@ class EnvironmentDtoTest {
         EnvironmentDto dto = new EnvironmentDto(emptyEnvVars);
 
         assertThat(dto).isNotNull();
-        assertThat(dto.environments()).isEmpty();
+        assertThat(dto.variables()).isEmpty();
     }
 }

--- a/service-api/src/test/java/greencity/dto/exportsettings/EnvironmentDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/exportsettings/EnvironmentDtoTest.java
@@ -1,0 +1,32 @@
+package greencity.dto.exportsettings;
+
+import org.junit.jupiter.api.Test;
+import java.util.Map;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EnvironmentDtoTest {
+
+    @Test
+    void createEnvironmentDtoWithGivenValuesTest() {
+        Map<String, String> envVars = Map.of(
+            "JAVA_HOME", "/usr/lib/jvm/java-11-openjdk",
+            "APP_ENV", "production");
+
+        EnvironmentDto dto = new EnvironmentDto(envVars);
+
+        assertThat(dto).isNotNull();
+        assertThat(dto.environments()).isNotEmpty();
+        assertThat(dto.environments()).containsEntry("JAVA_HOME", "/usr/lib/jvm/java-11-openjdk");
+        assertThat(dto.environments()).containsEntry("APP_ENV", "production");
+    }
+
+    @Test
+    void handleEmptyEnvironmentVariablesTest() {
+        Map<String, String> emptyEnvVars = Map.of();
+
+        EnvironmentDto dto = new EnvironmentDto(emptyEnvVars);
+
+        assertThat(dto).isNotNull();
+        assertThat(dto.environments()).isEmpty();
+    }
+}

--- a/service/src/main/java/greencity/service/ExportSettingsServiceImpl.java
+++ b/service/src/main/java/greencity/service/ExportSettingsServiceImpl.java
@@ -1,5 +1,6 @@
 package greencity.service;
 
+import greencity.dto.exportsettings.EnvironmentDto;
 import greencity.dto.exportsettings.TableParamsRequestDto;
 import greencity.dto.exportsettings.TableRowsDto;
 import greencity.dto.exportsettings.TablesMetadataDto;
@@ -42,5 +43,12 @@ public class ExportSettingsServiceImpl implements ExportSettingsService {
             tableParams.offset());
 
         return exportToFileService.exportTableDataToExcel(data);
+    }
+
+    @Override
+    public EnvironmentDto getEnvironmentVariables(String secretKey) {
+        dotenvService.validateSecretKey(secretKey);
+
+        return new EnvironmentDto(System.getenv());
     }
 }

--- a/service/src/test/java/greencity/service/ExportSettingsServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ExportSettingsServiceImplTest.java
@@ -121,7 +121,7 @@ class ExportSettingsServiceImplTest {
     void getEnvironmentVariablesWithValidSecretKeyTest() {
         EnvironmentDto result = settingsService.getEnvironmentVariables(SECRET_KEY);
 
-        assertFalse(result.environments().isEmpty());
+        assertFalse(result.variables().isEmpty());
     }
 
     @Test

--- a/service/src/test/java/greencity/service/ExportSettingsServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ExportSettingsServiceImplTest.java
@@ -118,14 +118,14 @@ class ExportSettingsServiceImplTest {
     }
 
     @Test
-    public void getEnvironmentVariablesWithValidSecretKeyTest() {
+    void getEnvironmentVariablesWithValidSecretKeyTest() {
         EnvironmentDto result = settingsService.getEnvironmentVariables(SECRET_KEY);
 
         assertFalse(result.environments().isEmpty());
     }
 
     @Test
-    public void getEnvironmentVariablesWithNotValidSecretKeyTest() {
+    void getEnvironmentVariablesWithNotValidSecretKeyTest() {
         doThrow(new BadSecretKeyException(ErrorMessage.BAD_SECRET_KEY)).when(dotenvService)
             .validateSecretKey(NOT_VALID_SECRET_KEY);
 

--- a/service/src/test/java/greencity/service/ExportSettingsServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ExportSettingsServiceImplTest.java
@@ -2,6 +2,7 @@ package greencity.service;
 
 import greencity.ModelUtils;
 import greencity.constant.ErrorMessage;
+import greencity.dto.exportsettings.EnvironmentDto;
 import greencity.dto.exportsettings.TableParamsRequestDto;
 import greencity.dto.exportsettings.TableRowsDto;
 import greencity.dto.exportsettings.TablesMetadataDto;
@@ -15,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doNothing;
@@ -113,5 +115,21 @@ class ExportSettingsServiceImplTest {
             () -> settingsService.getExcelFileAsResource(tableParams, NOT_VALID_SECRET_KEY));
 
         verify(exportSettingsRepo, times(0)).selectPortionFromTable(TABLE_NAME, LIMIT, OFFSET);
+    }
+
+    @Test
+    public void getEnvironmentVariablesWithValidSecretKeyTest() {
+        EnvironmentDto result = settingsService.getEnvironmentVariables(SECRET_KEY);
+
+        assertFalse(result.environments().isEmpty());
+    }
+
+    @Test
+    public void getEnvironmentVariablesWithNotValidSecretKeyTest() {
+        doThrow(new BadSecretKeyException(ErrorMessage.BAD_SECRET_KEY)).when(dotenvService)
+            .validateSecretKey(NOT_VALID_SECRET_KEY);
+
+        assertThrows(BadSecretKeyException.class,
+            () -> settingsService.getEnvironmentVariables(NOT_VALID_SECRET_KEY));
     }
 }


### PR DESCRIPTION
# GreenCity PR
## Issue Link 📋
[#8102](https://github.com/ita-social-projects/GreenCity/issues/8102)

## Added

- Added method _getEnvironmentVariables_ with java doc in the `ExportSettngsService` interface;
- Added implementation for the method _getEnvironmentVariables_ in the `ExportSettingsServiceImpl`; 
- Added method for receiving `EnvironmentDto` instance in the `ModelUtils`; 
- Added unit tests for method _getEnvironmentVariables_ in the `ExportSettingsServiceImplTest`; 
- Created `EnvironmentDto`;
- Added endpoint `/env` into the `ExportSettingsController` for receiving env variables; 
- Added unit tests for the newly added endpoint in the `ExportSettingsControllerTest`;

## Changed
- Refactored Java doc in the `ExportSettingsService` interface cause some params were missed;

## Summary Of Changes 🔥

- Added functionality for receiving all available environment variables in the **GreenCity** project;
- Functionality covered with unit tests;
- Endpoint secured by Spring Security + secretKey from .env file security;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a secure API endpoint that returns the application’s environment configuration when provided with a valid secret key.
	- Enhanced service interfaces to include secret key validation for accessing environment-specific data.
	- Added a new data structure to encapsulate environment variables.

- **Tests**
	- Added comprehensive tests to verify proper behavior for valid and invalid secret key scenarios, ensuring secure access and appropriate error handling.
	- Introduced unit tests for the new data structure to validate its functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->