### PR TITLE
Bug/8293/User can not retrieve notifications from UBS

### DIFF
--- a/service-api/src/main/java/greencity/client/RestClient.java
+++ b/service-api/src/main/java/greencity/client/RestClient.java
@@ -55,7 +55,7 @@ import static greencity.constant.AppConstant.AUTHORIZATION;
 public class RestClient {
     private final RestTemplate restTemplate;
     private final String greenCityUserServerAddress;
-    private final UriComponentsBuilder ubsNotificationsUrlBuilder;
+    private final String greenCityUbsServerAddress;
 
     private final HttpServletRequest httpServletRequest;
     private final JwtTool jwtTool;
@@ -92,8 +92,7 @@ public class RestClient {
         this.httpServletRequest = httpServletRequest;
         this.jwtTool = jwtTool;
         this.systemEmail = systemEmail;
-        this.ubsNotificationsUrlBuilder =
-            UriComponentsBuilder.fromHttpUrl(greenCityUbsServerAddress + RestTemplateLinks.NOTIFICATIONS);
+        this.greenCityUbsServerAddress = greenCityUbsServerAddress;
     }
 
     public PageableAdvancedDto<UbsNotificationDto> findAllNotificationsForUserFromUbs(Principal principal,
@@ -101,6 +100,9 @@ public class RestClient {
         HttpHeaders httpHeaders = setHeader();
         HttpEntity<String> httpEntity = new HttpEntity<>(httpHeaders);
         String userEmail = principal.getName();
+
+        UriComponentsBuilder ubsNotificationsUrlBuilder = UriComponentsBuilder.fromHttpUrl(
+            greenCityUbsServerAddress + RestTemplateLinks.NOTIFICATIONS);
 
         String url = ubsNotificationsUrlBuilder
             .queryParam(PAGE_QUERY_PARAM, pageable.getPageNumber())


### PR DESCRIPTION
# GreenCity PR
[Task](https://github.com/orgs/ita-social-projects/projects/44/views/1?pane=issue&itemId=105079675&issue=ita-social-projects%7CGreenCity%7C8293)

## Summary Of Changes :fire:
Made UriComponentsBuilder a method variable rather than a class field. The change was done because when the UriComponentsBuilder was a class field, the query parameters accumulated as it was used multiple times, causing incorrect url  to be built 

## Issue Link :clipboard:
[#8293](https://github.com/ita-social-projects/GreenCity/issues/8293)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the internal process for constructing notification endpoints by enhancing configuration handling, resulting in clearer and more efficient processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->