### PR TITLE
8307/fix custom habit creation 500 error

### DIFF
--- a/dao/src/main/java/greencity/entity/CustomToDoListItem.java
+++ b/dao/src/main/java/greencity/entity/CustomToDoListItem.java
@@ -18,7 +18,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 @Getter
 @Setter
 @EqualsAndHashCode
-@ToString(exclude = {"user", "dateCompleted"})
+@ToString(exclude = {"user", "dateCompleted", "habit"})
 @Table(name = "custom_to_do_list_items")
 @Builder
 public class CustomToDoListItem {

--- a/service/src/main/java/greencity/mapping/HabitTranslationMapper.java
+++ b/service/src/main/java/greencity/mapping/HabitTranslationMapper.java
@@ -64,13 +64,13 @@ public class HabitTranslationMapper extends AbstractConverter<HabitTranslationDt
      */
     public List<HabitTranslation> mapAllToList(List<HabitTranslationDto> dtoList, Language language, Habit habit) {
         return dtoList.stream()
-            .filter(dto -> language.getCode().equals(dto.getLanguageCode()))
+            .filter(dto -> Objects.equals(language.getCode(), dto.getLanguageCode()))
             .map(dto -> {
                 HabitTranslation habitTranslation = convert(dto);
                 habitTranslation.setLanguage(language);
                 habitTranslation.setHabit(habit);
                 return habitTranslation;
             })
-            .collect(Collectors.toList());
+            .toList();
     }
 }

--- a/service/src/main/java/greencity/mapping/HabitTranslationMapper.java
+++ b/service/src/main/java/greencity/mapping/HabitTranslationMapper.java
@@ -8,7 +8,6 @@ import org.modelmapper.AbstractConverter;
 import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Component
 public class HabitTranslationMapper extends AbstractConverter<HabitTranslationDto, HabitTranslation> {
@@ -30,7 +29,7 @@ public class HabitTranslationMapper extends AbstractConverter<HabitTranslationDt
      * @author Lilia Mokhnatska
      */
     public List<HabitTranslation> mapAllToList(List<HabitTranslationDto> dtoList) {
-        return dtoList.stream().map(this::convert).collect(Collectors.toList());
+        return dtoList.stream().map(this::convert).toList();
     }
 
     /**
@@ -46,7 +45,7 @@ public class HabitTranslationMapper extends AbstractConverter<HabitTranslationDt
      */
     public List<HabitTranslation> mapAllToList(List<HabitTranslationDto> dtoList, String language) {
         return dtoList.stream().filter(dto -> Objects.equals(language, dto.getLanguageCode()))
-            .map(this::convert).collect(Collectors.toList());
+            .map(this::convert).toList();
     }
 
     /**

--- a/service/src/main/java/greencity/mapping/HabitTranslationMapper.java
+++ b/service/src/main/java/greencity/mapping/HabitTranslationMapper.java
@@ -1,7 +1,9 @@
 package greencity.mapping;
 
 import greencity.dto.habittranslation.HabitTranslationDto;
+import greencity.entity.Habit;
 import greencity.entity.HabitTranslation;
+import greencity.entity.Language;
 import org.modelmapper.AbstractConverter;
 import org.springframework.stereotype.Component;
 import java.util.List;
@@ -45,5 +47,29 @@ public class HabitTranslationMapper extends AbstractConverter<HabitTranslationDt
     public List<HabitTranslation> mapAllToList(List<HabitTranslationDto> dtoList, String language) {
         return dtoList.stream().filter(dto -> Objects.equals(language, dto.getLanguageCode()))
             .map(this::convert).collect(Collectors.toList());
+    }
+
+    /**
+     * Method that builds {@link List} of {@link HabitTranslation} from {@link List}
+     * of {@link HabitTranslationDto}, {@link Language} language and {@link Habit} habit.
+     *
+     * @param dtoList  {@link List} of {@link HabitTranslationDto}
+     * @param language {@link Language}
+     * @param habit {@link Habit}
+     *
+     * @return {@link List} of {@link HabitTranslation}
+     *
+     * @author Bulhakova Oleksandra
+     */
+    public List<HabitTranslation> mapAllToList(List<HabitTranslationDto> dtoList, Language language, Habit habit) {
+        return dtoList.stream()
+                .filter(dto -> language.getCode().equals(dto.getLanguageCode()))
+                .map(dto -> {
+                    HabitTranslation habitTranslation = convert(dto);
+                    habitTranslation.setLanguage(language);
+                    habitTranslation.setHabit(habit);
+                    return habitTranslation;
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/service/src/main/java/greencity/mapping/HabitTranslationMapper.java
+++ b/service/src/main/java/greencity/mapping/HabitTranslationMapper.java
@@ -51,11 +51,12 @@ public class HabitTranslationMapper extends AbstractConverter<HabitTranslationDt
 
     /**
      * Method that builds {@link List} of {@link HabitTranslation} from {@link List}
-     * of {@link HabitTranslationDto}, {@link Language} language and {@link Habit} habit.
+     * of {@link HabitTranslationDto}, {@link Language} language and {@link Habit}
+     * habit.
      *
      * @param dtoList  {@link List} of {@link HabitTranslationDto}
      * @param language {@link Language}
-     * @param habit {@link Habit}
+     * @param habit    {@link Habit}
      *
      * @return {@link List} of {@link HabitTranslation}
      *
@@ -63,13 +64,13 @@ public class HabitTranslationMapper extends AbstractConverter<HabitTranslationDt
      */
     public List<HabitTranslation> mapAllToList(List<HabitTranslationDto> dtoList, Language language, Habit habit) {
         return dtoList.stream()
-                .filter(dto -> language.getCode().equals(dto.getLanguageCode()))
-                .map(dto -> {
-                    HabitTranslation habitTranslation = convert(dto);
-                    habitTranslation.setLanguage(language);
-                    habitTranslation.setHabit(habit);
-                    return habitTranslation;
-                })
-                .collect(Collectors.toList());
+            .filter(dto -> language.getCode().equals(dto.getLanguageCode()))
+            .map(dto -> {
+                HabitTranslation habitTranslation = convert(dto);
+                habitTranslation.setLanguage(language);
+                habitTranslation.setHabit(habit);
+                return habitTranslation;
+            })
+            .collect(Collectors.toList());
     }
 }

--- a/service/src/main/java/greencity/service/HabitServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitServiceImpl.java
@@ -503,15 +503,16 @@ public class HabitServiceImpl implements HabitService {
 
     private void saveHabitTranslationListsToHabitTranslationRepo(CustomHabitDtoRequest habitDto, Habit habit) {
         List<HabitTranslation> habitTranslations = habitDto
-                .getHabitTranslations().stream()
-                .filter(dto -> {
-                    if (!AppConstant.supportedLanguages.contains(dto.getLanguageCode())) {
-                        throw new NotFoundException(ErrorMessage.INVALID_LANGUAGE_CODE);
-                    }
-                    return true;
-                })
-                .map(dto -> mapHabitTranslationFromAddCustomHabitDtoRequestWithLanguage(habitDto, languageRepo.findByCode(dto.getLanguageCode()).get(), habit))
-                .flatMap(Collection::stream).toList();
+            .getHabitTranslations().stream()
+            .filter(dto -> {
+                if (!AppConstant.supportedLanguages.contains(dto.getLanguageCode())) {
+                    throw new NotFoundException(ErrorMessage.INVALID_LANGUAGE_CODE);
+                }
+                return true;
+            })
+            .map(dto -> mapHabitTranslationFromAddCustomHabitDtoRequestWithLanguage(habitDto,
+                languageRepo.findByCode(dto.getLanguageCode()).get(), habit))
+            .flatMap(Collection::stream).toList();
         habit.setHabitTranslations(habitTranslations);
     }
 
@@ -790,8 +791,9 @@ public class HabitServiceImpl implements HabitService {
         return new PageImpl<>(dtoList, pageable, dtoList.size());
     }
 
-    private List<HabitTranslation> mapHabitTranslationFromAddCustomHabitDtoRequestWithLanguage(CustomHabitDtoRequest habitDto,
-                                                                                   Language language, Habit habit) {
+    private List<HabitTranslation> mapHabitTranslationFromAddCustomHabitDtoRequestWithLanguage(
+        CustomHabitDtoRequest habitDto,
+        Language language, Habit habit) {
         return habitTranslationMapper.mapAllToList(habitDto.getHabitTranslations(), language, habit);
     }
 }

--- a/service/src/main/java/greencity/service/HabitServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitServiceImpl.java
@@ -512,7 +512,8 @@ public class HabitServiceImpl implements HabitService {
             })
             .map(dto -> mapHabitTranslationFromAddCustomHabitDtoRequestWithLanguage(habitDto,
                 languageRepo.findByCode(dto.getLanguageCode())
-                        .orElseThrow(() -> new NotFoundException(ErrorMessage.SELECT_CORRECT_LANGUAGE)), habit))
+                    .orElseThrow(() -> new NotFoundException(ErrorMessage.SELECT_CORRECT_LANGUAGE)),
+                habit))
             .flatMap(Collection::stream).toList();
         habit.setHabitTranslations(habitTranslations);
     }

--- a/service/src/main/java/greencity/service/HabitServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitServiceImpl.java
@@ -511,7 +511,8 @@ public class HabitServiceImpl implements HabitService {
                 return true;
             })
             .map(dto -> mapHabitTranslationFromAddCustomHabitDtoRequestWithLanguage(habitDto,
-                languageRepo.findByCode(dto.getLanguageCode()).get(), habit))
+                languageRepo.findByCode(dto.getLanguageCode())
+                        .orElseThrow(() -> new NotFoundException(ErrorMessage.SELECT_CORRECT_LANGUAGE)), habit))
             .flatMap(Collection::stream).toList();
         habit.setHabitTranslations(habitTranslations);
     }

--- a/service/src/main/java/greencity/service/HabitServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitServiceImpl.java
@@ -517,11 +517,6 @@ public class HabitServiceImpl implements HabitService {
         habit.setHabitTranslations(habitTranslations);
     }
 
-    private List<HabitTranslation> mapHabitTranslationFromAddCustomHabitDtoRequest(CustomHabitDtoRequest habitDto,
-        String language) {
-        return habitTranslationMapper.mapAllToList(habitDto.getHabitTranslations(), language);
-    }
-
     private void setTagsIdsToHabit(CustomHabitDtoRequest habitDto, Habit habit) {
         habit.setTags(habitDto.getTagIds().stream().map(tagId -> tagsRepo.findById(tagId)
             .orElseThrow(() -> new NotFoundException(ErrorMessage.TAG_NOT_FOUND + tagId)))

--- a/service/src/main/java/greencity/service/HabitServiceImpl.java
+++ b/service/src/main/java/greencity/service/HabitServiceImpl.java
@@ -15,12 +15,13 @@ import greencity.dto.notification.LikeNotificationDto;
 import greencity.dto.todolistitem.ToDoListItemDto;
 import greencity.dto.user.UserProfilePictureDto;
 import greencity.dto.user.UserVO;
-import greencity.entity.CustomToDoListItem;
 import greencity.entity.Habit;
-import greencity.entity.HabitAssign;
 import greencity.entity.HabitTranslation;
-import greencity.entity.Tag;
 import greencity.entity.User;
+import greencity.entity.Tag;
+import greencity.entity.HabitAssign;
+import greencity.entity.CustomToDoListItem;
+import greencity.entity.Language;
 import greencity.enums.HabitAssignStatus;
 import greencity.enums.Role;
 import greencity.enums.AchievementCategoryType;
@@ -502,15 +503,15 @@ public class HabitServiceImpl implements HabitService {
 
     private void saveHabitTranslationListsToHabitTranslationRepo(CustomHabitDtoRequest habitDto, Habit habit) {
         List<HabitTranslation> habitTranslations = habitDto
-            .getHabitTranslations().stream()
-            .filter(dto -> {
-                if (!AppConstant.supportedLanguages.contains(dto.getLanguageCode())) {
-                    throw new NotFoundException(ErrorMessage.INVALID_LANGUAGE_CODE);
-                }
-                return true;
-            })
-            .map(dto -> mapHabitTranslationFromAddCustomHabitDtoRequest(habitDto, dto.getLanguageCode()))
-            .flatMap(Collection::stream).toList();
+                .getHabitTranslations().stream()
+                .filter(dto -> {
+                    if (!AppConstant.supportedLanguages.contains(dto.getLanguageCode())) {
+                        throw new NotFoundException(ErrorMessage.INVALID_LANGUAGE_CODE);
+                    }
+                    return true;
+                })
+                .map(dto -> mapHabitTranslationFromAddCustomHabitDtoRequestWithLanguage(habitDto, languageRepo.findByCode(dto.getLanguageCode()).get(), habit))
+                .flatMap(Collection::stream).toList();
         habit.setHabitTranslations(habitTranslations);
     }
 
@@ -787,5 +788,10 @@ public class HabitServiceImpl implements HabitService {
                 .build())
             .collect(Collectors.toList());
         return new PageImpl<>(dtoList, pageable, dtoList.size());
+    }
+
+    private List<HabitTranslation> mapHabitTranslationFromAddCustomHabitDtoRequestWithLanguage(CustomHabitDtoRequest habitDto,
+                                                                                   Language language, Habit habit) {
+        return habitTranslationMapper.mapAllToList(habitDto.getHabitTranslations(), language, habit);
     }
 }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -3592,10 +3592,10 @@ public class ModelUtils {
 
     public static HabitTranslationDto getHabitTranslationDtoUk() {
         return HabitTranslationDto.builder()
-                .description(habitTranslationDescriptionUk)
-                .habitItem(habitItemUk)
-                .name(habitTranslationNameUk)
-                .languageCode("ua")
-                .build();
+            .description(habitTranslationDescriptionUk)
+            .habitItem(habitItemUk)
+            .name(habitTranslationNameUk)
+            .languageCode("ua")
+            .build();
     }
 }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -3589,4 +3589,13 @@ public class ModelUtils {
             .countComments(0)
             .build();
     }
+
+    public static HabitTranslationDto getHabitTranslationDtoUk() {
+        return HabitTranslationDto.builder()
+                .description(habitTranslationDescriptionUk)
+                .habitItem(habitItemUk)
+                .name(habitTranslationNameUk)
+                .languageCode("ua")
+                .build();
+    }
 }

--- a/service/src/test/java/greencity/mapping/HabitTranslationMapperTests.java
+++ b/service/src/test/java/greencity/mapping/HabitTranslationMapperTests.java
@@ -102,17 +102,17 @@ class HabitTranslationMapperTests {
         Language languageUk = ModelUtils.getLanguageUa();
         List<HabitTranslationDto> habitTranslationDtoList = List.of(habitTranslationDto);
         HabitTranslation expectedHabitTranslation = HabitTranslation.builder()
-                .description(habitTranslationDto.getDescription())
-                .habitItem(habitTranslationDto.getHabitItem())
-                .name(habitTranslationDto.getName())
-                .habit(habit)
-                .language(languageUk)
-                .build();
+            .description(habitTranslationDto.getDescription())
+            .habitItem(habitTranslationDto.getHabitItem())
+            .name(habitTranslationDto.getName())
+            .habit(habit)
+            .language(languageUk)
+            .build();
 
         List<HabitTranslation> expectedList = List.of(expectedHabitTranslation);
 
         assertEquals(expectedList,
-                habitTranslationMapper.mapAllToList(habitTranslationDtoList, languageUk, habit));
+            habitTranslationMapper.mapAllToList(habitTranslationDtoList, languageUk, habit));
     }
 
     @Test
@@ -123,16 +123,16 @@ class HabitTranslationMapperTests {
         Language languageEn = ModelUtils.getLanguage();
         List<HabitTranslationDto> habitTranslationDtoList = List.of(habitTranslationDto);
         HabitTranslation expectedHabitTranslation = HabitTranslation.builder()
-                .description(habitTranslationDto.getDescription())
-                .habitItem(habitTranslationDto.getHabitItem())
-                .name(habitTranslationDto.getName())
-                .habit(habit)
-                .language(languageEn)
-                .build();
+            .description(habitTranslationDto.getDescription())
+            .habitItem(habitTranslationDto.getHabitItem())
+            .name(habitTranslationDto.getName())
+            .habit(habit)
+            .language(languageEn)
+            .build();
 
         List<HabitTranslation> expectedList = List.of(expectedHabitTranslation);
 
         assertEquals(expectedList,
-                habitTranslationMapper.mapAllToList(habitTranslationDtoList, languageEn, habit));
+            habitTranslationMapper.mapAllToList(habitTranslationDtoList, languageEn, habit));
     }
 }

--- a/service/src/test/java/greencity/mapping/HabitTranslationMapperTests.java
+++ b/service/src/test/java/greencity/mapping/HabitTranslationMapperTests.java
@@ -3,7 +3,9 @@ package greencity.mapping;
 import greencity.ModelUtils;
 import greencity.constant.AppConstant;
 import greencity.dto.habittranslation.HabitTranslationDto;
+import greencity.entity.Habit;
 import greencity.entity.HabitTranslation;
+import greencity.entity.Language;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -90,5 +92,47 @@ class HabitTranslationMapperTests {
 
         assertEquals(expectedList,
             habitTranslationMapper.mapAllToList(habitTranslationDtoList, AppConstant.LANGUAGE_CODE_UA));
+    }
+
+    @Test
+    void mapAllToListWithUkLanguageAndHabitTest() {
+        HabitTranslationDto habitTranslationDto = ModelUtils.getHabitTranslationDtoUk();
+        habitTranslationDto.setLanguageCode(AppConstant.LANGUAGE_CODE_UA);
+        Habit habit = ModelUtils.getHabit();
+        Language languageUk = ModelUtils.getLanguageUa();
+        List<HabitTranslationDto> habitTranslationDtoList = List.of(habitTranslationDto);
+        HabitTranslation expectedHabitTranslation = HabitTranslation.builder()
+                .description(habitTranslationDto.getDescription())
+                .habitItem(habitTranslationDto.getHabitItem())
+                .name(habitTranslationDto.getName())
+                .habit(habit)
+                .language(languageUk)
+                .build();
+
+        List<HabitTranslation> expectedList = List.of(expectedHabitTranslation);
+
+        assertEquals(expectedList,
+                habitTranslationMapper.mapAllToList(habitTranslationDtoList, languageUk, habit));
+    }
+
+    @Test
+    void mapAllToListWithEnLanguageAndHabitTest() {
+        HabitTranslationDto habitTranslationDto = ModelUtils.getHabitTranslationDto();
+        habitTranslationDto.setLanguageCode(AppConstant.DEFAULT_LANGUAGE_CODE);
+        Habit habit = ModelUtils.getHabit();
+        Language languageEn = ModelUtils.getLanguage();
+        List<HabitTranslationDto> habitTranslationDtoList = List.of(habitTranslationDto);
+        HabitTranslation expectedHabitTranslation = HabitTranslation.builder()
+                .description(habitTranslationDto.getDescription())
+                .habitItem(habitTranslationDto.getHabitItem())
+                .name(habitTranslationDto.getName())
+                .habit(habit)
+                .language(languageEn)
+                .build();
+
+        List<HabitTranslation> expectedList = List.of(expectedHabitTranslation);
+
+        assertEquals(expectedList,
+                habitTranslationMapper.mapAllToList(habitTranslationDtoList, languageEn, habit));
     }
 }

--- a/service/src/test/java/greencity/service/HabitServiceImplTest.java
+++ b/service/src/test/java/greencity/service/HabitServiceImplTest.java
@@ -660,7 +660,8 @@ class HabitServiceImplTest {
         verify(habitRepo).save(customHabitMapper.convert(addCustomHabitDtoRequest));
         verify(customHabitMapper, times(3)).convert(addCustomHabitDtoRequest);
         verify(tagsRepo).findById(20L);
-        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDtoEN), Optional.of(languageEn).get(), habit);
+        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDtoEN),
+            Optional.of(languageEn).get(), habit);
         verify(customToDoListItemRepo).findAllByUserIdAndHabitId(1L, 1L);
         verify(customToDoListMapper).mapAllToList(anyList());
         verify(modelMapper).map(habit, CustomHabitDtoResponse.class);
@@ -733,7 +734,8 @@ class HabitServiceImplTest {
         verify(habitRepo).save(customHabitMapper.convert(addCustomHabitDtoRequest));
         verify(customHabitMapper, times(3)).convert(addCustomHabitDtoRequest);
         verify(tagsRepo).findById(20L);
-        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDtoEN), Optional.of(languageEn).get(), habit);
+        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDtoEN),
+            Optional.of(languageEn).get(), habit);
         verify(habitTranslationMapper, times(0)).mapAllToList(List.of(habitTranslationDtoEN), "ua");
         verify(customToDoListItemRepo).findAllByUserIdAndHabitId(1L, 1L);
         verify(customToDoListMapper).mapAllToList(anyList());
@@ -806,7 +808,8 @@ class HabitServiceImplTest {
         verify(habitRepo).save(customHabitMapper.convert(addCustomHabitDtoRequest));
         verify(customHabitMapper, times(3)).convert(addCustomHabitDtoRequest);
         verify(tagsRepo).findById(20L);
-        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDtoEN), Optional.of(languageEn).get(), habit);
+        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDtoEN),
+            Optional.of(languageEn).get(), habit);
         verify(customToDoListItemRepo).findAllByUserIdAndHabitId(1L, 1L);
         verify(customToDoListMapper).mapAllToList(anyList());
         verify(modelMapper).map(habit, CustomHabitDtoResponse.class);
@@ -880,7 +883,8 @@ class HabitServiceImplTest {
         verify(habitRepo).save(customHabitMapper.convert(addCustomHabitDtoRequest));
         verify(customHabitMapper, times(3)).convert(addCustomHabitDtoRequest);
         verify(tagsRepo).findById(20L);
-        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDtoEN), Optional.of(languageEn).get(), habit);
+        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDtoEN),
+            Optional.of(languageEn).get(), habit);
         verify(customToDoListItemRepo).findAllByUserIdAndHabitId(1L, 1L);
         verify(customToDoListMapper).mapAllToList(anyList());
         verify(modelMapper).map(habit, CustomHabitDtoResponse.class);

--- a/service/src/test/java/greencity/service/HabitServiceImplTest.java
+++ b/service/src/test/java/greencity/service/HabitServiceImplTest.java
@@ -660,7 +660,7 @@ class HabitServiceImplTest {
         verify(habitRepo).save(customHabitMapper.convert(addCustomHabitDtoRequest));
         verify(customHabitMapper, times(3)).convert(addCustomHabitDtoRequest);
         verify(tagsRepo).findById(20L);
-        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDtoEN), "en");
+        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDtoEN), Optional.of(languageEn).get(), habit);
         verify(customToDoListItemRepo).findAllByUserIdAndHabitId(1L, 1L);
         verify(customToDoListMapper).mapAllToList(anyList());
         verify(modelMapper).map(habit, CustomHabitDtoResponse.class);
@@ -733,7 +733,7 @@ class HabitServiceImplTest {
         verify(habitRepo).save(customHabitMapper.convert(addCustomHabitDtoRequest));
         verify(customHabitMapper, times(3)).convert(addCustomHabitDtoRequest);
         verify(tagsRepo).findById(20L);
-        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDtoEN), "en");
+        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDtoEN), Optional.of(languageEn).get(), habit);
         verify(habitTranslationMapper, times(0)).mapAllToList(List.of(habitTranslationDtoEN), "ua");
         verify(customToDoListItemRepo).findAllByUserIdAndHabitId(1L, 1L);
         verify(customToDoListMapper).mapAllToList(anyList());
@@ -806,7 +806,7 @@ class HabitServiceImplTest {
         verify(habitRepo).save(customHabitMapper.convert(addCustomHabitDtoRequest));
         verify(customHabitMapper, times(3)).convert(addCustomHabitDtoRequest);
         verify(tagsRepo).findById(20L);
-        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDtoEN), "en");
+        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDtoEN), Optional.of(languageEn).get(), habit);
         verify(customToDoListItemRepo).findAllByUserIdAndHabitId(1L, 1L);
         verify(customToDoListMapper).mapAllToList(anyList());
         verify(modelMapper).map(habit, CustomHabitDtoResponse.class);
@@ -880,7 +880,7 @@ class HabitServiceImplTest {
         verify(habitRepo).save(customHabitMapper.convert(addCustomHabitDtoRequest));
         verify(customHabitMapper, times(3)).convert(addCustomHabitDtoRequest);
         verify(tagsRepo).findById(20L);
-        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDtoEN), "en");
+        verify(habitTranslationMapper, times(1)).mapAllToList(List.of(habitTranslationDtoEN), Optional.of(languageEn).get(), habit);
         verify(customToDoListItemRepo).findAllByUserIdAndHabitId(1L, 1L);
         verify(customToDoListMapper).mapAllToList(anyList());
         verify(modelMapper).map(habit, CustomHabitDtoResponse.class);


### PR DESCRIPTION
Task - [#8307](https://github.com/ita-social-projects/GreenCity/issues/8307)

The problem was that we got a 500 error when attempted to create a custom habit. 

![Screenshot_648](https://github.com/user-attachments/assets/39cd57ce-1a20-4b93-95d1-1fec69022f73)

At first, it was a mapper error, but when I fixed it, it occurred that there was a small logic error in creation: to create a habit, we had to save a new habitTranslation which required habit id, but we couldn't because this saved habit wasn't added to habitTranslation yet. So I wrote a method that mapped habitTranslation and added habit, so that we can create it properly.

![Screenshot_649](https://github.com/user-attachments/assets/80cb27f1-2a71-4dc1-8409-46f1de68b07d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced habit translation mapping now supports language-specific filtering for more accurate translations.
  - Added a utility method to create a `HabitTranslationDto` specifically for the Ukrainian language.

- **Bug Fixes**
  - Improved string representation of `CustomToDoListItem` by excluding the `habit` field.

- **Refactor**
  - Revised handling of habit item details for cleaner outputs and streamlined processing.

- **Tests**
  - Introduced new test cases for mapping functionality with language-specific parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->