### PR TITLE
Fix/swagger 403 status code error

### DIFF
--- a/service/src/main/java/greencity/config/DotenvConfig.java
+++ b/service/src/main/java/greencity/config/DotenvConfig.java
@@ -24,8 +24,8 @@ public class DotenvConfig {
     Dotenv dotenv() {
         try {
             return Dotenv.configure()
-                    .filename(AppConstant.DOTENV_FILENAME)
-                    .load();
+                .filename(AppConstant.DOTENV_FILENAME)
+                .load();
         } catch (DotenvException ignored) {
             throw new FunctionalityNotAvailableException(ErrorMessage.FUNCTIONALITY_NOT_AVAILABLE);
         }

--- a/service/src/main/java/greencity/config/DotenvConfig.java
+++ b/service/src/main/java/greencity/config/DotenvConfig.java
@@ -13,7 +13,6 @@ import org.springframework.context.annotation.Lazy;
 @Configuration
 @Lazy
 public class DotenvConfig {
-
     @Bean
     public Dotenv fallbackDotenv() {
         return Dotenv.configure().ignoreIfMissing().load();

--- a/service/src/main/java/greencity/config/DotenvConfig.java
+++ b/service/src/main/java/greencity/config/DotenvConfig.java
@@ -5,6 +5,7 @@ import greencity.constant.ErrorMessage;
 import greencity.exception.exceptions.FunctionalityNotAvailableException;
 import io.github.cdimascio.dotenv.Dotenv;
 import io.github.cdimascio.dotenv.DotenvException;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -12,12 +13,19 @@ import org.springframework.context.annotation.Lazy;
 @Configuration
 @Lazy
 public class DotenvConfig {
+
     @Bean
+    public Dotenv fallbackDotenv() {
+        return Dotenv.configure().ignoreIfMissing().load();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(Dotenv.class)
     Dotenv dotenv() {
         try {
             return Dotenv.configure()
-                .filename(AppConstant.DOTENV_FILENAME)
-                .load();
+                    .filename(AppConstant.DOTENV_FILENAME)
+                    .load();
         } catch (DotenvException ignored) {
             throw new FunctionalityNotAvailableException(ErrorMessage.FUNCTIONALITY_NOT_AVAILABLE);
         }


### PR DESCRIPTION
This PR addresses a bug that caused Swagger to return a 403 status code due to an exception occurring during the creation of the DotEnv bean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced environment configuration handling with a reliable fallback option to gracefully manage missing configuration files.
  - Improved initialization logic to ensure that existing settings take precedence, enhancing overall system stability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->