### PR TITLE
Added likeV2/dislikeV2 methods with response body. Fixed CommentDtoMapper

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -350,6 +350,8 @@ public class SecurityConfig {
                     ECO_NEWS + "/{ecoNewsId}/favorites",
                     "/habit/assign/{habitId}/invite",
                     "place/v2/save",
+                    EVENTS + COMMENTS + "/dislikeV2" + COMMENT_ID,
+                    EVENTS + COMMENTS + "/likeV2" + COMMENT_ID,
                     LOGS)
                 .hasAnyRole(USER, ADMIN, MODERATOR, UBS_EMPLOYEE)
                 .requestMatchers(HttpMethod.PUT,

--- a/core/src/main/java/greencity/controller/EcoNewsCommentController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsCommentController.java
@@ -219,8 +219,9 @@ public class EcoNewsCommentController {
     @PostMapping("/comments/like")
     public void like(
         @RequestParam("commentId") Long commentId,
-        @Parameter(hidden = true) @CurrentUser UserVO userVO) {
-        commentService.like(commentId, userVO, null);
+        @Parameter(hidden = true) @CurrentUser UserVO userVO,
+        @ValidLanguage Locale locale) {
+        commentService.like(commentId, userVO, locale);
     }
 
     /**
@@ -241,9 +242,8 @@ public class EcoNewsCommentController {
     @PostMapping("/comments/dislike")
     public void dislike(
         @RequestParam("commentId") Long commentId,
-        @Parameter(hidden = true) @CurrentUser UserVO userVO,
-        @Parameter(hidden = true) @ValidLanguage Locale locale) {
-        commentService.dislike(commentId, userVO, locale);
+        @Parameter(hidden = true) @CurrentUser UserVO userVO) {
+        commentService.dislike(commentId, userVO);
     }
 
     /**

--- a/core/src/main/java/greencity/controller/EcoNewsCommentController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsCommentController.java
@@ -241,8 +241,9 @@ public class EcoNewsCommentController {
     @PostMapping("/comments/dislike")
     public void dislike(
         @RequestParam("commentId") Long commentId,
-        @Parameter(hidden = true) @CurrentUser UserVO userVO) {
-        commentService.dislike(commentId, userVO, null);
+        @Parameter(hidden = true) @CurrentUser UserVO userVO,
+        @Parameter(hidden = true) @ValidLanguage Locale locale) {
+        commentService.dislike(commentId, userVO, locale);
     }
 
     /**

--- a/core/src/main/java/greencity/controller/EventCommentController.java
+++ b/core/src/main/java/greencity/controller/EventCommentController.java
@@ -284,4 +284,51 @@ public class EventCommentController {
         @Parameter(hidden = true) @CurrentUser UserVO user) {
         commentService.dislike(commentId, user, null);
     }
+
+    /**
+     * Method to like/unlike certain {@link CommentDto} specified by id.
+     *
+     * @param commentId of {@link CommentDto} to like/dislike
+     * @return {@link CommentDto} with updated amount of likes
+     */
+    @Operation(summary = "Like/unlike comment.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST,
+            content = @Content(examples = @ExampleObject(HttpStatuses.BAD_REQUEST))),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED,
+            content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED))),
+        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND,
+            content = @Content(examples = @ExampleObject(HttpStatuses.NOT_FOUND)))
+    })
+    @PostMapping("/comments/likeV2/{commentId}")
+    public ResponseEntity<CommentDto> likeV2(
+        @PathVariable Long commentId,
+        @Parameter(hidden = true) @CurrentUser UserVO user,
+        @Parameter @ValidLanguage Locale locale) {
+        return ResponseEntity.ok(commentService.likeV2(commentId, user, locale));
+    }
+
+    /**
+     * Method to dislike certain {@link CommentDto} specified by id.
+     *
+     * @param commentId of {@link CommentDto} to like/dislike
+     */
+    @Operation(summary = "Dislike/remove dislike on comment.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST,
+            content = @Content(examples = @ExampleObject(HttpStatuses.BAD_REQUEST))),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED,
+            content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED))),
+        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND,
+            content = @Content(examples = @ExampleObject(HttpStatuses.NOT_FOUND)))
+    })
+    @PostMapping("/comments/dislikeV2/{commentId}")
+    public CommentDto dislikeV2(
+        @PathVariable Long commentId,
+        @Parameter(hidden = true) @CurrentUser UserVO user,
+        @Parameter @ValidLanguage Locale locale) {
+        return commentService.dislikeV2(commentId, user, locale);
+    }
 }

--- a/core/src/main/java/greencity/controller/EventCommentController.java
+++ b/core/src/main/java/greencity/controller/EventCommentController.java
@@ -282,7 +282,7 @@ public class EventCommentController {
     public void dislike(
         @PathVariable Long commentId,
         @Parameter(hidden = true) @CurrentUser UserVO user) {
-        commentService.dislike(commentId, user, null);
+        commentService.dislike(commentId, user);
     }
 
     /**
@@ -325,10 +325,9 @@ public class EventCommentController {
             content = @Content(examples = @ExampleObject(HttpStatuses.NOT_FOUND)))
     })
     @PostMapping("/comments/dislikeV2/{commentId}")
-    public CommentDto dislikeV2(
+    public ResponseEntity<CommentDto> dislikeV2(
         @PathVariable Long commentId,
-        @Parameter(hidden = true) @CurrentUser UserVO user,
-        @Parameter @ValidLanguage Locale locale) {
-        return commentService.dislikeV2(commentId, user, locale);
+        @Parameter(hidden = true) @CurrentUser UserVO user) {
+        return ResponseEntity.ok(commentService.dislikeV2(commentId, user));
     }
 }

--- a/core/src/main/java/greencity/controller/HabitCommentController.java
+++ b/core/src/main/java/greencity/controller/HabitCommentController.java
@@ -224,9 +224,8 @@ public class HabitCommentController {
     })
     @PostMapping("/comments/dislike")
     public void dislike(@RequestParam("commentId") Long commentId,
-        @Parameter(hidden = true) @CurrentUser UserVO user,
-        @Parameter(hidden = true) @ValidLanguage Locale locale) {
-        commentService.dislike(commentId, user, locale);
+        @Parameter(hidden = true) @CurrentUser UserVO user) {
+        commentService.dislike(commentId, user);
     }
 
     /**

--- a/core/src/test/java/greencity/controller/EcoNewsCommentControllerTest.java
+++ b/core/src/test/java/greencity/controller/EcoNewsCommentControllerTest.java
@@ -384,7 +384,7 @@ class EcoNewsCommentControllerTest {
             .principal(principal))
             .andExpect(status().isOk());
 
-        verify(commentService).dislike(numericCommentId, userVO, null);
+        verify(commentService).dislike(numericCommentId, userVO, Locale.ENGLISH);
     }
 
     @Test
@@ -411,7 +411,7 @@ class EcoNewsCommentControllerTest {
 
         doThrow(new NotFoundException(errorMessage))
             .when(commentService)
-            .dislike(commentId, userVO, null);
+            .dislike(commentId, userVO, Locale.ENGLISH);
 
         Assertions.assertThatThrownBy(
             () -> mockMvc.perform(post(ECONEWS_LINK + "/comments/dislike")

--- a/core/src/test/java/greencity/controller/EcoNewsCommentControllerTest.java
+++ b/core/src/test/java/greencity/controller/EcoNewsCommentControllerTest.java
@@ -384,7 +384,7 @@ class EcoNewsCommentControllerTest {
             .principal(principal))
             .andExpect(status().isOk());
 
-        verify(commentService).dislike(numericCommentId, userVO, Locale.ENGLISH);
+        verify(commentService).dislike(numericCommentId, userVO);
     }
 
     @Test
@@ -411,7 +411,7 @@ class EcoNewsCommentControllerTest {
 
         doThrow(new NotFoundException(errorMessage))
             .when(commentService)
-            .dislike(commentId, userVO, Locale.ENGLISH);
+            .dislike(commentId, userVO);
 
         Assertions.assertThatThrownBy(
             () -> mockMvc.perform(post(ECONEWS_LINK + "/comments/dislike")

--- a/core/src/test/java/greencity/controller/EcoNewsCommentControllerTest.java
+++ b/core/src/test/java/greencity/controller/EcoNewsCommentControllerTest.java
@@ -296,7 +296,7 @@ class EcoNewsCommentControllerTest {
             .principal(principal))
             .andExpect(status().isOk());
 
-        verify(commentService).like(numericCommentId, userVO, null);
+        verify(commentService).like(numericCommentId, userVO, Locale.ENGLISH);
     }
 
     @Test
@@ -323,7 +323,7 @@ class EcoNewsCommentControllerTest {
 
         doThrow(new NotFoundException(errorMessage))
             .when(commentService)
-            .like(commentId, userVO, null);
+            .like(commentId, userVO, Locale.ENGLISH);
 
         Assertions.assertThatThrownBy(
             () -> mockMvc.perform(post(ECONEWS_LINK + "/comments/like")

--- a/core/src/test/java/greencity/controller/EventCommentControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventCommentControllerTest.java
@@ -13,6 +13,7 @@ import greencity.service.CommentService;
 import greencity.service.UserService;
 import lombok.SneakyThrows;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,6 +43,7 @@ import static greencity.ModelUtils.getUserVO;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doThrow;
@@ -70,6 +72,12 @@ class EventCommentControllerTest {
     @Mock
     private CommentService commentService;
     private final Principal principal = getPrincipal();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeAll
+    static void setUp() {
+        objectMapper.findAndRegisterModules();
+    }
 
     @BeforeEach
     void setup() {
@@ -390,7 +398,7 @@ class EventCommentControllerTest {
             .principal(principal))
             .andExpect(status().isOk());
 
-        verify(commentService).dislike(commentId, userVO, null);
+        verify(commentService).dislike(commentId, userVO);
     }
 
     @Test
@@ -415,12 +423,46 @@ class EventCommentControllerTest {
 
         doThrow(new NotFoundException(errorMessage))
             .when(commentService)
-            .dislike(commentId, userVO, null);
+            .dislike(commentId, userVO);
 
         Assertions.assertThatThrownBy(
             () -> mockMvc.perform(post(EVENT_COMMENTS_CONTROLLER_LINK + "/dislike/" + commentId)
                 .principal(principal))
                 .andExpect(status().isNotFound()))
             .hasCause(new NotFoundException(errorMessage));
+    }
+
+    @Test
+    @SneakyThrows
+    void getLikeV2ResponseTest() {
+        long commentId = 1L;
+        CommentDto commentDto = getPageableCommentDtos().getPage().getFirst();
+        UserVO user = getUserVO();
+        String expectedJson = objectMapper.writeValueAsString(commentDto);
+        when(userService.findByEmail(anyString())).thenReturn(user);
+        when(commentService.likeV2(commentId, user, Locale.ENGLISH)).thenReturn(commentDto);
+        mockMvc.perform(post(EVENT_COMMENTS_CONTROLLER_LINK + "/likeV2/" + commentId)
+            .principal(principal)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(content().json(expectedJson))
+            .andExpect(status().isOk());
+        verify(commentService, times(1)).likeV2(commentId, user, Locale.ENGLISH);
+    }
+
+    @Test
+    @SneakyThrows
+    void getDislikeV2ResponseTest() {
+        long commentId = 1L;
+        CommentDto commentDto = getPageableCommentDtos().getPage().getFirst();
+        UserVO user = getUserVO();
+        String expectedJson = objectMapper.writeValueAsString(commentDto);
+        when(userService.findByEmail(anyString())).thenReturn(user);
+        when(commentService.dislikeV2(commentId, user)).thenReturn(commentDto);
+        mockMvc.perform(post(EVENT_COMMENTS_CONTROLLER_LINK + "/dislikeV2/" + commentId)
+            .principal(principal)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(content().json(expectedJson))
+            .andExpect(status().isOk());
+        verify(commentService, times(1)).dislikeV2(commentId, user);
     }
 }

--- a/core/src/test/java/greencity/controller/EventCommentControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventCommentControllerTest.java
@@ -122,9 +122,8 @@ class EventCommentControllerTest {
             .content(content))
             .andExpect(status().isCreated());
 
-        ObjectMapper mapper = new ObjectMapper();
         AddCommentDtoRequest addCommentDtoRequest =
-            mapper.readValue(content, AddCommentDtoRequest.class);
+            objectMapper.readValue(content, AddCommentDtoRequest.class);
 
         verify(userService).findByEmail("test@gmail.com");
         verify(commentService).save(eq(ArticleType.EVENT),
@@ -242,7 +241,6 @@ class EventCommentControllerTest {
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
         PageableDto<CommentDto> commentReplies = getPageableCommentDtos();
 
-        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
         String expectedJson = objectMapper.writeValueAsString(commentReplies);
 
         when(commentService.getAllActiveReplies(pageable, parentCommentId, userVO))

--- a/core/src/test/java/greencity/controller/HabitCommentControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitCommentControllerTest.java
@@ -383,7 +383,7 @@ class HabitCommentControllerTest {
             .principal(principal))
             .andExpect(status().isOk());
 
-        verify(commentService).dislike(numericCommentId, userVO, Locale.ENGLISH);
+        verify(commentService).dislike(numericCommentId, userVO);
     }
 
     @Test
@@ -410,7 +410,7 @@ class HabitCommentControllerTest {
 
         doThrow(new NotFoundException(errorMessage))
             .when(commentService)
-            .dislike(commentId, userVO, Locale.ENGLISH);
+            .dislike(commentId, userVO);
 
         Assertions.assertThatThrownBy(
             () -> mockMvc.perform(post(HABIT_LINK + "/comments/dislike")

--- a/service-api/src/main/java/greencity/service/CommentService.java
+++ b/service-api/src/main/java/greencity/service/CommentService.java
@@ -137,4 +137,22 @@ public interface CommentService {
      * @author Anton Bondar
      */
     void searchUsers(UserSearchDto searchUsers);
+
+    /**
+     * Method to like or unlike {@link CommentVO} specified by id.
+     *
+     * @param commentId id of {@link CommentVO} to like/unlike.
+     * @param userVO    current {@link UserVO} that wants to like/unlike.
+     * @return {@link CommentDto} comment with updated data.
+     */
+    CommentDto likeV2(Long commentId, UserVO userVO, Locale locale);
+
+    /**
+     * Method to dislike or remove dislike {@link CommentVO} specified by id.
+     *
+     * @param commentId id of {@link CommentVO} to dislike.
+     * @param userVO    current {@link UserVO} that wants to dislike.
+     * @return {@link CommentDto} comment with updated data.
+     */
+    CommentDto dislikeV2(Long commentId, UserVO userVO, Locale locale);
 }

--- a/service-api/src/main/java/greencity/service/CommentService.java
+++ b/service-api/src/main/java/greencity/service/CommentService.java
@@ -110,7 +110,7 @@ public interface CommentService {
      * @param commentId id of {@link CommentVO} to dislike.
      * @param userVO    current {@link UserVO} that wants to dislike.
      */
-    void dislike(Long commentId, UserVO userVO, Locale locale);
+    void dislike(Long commentId, UserVO userVO);
 
     /**
      * Method to change the existing {@link CommentVO}.
@@ -154,5 +154,5 @@ public interface CommentService {
      * @param userVO    current {@link UserVO} that wants to dislike.
      * @return {@link CommentDto} comment with updated data.
      */
-    CommentDto dislikeV2(Long commentId, UserVO userVO, Locale locale);
+    CommentDto dislikeV2(Long commentId, UserVO userVO);
 }

--- a/service/src/main/java/greencity/mapping/CommentDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/CommentDtoMapper.java
@@ -1,5 +1,6 @@
 package greencity.mapping;
 
+import greencity.dto.comment.CommentAuthorDto;
 import greencity.dto.comment.CommentDto;
 import greencity.entity.Comment;
 import greencity.entity.CommentImages;
@@ -23,7 +24,6 @@ public class CommentDtoMapper extends AbstractConverter<Comment, CommentDto> {
     protected CommentDto convert(Comment comment) {
         CommentDto commentDto = new CommentDto();
         commentDto.setId(comment.getId());
-        commentDto.setText(comment.getText());
         commentDto.setCreatedDate(comment.getCreatedDate());
         commentDto.setModifiedDate(comment.getModifiedDate());
         if (comment.getParentComment() != null) {
@@ -34,6 +34,15 @@ public class CommentDtoMapper extends AbstractConverter<Comment, CommentDto> {
         if (comment.getAdditionalImages() != null) {
             commentDto.setAdditionalImages(comment.getAdditionalImages().stream().map(CommentImages::getLink).toList());
         }
+        commentDto.setCurrentUserLiked(comment.isCurrentUserLiked());
+        commentDto.setCurrentUserDisliked(comment.isCurrentUserDisliked());
+        commentDto.setLikes(comment.getUsersLiked().size());
+        commentDto.setDislikes(comment.getUsersDisliked().size());
+        commentDto.setAuthor(
+            CommentAuthorDto.builder()
+                .id(comment.getUser().getId())
+                .name(comment.getUser().getName())
+                .profilePicturePath(comment.getUser().getProfilePicturePath()).build());
         return commentDto;
     }
 }

--- a/service/src/main/java/greencity/service/CommentServiceImpl.java
+++ b/service/src/main/java/greencity/service/CommentServiceImpl.java
@@ -710,7 +710,7 @@ public class CommentServiceImpl implements CommentService {
     }
 
     /**
-     * This helper method provides liking logic, similar both to like and likeV2
+     * This helper method provides liking logic, similar both to like and likeV2.
      *
      * @param commentId - id of a comment to like
      * @param userVO    - current user
@@ -747,7 +747,7 @@ public class CommentServiceImpl implements CommentService {
 
     /**
      * This helper method provides disliking logic, similar both to dislike and
-     * dislikeV2
+     * dislikeV2.
      *
      * @param commentId - id of a comment to like
      * @param userVO    - current user

--- a/service/src/main/java/greencity/service/CommentServiceImpl.java
+++ b/service/src/main/java/greencity/service/CommentServiceImpl.java
@@ -523,33 +523,7 @@ public class CommentServiceImpl implements CommentService {
      */
     @Override
     public void like(Long commentId, UserVO userVO, Locale locale) {
-        Comment comment = commentRepo.findByIdAndStatusNot(commentId, CommentStatus.DELETED)
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.COMMENT_NOT_FOUND_BY_ID + commentId));
-
-        boolean isAuthor = comment.getUser().getId().equals(userVO.getId());
-
-        if (isAuthor) {
-            throw new BadRequestException(ErrorMessage.USER_HAS_NO_PERMISSION);
-        }
-
-        if (removeLikeIfExists(comment, userVO)) {
-            return;
-        }
-
-        removeDislikeIfExists(comment, userVO);
-
-        User mappedUser = modelMapper.map(userVO, User.class);
-        if (mappedUser.equals(comment.getUser())) {
-            return;
-        }
-
-        comment.getUsersLiked().add(mappedUser);
-        achievementCalculation.calculateAchievement(userVO,
-            AchievementCategoryType.LIKE_COMMENT_OR_REPLY, AchievementAction.ASSIGN);
-        ratingCalculation.ratingCalculation(ratingPointsRepo.findByNameOrThrow("LIKE_COMMENT_OR_REPLY"), userVO);
-        createCommentLikeNotification(comment.getArticleType(), comment.getArticleId(), comment, userVO, locale);
-
-        commentRepo.save(comment);
+        likeHelper(commentId, userVO, locale);
     }
 
     /**
@@ -557,24 +531,7 @@ public class CommentServiceImpl implements CommentService {
      */
     @Override
     public void dislike(Long commentId, UserVO userVO, Locale locale) {
-        Comment comment = commentRepo.findByIdAndStatusNot(commentId, CommentStatus.DELETED)
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.COMMENT_NOT_FOUND_BY_ID + commentId));
-
-        boolean isAuthor = comment.getUser().getId().equals(userVO.getId());
-
-        if (isAuthor) {
-            throw new BadRequestException(ErrorMessage.USER_HAS_NO_PERMISSION);
-        }
-
-        removeLikeIfExists(comment, userVO);
-
-        if (removeDislikeIfExists(comment, userVO)) {
-            return;
-        }
-
-        comment.getUsersDisliked().add(modelMapper.map(userVO, User.class));
-
-        commentRepo.save(comment);
+        dislikeHelper(commentId, userVO, locale);
     }
 
     /**
@@ -723,7 +680,7 @@ public class CommentServiceImpl implements CommentService {
 
             userNotificationService.removeActionUserFromNotification(modelMapper.map(comment.getUser(), UserVO.class),
                 userVO, comment.getId(), getNotificationType(comment.getArticleType(), CommentActionType.COMMENT_LIKE));
-
+            comment.setCurrentUserLiked(false);
             return true;
         }
         return false;
@@ -746,8 +703,89 @@ public class CommentServiceImpl implements CommentService {
 
             userNotificationService.removeActionUserFromNotification(modelMapper.map(comment.getUser(), UserVO.class),
                 userVO, comment.getId(), getNotificationType(comment.getArticleType(), CommentActionType.COMMENT_LIKE));
+            comment.setCurrentUserDisliked(false);
             return true;
         }
         return false;
+    }
+
+    /**
+     * This helper method provides liking logic, similar both to like and likeV2
+     *
+     * @param commentId - id of a comment to like
+     * @param userVO    - current user
+     * @param locale    - language of content (if needed)
+     */
+    private CommentDto likeHelper(Long commentId, UserVO userVO, Locale locale) {
+        Comment comment = commentRepo.findByIdAndStatusNot(commentId, CommentStatus.DELETED)
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.COMMENT_NOT_FOUND_BY_ID + commentId));
+
+        boolean isAuthor = comment.getUser().getId().equals(userVO.getId());
+        if (isAuthor) {
+            throw new BadRequestException(ErrorMessage.USER_HAS_NO_PERMISSION);
+        }
+
+        if (removeLikeIfExists(comment, userVO)) {
+            return modelMapper.map(comment, CommentDto.class);
+        }
+        removeDislikeIfExists(comment, userVO);
+
+        User mappedUser = modelMapper.map(userVO, User.class);
+        if (mappedUser.equals(comment.getUser())) {
+            return modelMapper.map(comment, CommentDto.class);
+        }
+
+        comment.getUsersLiked().add(mappedUser);
+        comment.setCurrentUserLiked(true);
+        achievementCalculation.calculateAchievement(userVO,
+            AchievementCategoryType.LIKE_COMMENT_OR_REPLY, AchievementAction.ASSIGN);
+        ratingCalculation.ratingCalculation(ratingPointsRepo.findByNameOrThrow("LIKE_COMMENT_OR_REPLY"), userVO);
+        createCommentLikeNotification(comment.getArticleType(), comment.getArticleId(), comment, userVO, locale);
+
+        return modelMapper.map(commentRepo.save(comment), CommentDto.class);
+    }
+
+    /**
+     * This helper method provides disliking logic, similar both to dislike and
+     * dislikeV2
+     *
+     * @param commentId - id of a comment to like
+     * @param userVO    - current user
+     * @param locale    - language of content (if needed)
+     */
+    private CommentDto dislikeHelper(Long commentId, UserVO userVO, Locale locale) {
+        Comment comment = commentRepo.findByIdAndStatusNot(commentId, CommentStatus.DELETED)
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.COMMENT_NOT_FOUND_BY_ID + commentId));
+        boolean isAuthor = comment.getUser().getId().equals(userVO.getId());
+
+        if (isAuthor) {
+            throw new BadRequestException(ErrorMessage.USER_HAS_NO_PERMISSION);
+        }
+
+        removeLikeIfExists(comment, userVO);
+
+        if (removeDislikeIfExists(comment, userVO)) {
+            return modelMapper.map(comment, CommentDto.class);
+        }
+
+        comment.getUsersDisliked().add(modelMapper.map(userVO, User.class));
+        comment.setCurrentUserDisliked(true);
+        return modelMapper.map(commentRepo.save(comment), CommentDto.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CommentDto likeV2(Long commentId, UserVO userVO, Locale locale) {
+        return likeHelper(commentId, userVO, locale);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CommentDto dislikeV2(Long commentId, UserVO userVO, Locale locale) {
+        return dislikeHelper(commentId, userVO, locale);
     }
 }

--- a/service/src/main/java/greencity/service/CommentServiceImpl.java
+++ b/service/src/main/java/greencity/service/CommentServiceImpl.java
@@ -530,8 +530,8 @@ public class CommentServiceImpl implements CommentService {
      * {@inheritDoc}
      */
     @Override
-    public void dislike(Long commentId, UserVO userVO, Locale locale) {
-        dislikeHelper(commentId, userVO, locale);
+    public void dislike(Long commentId, UserVO userVO) {
+        dislikeHelper(commentId, userVO);
     }
 
     /**
@@ -751,9 +751,8 @@ public class CommentServiceImpl implements CommentService {
      *
      * @param commentId - id of a comment to like
      * @param userVO    - current user
-     * @param locale    - language of content (if needed)
      */
-    private CommentDto dislikeHelper(Long commentId, UserVO userVO, Locale locale) {
+    private CommentDto dislikeHelper(Long commentId, UserVO userVO) {
         Comment comment = commentRepo.findByIdAndStatusNot(commentId, CommentStatus.DELETED)
             .orElseThrow(() -> new NotFoundException(ErrorMessage.COMMENT_NOT_FOUND_BY_ID + commentId));
         boolean isAuthor = comment.getUser().getId().equals(userVO.getId());
@@ -785,7 +784,7 @@ public class CommentServiceImpl implements CommentService {
      * {@inheritDoc}
      */
     @Override
-    public CommentDto dislikeV2(Long commentId, UserVO userVO, Locale locale) {
-        return dislikeHelper(commentId, userVO, locale);
+    public CommentDto dislikeV2(Long commentId, UserVO userVO) {
+        return dislikeHelper(commentId, userVO);
     }
 }

--- a/service/src/test/java/greencity/service/CommentServiceImplTest.java
+++ b/service/src/test/java/greencity/service/CommentServiceImplTest.java
@@ -1243,7 +1243,7 @@ class CommentServiceImplTest {
         when(commentRepo.findByIdAndStatusNot(1L, CommentStatus.DELETED)).thenReturn(Optional.of(comment));
         when(userRepo.findById(user.getId())).thenReturn(Optional.of(user));
 
-        commentService.dislike(1L, userVO, null);
+        commentService.dislike(1L, userVO);
 
         verify(commentRepo).save(comment);
         assertEquals(1L, comment.getUsersDisliked().size());
@@ -1258,7 +1258,7 @@ class CommentServiceImplTest {
 
         when(commentRepo.findByIdAndStatusNot(1L, CommentStatus.DELETED)).thenReturn(Optional.of(comment));
 
-        assertThrows(BadRequestException.class, () -> commentService.dislike(1L, userVO, Locale.ENGLISH));
+        assertThrows(BadRequestException.class, () -> commentService.dislike(1L, userVO));
     }
 
     @Test
@@ -1273,7 +1273,7 @@ class CommentServiceImplTest {
         when(commentRepo.findByIdAndStatusNot(1L, CommentStatus.DELETED)).thenReturn(Optional.of(comment));
         when(userRepo.findById(user.getId())).thenReturn(Optional.of(user));
 
-        commentService.dislike(1L, userVO, null);
+        commentService.dislike(1L, userVO);
 
         assertEquals(0, comment.getUsersLiked().size());
         assertEquals(1, comment.getUsersDisliked().size());
@@ -1486,7 +1486,7 @@ class CommentServiceImplTest {
         when(commentRepo.findByIdAndStatusNot(1L, CommentStatus.DELETED)).thenReturn(Optional.of(comment));
         when(userRepo.findById(user.getId())).thenReturn(Optional.of(user));
 
-        commentService.dislikeV2(1L, userVO, null);
+        commentService.dislikeV2(1L, userVO);
 
         verify(commentRepo).save(comment);
         assertEquals(1L, comment.getUsersDisliked().size());

--- a/service/src/test/java/greencity/service/CommentServiceImplTest.java
+++ b/service/src/test/java/greencity/service/CommentServiceImplTest.java
@@ -1443,4 +1443,52 @@ class CommentServiceImplTest {
 
         verify(econewsRepo).findById(articleId);
     }
+
+    @Test
+    void likeV2Test() {
+        Long commentId = 1L;
+        UserVO userVO = getUserVONotCommentOwner();
+        User user = getUserNotCommentOwner();
+        Comment comment = getComment();
+        RatingPoints ratingPoints = RatingPoints.builder().id(1L).name("LIKE_COMMENT_OR_REPLY").points(1).build();
+        Long articleId = 10L;
+        Habit habit = getHabit();
+        habit.setUserId(user.getId());
+        HabitTranslation habitTranslation = getHabitTranslation();
+
+        when(userRepo.findById(user.getId())).thenReturn(Optional.of(user));
+        when(habitRepo.findById(articleId)).thenReturn(Optional.of(habit));
+        when(habitTranslationRepo.findByHabitAndLanguageCode(habit, Locale.of("en").getLanguage()))
+            .thenReturn(Optional.ofNullable(habitTranslation));
+        when(ratingPointsRepo.findByNameOrThrow("LIKE_COMMENT_OR_REPLY")).thenReturn(ratingPoints);
+        when(commentRepo.findByIdAndStatusNot(commentId, CommentStatus.DELETED)).thenReturn(Optional.of(comment));
+        when(modelMapper.map(userVO, User.class)).thenReturn(user);
+        doNothing().when(userNotificationService).createNotification(
+            any(UserVO.class), any(UserVO.class), any(NotificationType.class),
+            anyLong(), anyString(), anyLong(), anyString());
+
+        commentService.likeV2(commentId, userVO, Locale.ENGLISH);
+
+        assertTrue(comment.getUsersLiked().contains(user));
+
+        verify(commentRepo).findByIdAndStatusNot(commentId, CommentStatus.DELETED);
+        verify(modelMapper).map(userVO, User.class);
+    }
+
+    @Test
+    void dislikeV2Test() {
+        UserVO userVO = getUserVO();
+        User user = getUser();
+        Comment comment = getComment();
+        comment.getUser().setId(2L);
+        comment.setUsersDisliked(new HashSet<>());
+
+        when(commentRepo.findByIdAndStatusNot(1L, CommentStatus.DELETED)).thenReturn(Optional.of(comment));
+        when(userRepo.findById(user.getId())).thenReturn(Optional.of(user));
+
+        commentService.dislikeV2(1L, userVO, null);
+
+        verify(commentRepo).save(comment);
+        assertEquals(1L, comment.getUsersDisliked().size());
+    }
 }


### PR DESCRIPTION
## Summary of change
I have updated the like and dislike methods to return responses with the correct comment information, enabling the frontend to utilize them. Additionally, I fixed CommentDtoMapper, which previously generated an incorrect object mapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new endpoints for liking and disliking comments, enhancing user interaction capabilities.
	- Updated methods now return enriched response data, including updated like counts and user interaction details.
- **Bug Fixes**
	- Improved handling of user interactions with comments to ensure accurate tracking of likes and dislikes.
- **Refactor**
	- Streamlined and modularized comment reaction logic for better maintainability and clarity.
	- Simplified method signatures for liking and disliking comments.
- **Tests**
	- Added tests for the new like/dislike functionality to ensure reliable performance and correct behavior.
	- Updated existing tests to reflect changes in method signatures and parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->