### PR TITLE
Added ability to retrieve a list of cities relevant to the user

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -262,6 +262,7 @@ public class SecurityConfig {
                     "/user/{userId}/friends/",
                     "/user/{userId}/friendRequests/",
                     "/chat",
+                    EVENTS + "/addresses/get-relevant",
                     EVENTS + ATTENDERS + COUNT,
                     EVENTS + ORGANIZERS + COUNT,
                     EVENTS + EVENT_ID + LIKES,

--- a/core/src/main/java/greencity/controller/EventController.java
+++ b/core/src/main/java/greencity/controller/EventController.java
@@ -12,6 +12,7 @@ import greencity.dto.PageableDto;
 import greencity.dto.event.AddEventDtoRequest;
 import greencity.dto.event.AddressDto;
 import greencity.dto.event.EventAttenderDto;
+import greencity.dto.event.EventCityDto;
 import greencity.dto.event.EventDto;
 import greencity.dto.event.EventResponseDto;
 import greencity.dto.event.UpdateEventRequestDto;
@@ -732,5 +733,22 @@ public class EventController {
         @Parameter(hidden = true) Principal principal) {
         eventService.declineRequest(eventId, principal.getName(), userId);
         return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    /**
+     * Retrieves cities relevant to the user, such as the user's own city
+     * (if available) and the top three cities with the highest number of events.
+     *
+     * @author Andrii Danylenko
+     */
+    @Operation(summary = "Retrieves cities relevant to the user, such as the user's own city " +
+            "(if available) and the top three cities with the highest number of events.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED)
+    })
+    @GetMapping("/addresses/get-relevant")
+    public ResponseEntity<List<EventCityDto>> getRelevantAddresses(@Parameter(hidden = true) @CurrentUser UserVO userVO) {
+        return ResponseEntity.ok(eventService.getAllRelevantEventsCityByUser(userVO));
     }
 }

--- a/core/src/main/java/greencity/controller/EventController.java
+++ b/core/src/main/java/greencity/controller/EventController.java
@@ -736,19 +736,20 @@ public class EventController {
     }
 
     /**
-     * Retrieves cities relevant to the user, such as the user's own city
-     * (if available) and the top three cities with the highest number of events.
+     * Retrieves cities relevant to the user, such as the user's own city (if
+     * available) and the top three cities with the highest number of events.
      *
      * @author Andrii Danylenko
      */
-    @Operation(summary = "Retrieves cities relevant to the user, such as the user's own city " +
-            "(if available) and the top three cities with the highest number of events.")
+    @Operation(summary = "Retrieves cities relevant to the user, such as the user's own city "
+            + "(if available) and the top three cities with the highest number of events.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED)
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED)
     })
     @GetMapping("/addresses/get-relevant")
-    public ResponseEntity<List<EventCityDto>> getRelevantAddresses(@Parameter(hidden = true) @CurrentUser UserVO userVO) {
+    public ResponseEntity<List<EventCityDto>> getRelevantAddresses(
+        @Parameter(hidden = true) @CurrentUser UserVO userVO) {
         return ResponseEntity.ok(eventService.getAllRelevantEventsCityByUser(userVO));
     }
 }

--- a/core/src/main/java/greencity/controller/EventController.java
+++ b/core/src/main/java/greencity/controller/EventController.java
@@ -742,7 +742,7 @@ public class EventController {
      * @author Andrii Danylenko
      */
     @Operation(summary = "Retrieves cities relevant to the user, such as the user's own city "
-            + "(if available) and the top three cities with the highest number of events.")
+        + "(if available) and the top three cities with the highest number of events.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED)

--- a/core/src/test/java/greencity/controller/EventControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventControllerTest.java
@@ -40,6 +40,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
 import static greencity.ModelUtils.getCreateJsonFile;
 import static greencity.ModelUtils.getEventDtoPageableAdvancedDto;
 import static greencity.ModelUtils.getPrincipal;
@@ -84,9 +85,9 @@ class EventControllerTest {
     @BeforeEach
     void setup() {
         this.mockMvc = MockMvcBuilders.standaloneSetup(eventController)
-            .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver(),
-                new UserArgumentResolver(userService, modelMapper))
-            .build();
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver(),
+                        new UserArgumentResolver(userService, modelMapper))
+                .build();
     }
 
     @Test
@@ -102,16 +103,16 @@ class EventControllerTest {
         FilterEventDto filterEventDto = ModelUtils.getFilterEventDto();
 
         when(eventService.getEvents(pageable, filterEventDto, userId))
-            .thenReturn(eventDtoPageableAdvancedDto);
+                .thenReturn(eventDtoPageableAdvancedDto);
 
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK)
-            .param("page", "0")
-            .param("size", "20")
-            .param("user-id", userId.toString())
-            .param("statuses", filterEventDto.getStatuses().stream().map(Enum::name).collect(Collectors.joining(",")))
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().json(expectedJson));
+                        .param("page", "0")
+                        .param("size", "20")
+                        .param("user-id", userId.toString())
+                        .param("statuses", filterEventDto.getStatuses().stream().map(Enum::name).collect(Collectors.joining(",")))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().json(expectedJson));
 
         verify(eventService).getEvents(pageable, filterEventDto, userId);
     }
@@ -120,10 +121,10 @@ class EventControllerTest {
     @SneakyThrows
     void getEventsThrowExceptionTest() {
         assertThatThrownBy(
-            () -> mockMvc.perform(get(EVENTS_CONTROLLER_LINK)
-                .param("statuses", EventStatus.JOINED.name()))
-                .andExpect(status().isBadRequest()))
-            .hasCause(new BadRequestException(ErrorMessage.STATUSES_REQUIRE_USER_ID));
+                () -> mockMvc.perform(get(EVENTS_CONTROLLER_LINK)
+                                .param("statuses", EventStatus.JOINED.name()))
+                        .andExpect(status().isBadRequest()))
+                .hasCause(new BadRequestException(ErrorMessage.STATUSES_REQUIRE_USER_ID));
     }
 
     @Test
@@ -131,7 +132,7 @@ class EventControllerTest {
     void addAttenderTest() {
         Long eventId = 1L;
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId)
-            .principal(principal));
+                .principal(principal));
         verify(eventService).addAttender(eventId, principal.getName());
     }
 
@@ -140,8 +141,8 @@ class EventControllerTest {
     void addAttenderWithNotValidIdBadRequestTest() {
         String notValidId = "id";
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", notValidId)
-            .principal(principal))
-            .andExpect(status().isBadRequest());
+                        .principal(principal))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -150,14 +151,14 @@ class EventControllerTest {
         Long eventId = 1L;
 
         doThrow(new NotFoundException("ErrorMessage"))
-            .when(eventService)
-            .addAttender(eventId, principal.getName());
+                .when(eventService)
+                .addAttender(eventId, principal.getName());
 
         assertThatThrownBy(
-            () -> mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId)
-                .principal(principal))
-                .andExpect(status().isNotFound()))
-            .hasCause(new NotFoundException("ErrorMessage"));
+                () -> mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId)
+                                .principal(principal))
+                        .andExpect(status().isNotFound()))
+                .hasCause(new NotFoundException("ErrorMessage"));
     }
 
     @Test
@@ -166,14 +167,14 @@ class EventControllerTest {
         Long eventId = 1L;
 
         doThrow(new BadRequestException("ErrorMessage"))
-            .when(eventService)
-            .addAttender(eventId, principal.getName());
+                .when(eventService)
+                .addAttender(eventId, principal.getName());
 
         assertThatThrownBy(
-            () -> mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId)
-                .principal(principal))
-                .andExpect(status().isBadRequest()))
-            .hasCause(new BadRequestException("ErrorMessage"));
+                () -> mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId)
+                                .principal(principal))
+                        .andExpect(status().isBadRequest()))
+                .hasCause(new BadRequestException("ErrorMessage"));
     }
 
     @Test
@@ -181,8 +182,8 @@ class EventControllerTest {
     void addToFavoritesTest() {
         Long eventId = 1L;
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/favorites", eventId)
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
         verify(eventService).addToFavorites(eventId, principal.getName());
     }
 
@@ -191,8 +192,8 @@ class EventControllerTest {
     void removeFromFavoritesTest() {
         Long eventId = 1L;
         mockMvc.perform(delete(EVENTS_CONTROLLER_LINK + "/{eventId}/favorites", eventId)
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
         verify(eventService).removeFromFavorites(eventId, principal.getName());
     }
 
@@ -204,14 +205,14 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile jsonFile =
-            new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
+                new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
 
         mockMvc.perform(multipart(EVENTS_CONTROLLER_LINK)
-            .file(jsonFile)
-            .principal(principal)
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-            .andExpect(status().isCreated());
+                        .file(jsonFile)
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andExpect(status().isCreated());
 
         verify(eventService).save(eq(addEventDtoRequest), eq(principal.getName()), isNull());
     }
@@ -221,13 +222,13 @@ class EventControllerTest {
     void saveBadRequestTest() {
         String json = "{}";
         MockMultipartFile jsonFile =
-            new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
+                new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
         mockMvc.perform(multipart(EVENTS_CONTROLLER_LINK)
-            .file(jsonFile)
-            .principal(principal)
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-            .andExpect(status().isBadRequest());
+                        .file(jsonFile)
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -238,14 +239,14 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile jsonFile =
-            new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
+                new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
 
         mockMvc.perform(multipart("/events/createV2")
-            .file(jsonFile)
-            .principal(principal)
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-            .andExpect(status().isCreated());
+                        .file(jsonFile)
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andExpect(status().isCreated());
 
         verify(eventService).saveV2(eq(addEventDtoRequest), eq(principal.getName()), isNull());
     }
@@ -255,13 +256,13 @@ class EventControllerTest {
     void saveV2BadRequestTest() {
         String json = "{}";
         MockMultipartFile jsonFile =
-            new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
+                new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
         mockMvc.perform(multipart("/events/createV2")
-            .file(jsonFile)
-            .principal(principal)
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-            .andExpect(status().isBadRequest());
+                        .file(jsonFile)
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -269,7 +270,7 @@ class EventControllerTest {
     void removeAttenderTest() {
         Long eventId = 1L;
         mockMvc.perform(delete(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId).principal(principal))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
         verify(eventService).removeAttender(eventId, principal.getName());
     }
 
@@ -278,8 +279,8 @@ class EventControllerTest {
     void removeAttenderBadRequestTest() {
         String notValidId = "id";
         mockMvc.perform(delete(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", notValidId)
-            .principal(principal))
-            .andExpect(status().isBadRequest());
+                        .principal(principal))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -287,20 +288,20 @@ class EventControllerTest {
     void removeAttenderNotFoundTest() {
         Long eventId = 1L;
         doThrow(new NotFoundException("ErrorMessage"))
-            .when(eventService)
-            .removeAttender(eventId, principal.getName());
+                .when(eventService)
+                .removeAttender(eventId, principal.getName());
 
         assertThatThrownBy(() -> mockMvc
-            .perform(delete(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId).principal(principal))
-            .andExpect(status().isNotFound())).hasCause(new NotFoundException("ErrorMessage"));
+                .perform(delete(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId).principal(principal))
+                .andExpect(status().isNotFound())).hasCause(new NotFoundException("ErrorMessage"));
     }
 
     @Test
     @SneakyThrows
     void deleteTest() {
         mockMvc.perform(delete(EVENTS_CONTROLLER_LINK + "/{eventId}", 1)
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
 
         verify(eventService).delete(1L, "test@gmail.com");
     }
@@ -309,8 +310,8 @@ class EventControllerTest {
     @SneakyThrows
     void deleteFailedTest() {
         mockMvc.perform(delete(EVENTS_CONTROLLER_LINK + "/{eventId}", "not_number")
-            .principal(principal))
-            .andExpect(status().isBadRequest());
+                        .principal(principal))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -321,7 +322,7 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(updateEventDto);
 
         MockMultipartFile jsonFile =
-            new MockMultipartFile("eventDto", "", "application/json", json.getBytes());
+                new MockMultipartFile("eventDto", "", "application/json", json.getBytes());
 
         MockMultipartHttpServletRequestBuilder builder = multipart(EVENTS_CONTROLLER_LINK + "/{eventId}", 1L);
         builder.with(request -> {
@@ -330,11 +331,11 @@ class EventControllerTest {
         });
 
         mockMvc.perform(builder
-            .file(jsonFile)
-            .principal(principal)
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-            .andExpect(status().isOk());
+                        .file(jsonFile)
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andExpect(status().isOk());
 
         verify(eventService).update(updateEventDto, principal.getName(), null);
     }
@@ -347,7 +348,7 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(updateEventDto);
 
         MockMultipartFile jsonFile =
-            new MockMultipartFile("eventDto", "", "application/json", json.getBytes());
+                new MockMultipartFile("eventDto", "", "application/json", json.getBytes());
 
         MockMultipartHttpServletRequestBuilder builder = multipart(EVENTS_CONTROLLER_LINK + "/{eventId}", 2L);
         builder.with(request -> {
@@ -356,13 +357,13 @@ class EventControllerTest {
         });
 
         assertThatThrownBy(() -> mockMvc
-            .perform(builder
-                .file(jsonFile)
-                .principal(principal)
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-            .andExpect(status().isBadRequest()))
-            .hasCause(new WrongIdException(ErrorMessage.EVENT_ID_IN_PATH_PARAM_AND_ENTITY_NOT_EQUAL));
+                .perform(builder
+                        .file(jsonFile)
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andExpect(status().isBadRequest()))
+                .hasCause(new WrongIdException(ErrorMessage.EVENT_ID_IN_PATH_PARAM_AND_ENTITY_NOT_EQUAL));
     }
 
     @Test
@@ -374,8 +375,8 @@ class EventControllerTest {
         when(userService.findByEmail(anyString())).thenReturn(userVO);
 
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/like", eventId)
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
 
         verify(eventService).like(eventId, userVO);
     }
@@ -385,8 +386,8 @@ class EventControllerTest {
         UserVO userVO = getUserVO();
         when(userService.findByEmail(anyString())).thenReturn(userVO);
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/dislike", 1)
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
         verify(eventService).dislike(userVO, 1L);
     }
 
@@ -398,9 +399,9 @@ class EventControllerTest {
         when(userService.findByEmail(anyString())).thenReturn(userVO);
         when(eventService.dislikeV2(anyLong(), eq(userVO))).thenReturn(eventDto);
         MvcResult result = mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/dislike-v2", 2)
-            .principal(principal))
-            .andExpect(status().isOk())
-            .andReturn();
+                        .principal(principal))
+                .andExpect(status().isOk())
+                .andReturn();
         assertEquals(200, result.getResponse().getStatus());
         assertEquals(eventDto, objectMapper.readValue(result.getResponse().getContentAsString(), EventDto.class));
         verify(eventService).dislikeV2(2L, userVO);
@@ -414,9 +415,9 @@ class EventControllerTest {
         when(userService.findByEmail(anyString())).thenReturn(userVO);
         when(eventService.likeV2(anyLong(), eq(userVO))).thenReturn(eventDto);
         MvcResult result = mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/like-v2", 2)
-            .principal(principal))
-            .andExpect(status().isOk())
-            .andReturn();
+                        .principal(principal))
+                .andExpect(status().isOk())
+                .andReturn();
         assertEquals(200, result.getResponse().getStatus());
         assertEquals(eventDto, objectMapper.readValue(result.getResponse().getContentAsString(), EventDto.class));
         verify(eventService).likeV2(2L, userVO);
@@ -426,8 +427,8 @@ class EventControllerTest {
     @SneakyThrows
     void countLikesTest() {
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}/likes/count", EVENT_ID)
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
 
         verify(eventService).countLikes(EVENT_ID);
     }
@@ -436,8 +437,8 @@ class EventControllerTest {
     @SneakyThrows
     void countDislikesTest() {
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}/dislikes/count", EVENT_ID)
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
 
         verify(eventService).countDislikes(EVENT_ID);
     }
@@ -449,8 +450,8 @@ class EventControllerTest {
         when(userService.findByEmail(anyString())).thenReturn(userVO);
 
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}/likes", EVENT_ID)
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
 
         verify(eventService).isEventLikedByUser(EVENT_ID, userVO);
     }
@@ -462,8 +463,8 @@ class EventControllerTest {
         when(userService.findByEmail(anyString())).thenReturn(userVO);
 
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}/dislikes", EVENT_ID)
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
 
         verify(eventService).isEventDislikedByUser(EVENT_ID, userVO);
     }
@@ -475,10 +476,10 @@ class EventControllerTest {
         int grade = 2;
 
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/ratings", eventId)
-            .principal(principal)
-            .content(String.valueOf(grade))
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk());
+                        .principal(principal)
+                        .content(String.valueOf(grade))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
 
         verify(eventService).rateEvent(eventId, principal.getName(), grade);
     }
@@ -490,11 +491,11 @@ class EventControllerTest {
         int grade = 2;
 
         mockMvc.perform(
-            post(EVENTS_CONTROLLER_LINK + "/{eventId}/ratings", notValidId)
-                .principal(principal)
-                .content(String.valueOf(grade))
-                .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isBadRequest());
+                        post(EVENTS_CONTROLLER_LINK + "/{eventId}/ratings", notValidId)
+                                .principal(principal)
+                                .content(String.valueOf(grade))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -504,11 +505,11 @@ class EventControllerTest {
         String notValidGrade = "grade";
 
         mockMvc
-            .perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/ratings", eventId)
-                .principal(principal)
-                .content(notValidGrade)
-                .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isBadRequest());
+                .perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/ratings", eventId)
+                        .principal(principal)
+                        .content(notValidGrade)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -518,15 +519,15 @@ class EventControllerTest {
         int grade = 2;
 
         doThrow(new NotFoundException("ErrorMessage"))
-            .when(eventService)
-            .rateEvent(eventId, principal.getName(), grade);
+                .when(eventService)
+                .rateEvent(eventId, principal.getName(), grade);
 
         assertThatThrownBy(() -> mockMvc
-            .perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/ratings", eventId)
-                .principal(principal)
-                .content(String.valueOf(grade))
-                .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isNotFound())).hasCause(new NotFoundException("ErrorMessage"));
+                .perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/ratings", eventId)
+                        .principal(principal)
+                        .content(String.valueOf(grade))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())).hasCause(new NotFoundException("ErrorMessage"));
     }
 
     @Test
@@ -536,15 +537,15 @@ class EventControllerTest {
         int grade = 2;
 
         doThrow(new BadRequestException("ErrorMessage"))
-            .when(eventService)
-            .rateEvent(eventId, principal.getName(), grade);
+                .when(eventService)
+                .rateEvent(eventId, principal.getName(), grade);
 
         assertThatThrownBy(() -> mockMvc
-            .perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/ratings", eventId)
-                .principal(principal)
-                .content(String.valueOf(grade))
-                .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isBadRequest())).hasCause(new BadRequestException("ErrorMessage"));
+                .perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/ratings", eventId)
+                        .principal(principal)
+                        .content(String.valueOf(grade))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())).hasCause(new BadRequestException("ErrorMessage"));
     }
 
     @Test
@@ -553,28 +554,28 @@ class EventControllerTest {
         String json = "";
 
         MockMultipartFile jsonFile =
-            new MockMultipartFile("eventDto", "", "application/json", json.getBytes());
+                new MockMultipartFile("eventDto", "", "application/json", json.getBytes());
 
         MockMultipartHttpServletRequestBuilder builder =
-            multipart(EVENTS_CONTROLLER_LINK + "/{eventId}", 1L);
+                multipart(EVENTS_CONTROLLER_LINK + "/{eventId}", 1L);
         builder.with(request -> {
             request.setMethod("PUT");
             return request;
         });
 
         mockMvc.perform(builder
-            .file(jsonFile)
-            .principal(principal)
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-            .andExpect(status().isBadRequest());
+                        .file(jsonFile)
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
     @SneakyThrows
     void getEventTest() {
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}", 1L).principal(principal))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
 
         verify(eventService).getEvent(1L, principal);
     }
@@ -583,7 +584,7 @@ class EventControllerTest {
     @SneakyThrows
     void getEventFailedTest() {
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}", "not_number").principal(principal))
-            .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest());
 
         verify(eventService, times(0)).getEvent(1L, principal);
     }
@@ -596,10 +597,10 @@ class EventControllerTest {
         when(eventService.getEvent(1L, principal)).thenReturn(eventDto);
 
         MvcResult result = mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}", 1L)
-            .principal(principal)
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk()).andReturn();
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk()).andReturn();
 
         EventDto responseEventDto = objectMapper.readValue(result.getResponse().getContentAsString(), EventDto.class);
 
@@ -613,7 +614,7 @@ class EventControllerTest {
     void getAllEventSubscribersTest() {
         Long eventId = 1L;
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
 
         verify(eventService).getAllEventAttenders(eventId);
     }
@@ -623,7 +624,7 @@ class EventControllerTest {
     void getAllEventSubscribersWithNotValidIdBadRequestTest() {
         String notValidId = "id";
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", notValidId))
-            .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -632,20 +633,20 @@ class EventControllerTest {
         Long eventId = 1L;
 
         doThrow(new NotFoundException("ErrorMessage"))
-            .when(eventService)
-            .getAllEventAttenders(eventId);
+                .when(eventService)
+                .getAllEventAttenders(eventId);
 
         assertThatThrownBy(
-            () -> mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId))
-                .andExpect(status().isNotFound()))
-            .hasCause(new NotFoundException("ErrorMessage"));
+                () -> mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId))
+                        .andExpect(status().isNotFound()))
+                .hasCause(new NotFoundException("ErrorMessage"));
     }
 
     @Test
     @SneakyThrows
     void getAllEventsAddressesTest() {
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/addresses"))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
         verify(eventService).getAllEventsAddresses();
     }
 
@@ -653,7 +654,7 @@ class EventControllerTest {
     @SneakyThrows
     void getAllAttendersCountTest() {
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/attenders/count?user-id=1"))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
         verify(eventService).getCountOfAttendedEventsByUserId(1L);
     }
 
@@ -661,30 +662,30 @@ class EventControllerTest {
     @SneakyThrows
     void getOrganizersCountTest() {
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/organizers/count?user-id=1"))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
         verify(eventService).getCountOfOrganizedEventsByUserId(1L);
     }
 
     @SneakyThrows
     private AddEventDtoRequest getAddEventDtoRequest() {
         String json = """
-            {
-                "title":"string",
-                "description":"stringstringstringstringstringstringstringstring",
-                "open":true,
-                "datesLocations":[
-                    {
-                        "startDate":"2023-05-27T15:00:00Z",
-                        "finishDate":"2023-05-27T17:00:00Z",
-                        "coordinates":{
-                            "latitude":1,
-                            "longitude":1
-                        },
-                        "onlineLink":"http://localhost:8080/swagger-ui.html#/events-controller"
-                    }
-                ],
-                "tags":["Social"]
-            }""";
+                {
+                    "title":"string",
+                    "description":"stringstringstringstringstringstringstringstring",
+                    "open":true,
+                    "datesLocations":[
+                        {
+                            "startDate":"2023-05-27T15:00:00Z",
+                            "finishDate":"2023-05-27T17:00:00Z",
+                            "coordinates":{
+                                "latitude":1,
+                                "longitude":1
+                            },
+                            "onlineLink":"http://localhost:8080/swagger-ui.html#/events-controller"
+                        }
+                    ],
+                    "tags":["Social"]
+                }""";
 
         return objectMapper.readValue(json, AddEventDtoRequest.class);
     }
@@ -692,24 +693,24 @@ class EventControllerTest {
     @SneakyThrows
     private UpdateEventRequestDto getUpdateEventDto() {
         String json = """
-            {
-                "id":1,
-                "title":"string",
-                "description":"stringstringstringstringstringstringstringstring",
-                "open":true,
-                "datesLocations":[
-                    {
-                        "startDate":"2023-05-27T15:00:00Z",
-                        "finishDate":"2023-05-27T17:00:00Z",
-                        "coordinates":{
-                            "latitude":1,
-                            "longitude":1
-                        },
-                        "onlineLink":"http://localhost:8080/swagger-ui.html#/events-controller"
-                    }
-                ],
-                "tags":["Social"]
-            }""";
+                {
+                    "id":1,
+                    "title":"string",
+                    "description":"stringstringstringstringstringstringstringstring",
+                    "open":true,
+                    "datesLocations":[
+                        {
+                            "startDate":"2023-05-27T15:00:00Z",
+                            "finishDate":"2023-05-27T17:00:00Z",
+                            "coordinates":{
+                                "latitude":1,
+                                "longitude":1
+                            },
+                            "onlineLink":"http://localhost:8080/swagger-ui.html#/events-controller"
+                        }
+                    ],
+                    "tags":["Social"]
+                }""";
 
         return objectMapper.readValue(json, UpdateEventRequestDto.class);
     }
@@ -717,51 +718,51 @@ class EventControllerTest {
     @SneakyThrows
     private EventDto getEventDto() {
         String json = """
-            {
-              "additionalImages": [
-                "string"
-              ],
-              "dates": [
                 {
-                    "coordinates": {
-                    "streetUk": "string",
-                    "streetEn": "string",
-                    "houseNumber": "string",
-                    "cityUk": "string",
-                    "cityEn": "string",
-                    "regionUk": "string",
-                    "regionEn": "string",
-                    "countryUk": "string",
-                    "countryEn": "string",
-                    "latitude": 0,
-                    "longitude": 0
+                  "additionalImages": [
+                    "string"
+                  ],
+                  "dates": [
+                    {
+                        "coordinates": {
+                        "streetUk": "string",
+                        "streetEn": "string",
+                        "houseNumber": "string",
+                        "cityUk": "string",
+                        "cityEn": "string",
+                        "regionUk": "string",
+                        "regionEn": "string",
+                        "countryUk": "string",
+                        "countryEn": "string",
+                        "latitude": 0,
+                        "longitude": 0
+                      },
+                      "finishDate": "2022-12-08T15:13:27.538Z",
+                      "id": 0,
+                      "onlineLink": "string",
+                      "startDate": "2022-12-08T15:13:27.538Z"
+                    }
+                  ],
+                  "description": "stringstringstringstringstringstringstring",
+                  "creationDate": "2022-12-08",
+                  "id": 0,
+                  "isSubscribed": true,
+                  "open": true,
+                  "organizer": {
+                    "id": 0,
+                    "name": "string",
+                    "organizerRating": 0
                   },
-                  "finishDate": "2022-12-08T15:13:27.538Z",
-                  "id": 0,
-                  "onlineLink": "string",
-                  "startDate": "2022-12-08T15:13:27.538Z"
-                }
-              ],
-              "description": "stringstringstringstringstringstringstring",
-              "creationDate": "2022-12-08",
-              "id": 0,
-              "isSubscribed": true,
-              "open": true,
-              "organizer": {
-                "id": 0,
-                "name": "string",
-                "organizerRating": 0
-              },
-              "tags": [
-                {
-                  "id": 0,
-                  "nameEn": "string",
-                  "nameUk": "string"
-                }
-              ],
-              "title": "string",
-              "titleImage": "string"
-            }""";
+                  "tags": [
+                    {
+                      "id": 0,
+                      "nameEn": "string",
+                      "nameUk": "string"
+                    }
+                  ],
+                  "title": "string",
+                  "titleImage": "string"
+                }""";
 
         return objectMapper.readValue(json, EventDto.class);
     }
@@ -771,8 +772,8 @@ class EventControllerTest {
     void addToRequestedTest() {
         Long eventId = 1L;
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/addToRequested", eventId)
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
         verify(eventService).addToRequested(eventId, principal.getName());
     }
 
@@ -781,8 +782,8 @@ class EventControllerTest {
     void removeFromRequestedTest() {
         Long eventId = 1L;
         mockMvc.perform(delete(EVENTS_CONTROLLER_LINK + "/{eventId}/removeFromRequested", eventId)
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
         verify(eventService).removeFromRequested(eventId, principal.getName());
     }
 
@@ -792,8 +793,8 @@ class EventControllerTest {
         Long eventId = 1L;
         Pageable pageable = PageRequest.of(0, 20);
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}/requested-users", eventId)
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
         verify(eventService).getRequestedUsers(eventId, principal.getName(), pageable);
     }
 
@@ -803,8 +804,8 @@ class EventControllerTest {
         Long eventId = 1L;
         Long userId = 1L;
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/requested-users/{userId}/approve", eventId, userId)
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
         verify(eventService).approveRequest(eventId, principal.getName(), userId);
     }
 
@@ -814,8 +815,8 @@ class EventControllerTest {
         Long eventId = 1L;
         Long userId = 1L;
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/requested-users/{userId}/decline", eventId, userId)
-            .principal(principal))
-            .andExpect(status().isOk());
+                        .principal(principal))
+                .andExpect(status().isOk());
         verify(eventService).declineRequest(eventId, principal.getName(), userId);
     }
 
@@ -830,10 +831,10 @@ class EventControllerTest {
         String expectedJson = objectMapper.writeValueAsString(eventResponseDto);
 
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/v2/{eventId}", eventId)
-            .principal(principal)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().json(expectedJson));
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().json(expectedJson));
 
         verify(eventService, times(1)).getEventV2(eventId, principal);
     }
@@ -842,7 +843,7 @@ class EventControllerTest {
     @SneakyThrows
     void getEventV2FailedTest() {
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/v2/{eventId}", "not_number").principal(principal))
-            .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest());
 
         verify(eventService, times(0)).getEventV2(1L, principal);
     }
@@ -860,11 +861,11 @@ class EventControllerTest {
         });
 
         mockMvc.perform(builder
-            .file(jsonFile)
-            .principal(principal)
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-            .andExpect(status().isOk());
+                        .file(jsonFile)
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andExpect(status().isOk());
 
         verify(eventService).updateV2(updateEventDto, principal.getName(), null);
     }
@@ -883,12 +884,23 @@ class EventControllerTest {
         });
 
         assertThatThrownBy(() -> mockMvc
-            .perform(builder
-                .file(jsonFile)
-                .principal(principal)
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-            .andExpect(status().isBadRequest()))
-            .hasCause(new WrongIdException(ErrorMessage.EVENT_ID_IN_PATH_PARAM_AND_ENTITY_NOT_EQUAL));
+                .perform(builder
+                        .file(jsonFile)
+                        .principal(principal)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andExpect(status().isBadRequest()))
+                .hasCause(new WrongIdException(ErrorMessage.EVENT_ID_IN_PATH_PARAM_AND_ENTITY_NOT_EQUAL));
+    }
+
+    @Test
+    @SneakyThrows
+    void getRelevantAddressesTest() {
+        UserVO userVO = ModelUtils.getUserVO();
+        when(userService.findByEmail(principal.getName())).thenReturn(userVO);
+        mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/addresses/get-relevant")
+                        .principal(principal))
+                .andExpect(status().isOk());
+        verify(eventService, times(1)).getAllRelevantEventsCityByUser(userVO);
     }
 }

--- a/core/src/test/java/greencity/controller/EventControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventControllerTest.java
@@ -85,9 +85,9 @@ class EventControllerTest {
     @BeforeEach
     void setup() {
         this.mockMvc = MockMvcBuilders.standaloneSetup(eventController)
-                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver(),
-                        new UserArgumentResolver(userService, modelMapper))
-                .build();
+            .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver(),
+                new UserArgumentResolver(userService, modelMapper))
+            .build();
     }
 
     @Test
@@ -103,16 +103,16 @@ class EventControllerTest {
         FilterEventDto filterEventDto = ModelUtils.getFilterEventDto();
 
         when(eventService.getEvents(pageable, filterEventDto, userId))
-                .thenReturn(eventDtoPageableAdvancedDto);
+            .thenReturn(eventDtoPageableAdvancedDto);
 
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK)
-                        .param("page", "0")
-                        .param("size", "20")
-                        .param("user-id", userId.toString())
-                        .param("statuses", filterEventDto.getStatuses().stream().map(Enum::name).collect(Collectors.joining(",")))
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().json(expectedJson));
+            .param("page", "0")
+            .param("size", "20")
+            .param("user-id", userId.toString())
+            .param("statuses", filterEventDto.getStatuses().stream().map(Enum::name).collect(Collectors.joining(",")))
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().json(expectedJson));
 
         verify(eventService).getEvents(pageable, filterEventDto, userId);
     }
@@ -121,10 +121,10 @@ class EventControllerTest {
     @SneakyThrows
     void getEventsThrowExceptionTest() {
         assertThatThrownBy(
-                () -> mockMvc.perform(get(EVENTS_CONTROLLER_LINK)
-                                .param("statuses", EventStatus.JOINED.name()))
-                        .andExpect(status().isBadRequest()))
-                .hasCause(new BadRequestException(ErrorMessage.STATUSES_REQUIRE_USER_ID));
+            () -> mockMvc.perform(get(EVENTS_CONTROLLER_LINK)
+                .param("statuses", EventStatus.JOINED.name()))
+                .andExpect(status().isBadRequest()))
+            .hasCause(new BadRequestException(ErrorMessage.STATUSES_REQUIRE_USER_ID));
     }
 
     @Test
@@ -132,7 +132,7 @@ class EventControllerTest {
     void addAttenderTest() {
         Long eventId = 1L;
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId)
-                .principal(principal));
+            .principal(principal));
         verify(eventService).addAttender(eventId, principal.getName());
     }
 
@@ -141,8 +141,8 @@ class EventControllerTest {
     void addAttenderWithNotValidIdBadRequestTest() {
         String notValidId = "id";
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", notValidId)
-                        .principal(principal))
-                .andExpect(status().isBadRequest());
+            .principal(principal))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -151,14 +151,14 @@ class EventControllerTest {
         Long eventId = 1L;
 
         doThrow(new NotFoundException("ErrorMessage"))
-                .when(eventService)
-                .addAttender(eventId, principal.getName());
+            .when(eventService)
+            .addAttender(eventId, principal.getName());
 
         assertThatThrownBy(
-                () -> mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId)
-                                .principal(principal))
-                        .andExpect(status().isNotFound()))
-                .hasCause(new NotFoundException("ErrorMessage"));
+            () -> mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId)
+                .principal(principal))
+                .andExpect(status().isNotFound()))
+            .hasCause(new NotFoundException("ErrorMessage"));
     }
 
     @Test
@@ -167,14 +167,14 @@ class EventControllerTest {
         Long eventId = 1L;
 
         doThrow(new BadRequestException("ErrorMessage"))
-                .when(eventService)
-                .addAttender(eventId, principal.getName());
+            .when(eventService)
+            .addAttender(eventId, principal.getName());
 
         assertThatThrownBy(
-                () -> mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId)
-                                .principal(principal))
-                        .andExpect(status().isBadRequest()))
-                .hasCause(new BadRequestException("ErrorMessage"));
+            () -> mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId)
+                .principal(principal))
+                .andExpect(status().isBadRequest()))
+            .hasCause(new BadRequestException("ErrorMessage"));
     }
 
     @Test
@@ -182,8 +182,8 @@ class EventControllerTest {
     void addToFavoritesTest() {
         Long eventId = 1L;
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/favorites", eventId)
-                        .principal(principal))
-                .andExpect(status().isOk());
+            .principal(principal))
+            .andExpect(status().isOk());
         verify(eventService).addToFavorites(eventId, principal.getName());
     }
 
@@ -192,8 +192,8 @@ class EventControllerTest {
     void removeFromFavoritesTest() {
         Long eventId = 1L;
         mockMvc.perform(delete(EVENTS_CONTROLLER_LINK + "/{eventId}/favorites", eventId)
-                        .principal(principal))
-                .andExpect(status().isOk());
+            .principal(principal))
+            .andExpect(status().isOk());
         verify(eventService).removeFromFavorites(eventId, principal.getName());
     }
 
@@ -205,14 +205,14 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile jsonFile =
-                new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
+            new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
 
         mockMvc.perform(multipart(EVENTS_CONTROLLER_LINK)
-                        .file(jsonFile)
-                        .principal(principal)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-                .andExpect(status().isCreated());
+            .file(jsonFile)
+            .principal(principal)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .andExpect(status().isCreated());
 
         verify(eventService).save(eq(addEventDtoRequest), eq(principal.getName()), isNull());
     }
@@ -222,13 +222,13 @@ class EventControllerTest {
     void saveBadRequestTest() {
         String json = "{}";
         MockMultipartFile jsonFile =
-                new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
+            new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
         mockMvc.perform(multipart(EVENTS_CONTROLLER_LINK)
-                        .file(jsonFile)
-                        .principal(principal)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-                .andExpect(status().isBadRequest());
+            .file(jsonFile)
+            .principal(principal)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -239,14 +239,14 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile jsonFile =
-                new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
+            new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
 
         mockMvc.perform(multipart("/events/createV2")
-                        .file(jsonFile)
-                        .principal(principal)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-                .andExpect(status().isCreated());
+            .file(jsonFile)
+            .principal(principal)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .andExpect(status().isCreated());
 
         verify(eventService).saveV2(eq(addEventDtoRequest), eq(principal.getName()), isNull());
     }
@@ -256,13 +256,13 @@ class EventControllerTest {
     void saveV2BadRequestTest() {
         String json = "{}";
         MockMultipartFile jsonFile =
-                new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
+            new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
         mockMvc.perform(multipart("/events/createV2")
-                        .file(jsonFile)
-                        .principal(principal)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-                .andExpect(status().isBadRequest());
+            .file(jsonFile)
+            .principal(principal)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -270,7 +270,7 @@ class EventControllerTest {
     void removeAttenderTest() {
         Long eventId = 1L;
         mockMvc.perform(delete(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId).principal(principal))
-                .andExpect(status().isOk());
+            .andExpect(status().isOk());
         verify(eventService).removeAttender(eventId, principal.getName());
     }
 
@@ -279,8 +279,8 @@ class EventControllerTest {
     void removeAttenderBadRequestTest() {
         String notValidId = "id";
         mockMvc.perform(delete(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", notValidId)
-                        .principal(principal))
-                .andExpect(status().isBadRequest());
+            .principal(principal))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -288,20 +288,20 @@ class EventControllerTest {
     void removeAttenderNotFoundTest() {
         Long eventId = 1L;
         doThrow(new NotFoundException("ErrorMessage"))
-                .when(eventService)
-                .removeAttender(eventId, principal.getName());
+            .when(eventService)
+            .removeAttender(eventId, principal.getName());
 
         assertThatThrownBy(() -> mockMvc
-                .perform(delete(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId).principal(principal))
-                .andExpect(status().isNotFound())).hasCause(new NotFoundException("ErrorMessage"));
+            .perform(delete(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId).principal(principal))
+            .andExpect(status().isNotFound())).hasCause(new NotFoundException("ErrorMessage"));
     }
 
     @Test
     @SneakyThrows
     void deleteTest() {
         mockMvc.perform(delete(EVENTS_CONTROLLER_LINK + "/{eventId}", 1)
-                        .principal(principal))
-                .andExpect(status().isOk());
+            .principal(principal))
+            .andExpect(status().isOk());
 
         verify(eventService).delete(1L, "test@gmail.com");
     }
@@ -310,8 +310,8 @@ class EventControllerTest {
     @SneakyThrows
     void deleteFailedTest() {
         mockMvc.perform(delete(EVENTS_CONTROLLER_LINK + "/{eventId}", "not_number")
-                        .principal(principal))
-                .andExpect(status().isBadRequest());
+            .principal(principal))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -322,7 +322,7 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(updateEventDto);
 
         MockMultipartFile jsonFile =
-                new MockMultipartFile("eventDto", "", "application/json", json.getBytes());
+            new MockMultipartFile("eventDto", "", "application/json", json.getBytes());
 
         MockMultipartHttpServletRequestBuilder builder = multipart(EVENTS_CONTROLLER_LINK + "/{eventId}", 1L);
         builder.with(request -> {
@@ -331,11 +331,11 @@ class EventControllerTest {
         });
 
         mockMvc.perform(builder
-                        .file(jsonFile)
-                        .principal(principal)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-                .andExpect(status().isOk());
+            .file(jsonFile)
+            .principal(principal)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .andExpect(status().isOk());
 
         verify(eventService).update(updateEventDto, principal.getName(), null);
     }
@@ -348,7 +348,7 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(updateEventDto);
 
         MockMultipartFile jsonFile =
-                new MockMultipartFile("eventDto", "", "application/json", json.getBytes());
+            new MockMultipartFile("eventDto", "", "application/json", json.getBytes());
 
         MockMultipartHttpServletRequestBuilder builder = multipart(EVENTS_CONTROLLER_LINK + "/{eventId}", 2L);
         builder.with(request -> {
@@ -357,13 +357,13 @@ class EventControllerTest {
         });
 
         assertThatThrownBy(() -> mockMvc
-                .perform(builder
-                        .file(jsonFile)
-                        .principal(principal)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-                .andExpect(status().isBadRequest()))
-                .hasCause(new WrongIdException(ErrorMessage.EVENT_ID_IN_PATH_PARAM_AND_ENTITY_NOT_EQUAL));
+            .perform(builder
+                .file(jsonFile)
+                .principal(principal)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .andExpect(status().isBadRequest()))
+            .hasCause(new WrongIdException(ErrorMessage.EVENT_ID_IN_PATH_PARAM_AND_ENTITY_NOT_EQUAL));
     }
 
     @Test
@@ -375,8 +375,8 @@ class EventControllerTest {
         when(userService.findByEmail(anyString())).thenReturn(userVO);
 
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/like", eventId)
-                        .principal(principal))
-                .andExpect(status().isOk());
+            .principal(principal))
+            .andExpect(status().isOk());
 
         verify(eventService).like(eventId, userVO);
     }
@@ -386,8 +386,8 @@ class EventControllerTest {
         UserVO userVO = getUserVO();
         when(userService.findByEmail(anyString())).thenReturn(userVO);
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/dislike", 1)
-                        .principal(principal))
-                .andExpect(status().isOk());
+            .principal(principal))
+            .andExpect(status().isOk());
         verify(eventService).dislike(userVO, 1L);
     }
 
@@ -399,9 +399,9 @@ class EventControllerTest {
         when(userService.findByEmail(anyString())).thenReturn(userVO);
         when(eventService.dislikeV2(anyLong(), eq(userVO))).thenReturn(eventDto);
         MvcResult result = mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/dislike-v2", 2)
-                        .principal(principal))
-                .andExpect(status().isOk())
-                .andReturn();
+            .principal(principal))
+            .andExpect(status().isOk())
+            .andReturn();
         assertEquals(200, result.getResponse().getStatus());
         assertEquals(eventDto, objectMapper.readValue(result.getResponse().getContentAsString(), EventDto.class));
         verify(eventService).dislikeV2(2L, userVO);
@@ -415,9 +415,9 @@ class EventControllerTest {
         when(userService.findByEmail(anyString())).thenReturn(userVO);
         when(eventService.likeV2(anyLong(), eq(userVO))).thenReturn(eventDto);
         MvcResult result = mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/like-v2", 2)
-                        .principal(principal))
-                .andExpect(status().isOk())
-                .andReturn();
+            .principal(principal))
+            .andExpect(status().isOk())
+            .andReturn();
         assertEquals(200, result.getResponse().getStatus());
         assertEquals(eventDto, objectMapper.readValue(result.getResponse().getContentAsString(), EventDto.class));
         verify(eventService).likeV2(2L, userVO);
@@ -427,8 +427,8 @@ class EventControllerTest {
     @SneakyThrows
     void countLikesTest() {
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}/likes/count", EVENT_ID)
-                        .principal(principal))
-                .andExpect(status().isOk());
+            .principal(principal))
+            .andExpect(status().isOk());
 
         verify(eventService).countLikes(EVENT_ID);
     }
@@ -437,8 +437,8 @@ class EventControllerTest {
     @SneakyThrows
     void countDislikesTest() {
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}/dislikes/count", EVENT_ID)
-                        .principal(principal))
-                .andExpect(status().isOk());
+            .principal(principal))
+            .andExpect(status().isOk());
 
         verify(eventService).countDislikes(EVENT_ID);
     }
@@ -450,8 +450,8 @@ class EventControllerTest {
         when(userService.findByEmail(anyString())).thenReturn(userVO);
 
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}/likes", EVENT_ID)
-                        .principal(principal))
-                .andExpect(status().isOk());
+            .principal(principal))
+            .andExpect(status().isOk());
 
         verify(eventService).isEventLikedByUser(EVENT_ID, userVO);
     }
@@ -463,8 +463,8 @@ class EventControllerTest {
         when(userService.findByEmail(anyString())).thenReturn(userVO);
 
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}/dislikes", EVENT_ID)
-                        .principal(principal))
-                .andExpect(status().isOk());
+            .principal(principal))
+            .andExpect(status().isOk());
 
         verify(eventService).isEventDislikedByUser(EVENT_ID, userVO);
     }
@@ -476,10 +476,10 @@ class EventControllerTest {
         int grade = 2;
 
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/ratings", eventId)
-                        .principal(principal)
-                        .content(String.valueOf(grade))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
+            .principal(principal)
+            .content(String.valueOf(grade))
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
 
         verify(eventService).rateEvent(eventId, principal.getName(), grade);
     }
@@ -491,11 +491,11 @@ class EventControllerTest {
         int grade = 2;
 
         mockMvc.perform(
-                        post(EVENTS_CONTROLLER_LINK + "/{eventId}/ratings", notValidId)
-                                .principal(principal)
-                                .content(String.valueOf(grade))
-                                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest());
+            post(EVENTS_CONTROLLER_LINK + "/{eventId}/ratings", notValidId)
+                .principal(principal)
+                .content(String.valueOf(grade))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -505,11 +505,11 @@ class EventControllerTest {
         String notValidGrade = "grade";
 
         mockMvc
-                .perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/ratings", eventId)
-                        .principal(principal)
-                        .content(notValidGrade)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest());
+            .perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/ratings", eventId)
+                .principal(principal)
+                .content(notValidGrade)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -519,15 +519,15 @@ class EventControllerTest {
         int grade = 2;
 
         doThrow(new NotFoundException("ErrorMessage"))
-                .when(eventService)
-                .rateEvent(eventId, principal.getName(), grade);
+            .when(eventService)
+            .rateEvent(eventId, principal.getName(), grade);
 
         assertThatThrownBy(() -> mockMvc
-                .perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/ratings", eventId)
-                        .principal(principal)
-                        .content(String.valueOf(grade))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound())).hasCause(new NotFoundException("ErrorMessage"));
+            .perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/ratings", eventId)
+                .principal(principal)
+                .content(String.valueOf(grade))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())).hasCause(new NotFoundException("ErrorMessage"));
     }
 
     @Test
@@ -537,15 +537,15 @@ class EventControllerTest {
         int grade = 2;
 
         doThrow(new BadRequestException("ErrorMessage"))
-                .when(eventService)
-                .rateEvent(eventId, principal.getName(), grade);
+            .when(eventService)
+            .rateEvent(eventId, principal.getName(), grade);
 
         assertThatThrownBy(() -> mockMvc
-                .perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/ratings", eventId)
-                        .principal(principal)
-                        .content(String.valueOf(grade))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())).hasCause(new BadRequestException("ErrorMessage"));
+            .perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/ratings", eventId)
+                .principal(principal)
+                .content(String.valueOf(grade))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())).hasCause(new BadRequestException("ErrorMessage"));
     }
 
     @Test
@@ -554,28 +554,28 @@ class EventControllerTest {
         String json = "";
 
         MockMultipartFile jsonFile =
-                new MockMultipartFile("eventDto", "", "application/json", json.getBytes());
+            new MockMultipartFile("eventDto", "", "application/json", json.getBytes());
 
         MockMultipartHttpServletRequestBuilder builder =
-                multipart(EVENTS_CONTROLLER_LINK + "/{eventId}", 1L);
+            multipart(EVENTS_CONTROLLER_LINK + "/{eventId}", 1L);
         builder.with(request -> {
             request.setMethod("PUT");
             return request;
         });
 
         mockMvc.perform(builder
-                        .file(jsonFile)
-                        .principal(principal)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-                .andExpect(status().isBadRequest());
+            .file(jsonFile)
+            .principal(principal)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
     @SneakyThrows
     void getEventTest() {
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}", 1L).principal(principal))
-                .andExpect(status().isOk());
+            .andExpect(status().isOk());
 
         verify(eventService).getEvent(1L, principal);
     }
@@ -584,7 +584,7 @@ class EventControllerTest {
     @SneakyThrows
     void getEventFailedTest() {
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}", "not_number").principal(principal))
-                .andExpect(status().isBadRequest());
+            .andExpect(status().isBadRequest());
 
         verify(eventService, times(0)).getEvent(1L, principal);
     }
@@ -597,10 +597,10 @@ class EventControllerTest {
         when(eventService.getEvent(1L, principal)).thenReturn(eventDto);
 
         MvcResult result = mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}", 1L)
-                        .principal(principal)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk()).andReturn();
+            .principal(principal)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk()).andReturn();
 
         EventDto responseEventDto = objectMapper.readValue(result.getResponse().getContentAsString(), EventDto.class);
 
@@ -614,7 +614,7 @@ class EventControllerTest {
     void getAllEventSubscribersTest() {
         Long eventId = 1L;
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId))
-                .andExpect(status().isOk());
+            .andExpect(status().isOk());
 
         verify(eventService).getAllEventAttenders(eventId);
     }
@@ -624,7 +624,7 @@ class EventControllerTest {
     void getAllEventSubscribersWithNotValidIdBadRequestTest() {
         String notValidId = "id";
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", notValidId))
-                .andExpect(status().isBadRequest());
+            .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -633,20 +633,20 @@ class EventControllerTest {
         Long eventId = 1L;
 
         doThrow(new NotFoundException("ErrorMessage"))
-                .when(eventService)
-                .getAllEventAttenders(eventId);
+            .when(eventService)
+            .getAllEventAttenders(eventId);
 
         assertThatThrownBy(
-                () -> mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId))
-                        .andExpect(status().isNotFound()))
-                .hasCause(new NotFoundException("ErrorMessage"));
+            () -> mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}/attenders", eventId))
+                .andExpect(status().isNotFound()))
+            .hasCause(new NotFoundException("ErrorMessage"));
     }
 
     @Test
     @SneakyThrows
     void getAllEventsAddressesTest() {
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/addresses"))
-                .andExpect(status().isOk());
+            .andExpect(status().isOk());
         verify(eventService).getAllEventsAddresses();
     }
 
@@ -654,7 +654,7 @@ class EventControllerTest {
     @SneakyThrows
     void getAllAttendersCountTest() {
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/attenders/count?user-id=1"))
-                .andExpect(status().isOk());
+            .andExpect(status().isOk());
         verify(eventService).getCountOfAttendedEventsByUserId(1L);
     }
 
@@ -662,30 +662,30 @@ class EventControllerTest {
     @SneakyThrows
     void getOrganizersCountTest() {
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/organizers/count?user-id=1"))
-                .andExpect(status().isOk());
+            .andExpect(status().isOk());
         verify(eventService).getCountOfOrganizedEventsByUserId(1L);
     }
 
     @SneakyThrows
     private AddEventDtoRequest getAddEventDtoRequest() {
         String json = """
-                {
-                    "title":"string",
-                    "description":"stringstringstringstringstringstringstringstring",
-                    "open":true,
-                    "datesLocations":[
-                        {
-                            "startDate":"2023-05-27T15:00:00Z",
-                            "finishDate":"2023-05-27T17:00:00Z",
-                            "coordinates":{
-                                "latitude":1,
-                                "longitude":1
-                            },
-                            "onlineLink":"http://localhost:8080/swagger-ui.html#/events-controller"
-                        }
-                    ],
-                    "tags":["Social"]
-                }""";
+            {
+                "title":"string",
+                "description":"stringstringstringstringstringstringstringstring",
+                "open":true,
+                "datesLocations":[
+                    {
+                        "startDate":"2023-05-27T15:00:00Z",
+                        "finishDate":"2023-05-27T17:00:00Z",
+                        "coordinates":{
+                            "latitude":1,
+                            "longitude":1
+                        },
+                        "onlineLink":"http://localhost:8080/swagger-ui.html#/events-controller"
+                    }
+                ],
+                "tags":["Social"]
+            }""";
 
         return objectMapper.readValue(json, AddEventDtoRequest.class);
     }
@@ -693,24 +693,24 @@ class EventControllerTest {
     @SneakyThrows
     private UpdateEventRequestDto getUpdateEventDto() {
         String json = """
-                {
-                    "id":1,
-                    "title":"string",
-                    "description":"stringstringstringstringstringstringstringstring",
-                    "open":true,
-                    "datesLocations":[
-                        {
-                            "startDate":"2023-05-27T15:00:00Z",
-                            "finishDate":"2023-05-27T17:00:00Z",
-                            "coordinates":{
-                                "latitude":1,
-                                "longitude":1
-                            },
-                            "onlineLink":"http://localhost:8080/swagger-ui.html#/events-controller"
-                        }
-                    ],
-                    "tags":["Social"]
-                }""";
+            {
+                "id":1,
+                "title":"string",
+                "description":"stringstringstringstringstringstringstringstring",
+                "open":true,
+                "datesLocations":[
+                    {
+                        "startDate":"2023-05-27T15:00:00Z",
+                        "finishDate":"2023-05-27T17:00:00Z",
+                        "coordinates":{
+                            "latitude":1,
+                            "longitude":1
+                        },
+                        "onlineLink":"http://localhost:8080/swagger-ui.html#/events-controller"
+                    }
+                ],
+                "tags":["Social"]
+            }""";
 
         return objectMapper.readValue(json, UpdateEventRequestDto.class);
     }
@@ -718,51 +718,51 @@ class EventControllerTest {
     @SneakyThrows
     private EventDto getEventDto() {
         String json = """
+            {
+              "additionalImages": [
+                "string"
+              ],
+              "dates": [
                 {
-                  "additionalImages": [
-                    "string"
-                  ],
-                  "dates": [
-                    {
-                        "coordinates": {
-                        "streetUk": "string",
-                        "streetEn": "string",
-                        "houseNumber": "string",
-                        "cityUk": "string",
-                        "cityEn": "string",
-                        "regionUk": "string",
-                        "regionEn": "string",
-                        "countryUk": "string",
-                        "countryEn": "string",
-                        "latitude": 0,
-                        "longitude": 0
-                      },
-                      "finishDate": "2022-12-08T15:13:27.538Z",
-                      "id": 0,
-                      "onlineLink": "string",
-                      "startDate": "2022-12-08T15:13:27.538Z"
-                    }
-                  ],
-                  "description": "stringstringstringstringstringstringstring",
-                  "creationDate": "2022-12-08",
-                  "id": 0,
-                  "isSubscribed": true,
-                  "open": true,
-                  "organizer": {
-                    "id": 0,
-                    "name": "string",
-                    "organizerRating": 0
+                    "coordinates": {
+                    "streetUk": "string",
+                    "streetEn": "string",
+                    "houseNumber": "string",
+                    "cityUk": "string",
+                    "cityEn": "string",
+                    "regionUk": "string",
+                    "regionEn": "string",
+                    "countryUk": "string",
+                    "countryEn": "string",
+                    "latitude": 0,
+                    "longitude": 0
                   },
-                  "tags": [
-                    {
-                      "id": 0,
-                      "nameEn": "string",
-                      "nameUk": "string"
-                    }
-                  ],
-                  "title": "string",
-                  "titleImage": "string"
-                }""";
+                  "finishDate": "2022-12-08T15:13:27.538Z",
+                  "id": 0,
+                  "onlineLink": "string",
+                  "startDate": "2022-12-08T15:13:27.538Z"
+                }
+              ],
+              "description": "stringstringstringstringstringstringstring",
+              "creationDate": "2022-12-08",
+              "id": 0,
+              "isSubscribed": true,
+              "open": true,
+              "organizer": {
+                "id": 0,
+                "name": "string",
+                "organizerRating": 0
+              },
+              "tags": [
+                {
+                  "id": 0,
+                  "nameEn": "string",
+                  "nameUk": "string"
+                }
+              ],
+              "title": "string",
+              "titleImage": "string"
+            }""";
 
         return objectMapper.readValue(json, EventDto.class);
     }
@@ -772,8 +772,8 @@ class EventControllerTest {
     void addToRequestedTest() {
         Long eventId = 1L;
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/addToRequested", eventId)
-                        .principal(principal))
-                .andExpect(status().isOk());
+            .principal(principal))
+            .andExpect(status().isOk());
         verify(eventService).addToRequested(eventId, principal.getName());
     }
 
@@ -782,8 +782,8 @@ class EventControllerTest {
     void removeFromRequestedTest() {
         Long eventId = 1L;
         mockMvc.perform(delete(EVENTS_CONTROLLER_LINK + "/{eventId}/removeFromRequested", eventId)
-                        .principal(principal))
-                .andExpect(status().isOk());
+            .principal(principal))
+            .andExpect(status().isOk());
         verify(eventService).removeFromRequested(eventId, principal.getName());
     }
 
@@ -793,8 +793,8 @@ class EventControllerTest {
         Long eventId = 1L;
         Pageable pageable = PageRequest.of(0, 20);
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/{eventId}/requested-users", eventId)
-                        .principal(principal))
-                .andExpect(status().isOk());
+            .principal(principal))
+            .andExpect(status().isOk());
         verify(eventService).getRequestedUsers(eventId, principal.getName(), pageable);
     }
 
@@ -804,8 +804,8 @@ class EventControllerTest {
         Long eventId = 1L;
         Long userId = 1L;
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/requested-users/{userId}/approve", eventId, userId)
-                        .principal(principal))
-                .andExpect(status().isOk());
+            .principal(principal))
+            .andExpect(status().isOk());
         verify(eventService).approveRequest(eventId, principal.getName(), userId);
     }
 
@@ -815,8 +815,8 @@ class EventControllerTest {
         Long eventId = 1L;
         Long userId = 1L;
         mockMvc.perform(post(EVENTS_CONTROLLER_LINK + "/{eventId}/requested-users/{userId}/decline", eventId, userId)
-                        .principal(principal))
-                .andExpect(status().isOk());
+            .principal(principal))
+            .andExpect(status().isOk());
         verify(eventService).declineRequest(eventId, principal.getName(), userId);
     }
 
@@ -831,10 +831,10 @@ class EventControllerTest {
         String expectedJson = objectMapper.writeValueAsString(eventResponseDto);
 
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/v2/{eventId}", eventId)
-                        .principal(principal)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().json(expectedJson));
+            .principal(principal)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().json(expectedJson));
 
         verify(eventService, times(1)).getEventV2(eventId, principal);
     }
@@ -843,7 +843,7 @@ class EventControllerTest {
     @SneakyThrows
     void getEventV2FailedTest() {
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/v2/{eventId}", "not_number").principal(principal))
-                .andExpect(status().isBadRequest());
+            .andExpect(status().isBadRequest());
 
         verify(eventService, times(0)).getEventV2(1L, principal);
     }
@@ -861,11 +861,11 @@ class EventControllerTest {
         });
 
         mockMvc.perform(builder
-                        .file(jsonFile)
-                        .principal(principal)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-                .andExpect(status().isOk());
+            .file(jsonFile)
+            .principal(principal)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .andExpect(status().isOk());
 
         verify(eventService).updateV2(updateEventDto, principal.getName(), null);
     }
@@ -884,13 +884,13 @@ class EventControllerTest {
         });
 
         assertThatThrownBy(() -> mockMvc
-                .perform(builder
-                        .file(jsonFile)
-                        .principal(principal)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-                .andExpect(status().isBadRequest()))
-                .hasCause(new WrongIdException(ErrorMessage.EVENT_ID_IN_PATH_PARAM_AND_ENTITY_NOT_EQUAL));
+            .perform(builder
+                .file(jsonFile)
+                .principal(principal)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .andExpect(status().isBadRequest()))
+            .hasCause(new WrongIdException(ErrorMessage.EVENT_ID_IN_PATH_PARAM_AND_ENTITY_NOT_EQUAL));
     }
 
     @Test
@@ -899,8 +899,8 @@ class EventControllerTest {
         UserVO userVO = ModelUtils.getUserVO();
         when(userService.findByEmail(principal.getName())).thenReturn(userVO);
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/addresses/get-relevant")
-                        .principal(principal))
-                .andExpect(status().isOk());
+            .principal(principal))
+            .andExpect(status().isOk());
         verify(eventService, times(1)).getAllRelevantEventsCityByUser(userVO);
     }
 }

--- a/dao/src/main/java/greencity/repository/EventRepo.java
+++ b/dao/src/main/java/greencity/repository/EventRepo.java
@@ -1,6 +1,7 @@
 package greencity.repository;
 
 import greencity.dto.event.EventAttenderDto;
+import greencity.dto.event.EventCityDtoProjection;
 import greencity.dto.user.UserProfilePictureDto;
 import greencity.entity.User;
 import greencity.entity.event.Address;
@@ -253,4 +254,26 @@ public interface EventRepo extends EventSearchRepo, JpaRepository<Event, Long>, 
      */
     @Query("SELECT e FROM Event e JOIN e.attenders a WHERE a.id = :userId")
     List<Event> findAllAttendedEventsByUserId(Long userId);
+
+    @Query(nativeQuery = true, value = """
+            SELECT * FROM (
+                    (
+                        SELECT city_en AS cityNameEn, city_uk AS cityNameUa, COUNT(*) AS amountOfEvents, 0 as priority
+                        FROM events_dates_locations
+                        WHERE city_en = ?1 OR city_uk = ?1
+                        GROUP BY city_en, city_uk
+                        LIMIT 1
+                    )
+                    UNION
+                    (
+                        SELECT city_en AS cityNameEn, city_uk AS cityNameUa, COUNT(*) AS amountOfEvents, 1 as priority
+                        FROM events_dates_locations
+                        WHERE NOT (city_en = ?1 OR city_uk = ?1)
+                        GROUP BY city_en, city_uk
+                        ORDER BY COUNT(*) DESC
+                        LIMIT 3
+                    )
+                ) AS combined
+                ORDER BY priority, amountOfEvents DESC""")
+    List<EventCityDtoProjection> findRelevantCitiesForUser(String userCity);
 }

--- a/dao/src/main/java/greencity/repository/EventRepo.java
+++ b/dao/src/main/java/greencity/repository/EventRepo.java
@@ -266,7 +266,7 @@ public interface EventRepo extends EventSearchRepo, JpaRepository<Event, Long>, 
     @Query(nativeQuery = true, value = """
         SELECT * FROM (
                 (
-                    SELECT city_en AS cityNameEn, city_uk AS cityNameUa, COUNT(*) AS amountOfEvents, 0 as priority
+                    SELECT city_en AS cityNameEn, city_uk AS cityNameUk, COUNT(*) AS amountOfEvents, 0 as priority
                     FROM events_dates_locations
                     WHERE city_en = ?1 OR city_uk = ?1
                     GROUP BY city_en, city_uk
@@ -274,7 +274,7 @@ public interface EventRepo extends EventSearchRepo, JpaRepository<Event, Long>, 
                 )
                 UNION
                 (
-                    SELECT city_en AS cityNameEn, city_uk AS cityNameUa, COUNT(*) AS amountOfEvents, 1 as priority
+                    SELECT city_en AS cityNameEn, city_uk AS cityNameUk, COUNT(*) AS amountOfEvents, 1 as priority
                     FROM events_dates_locations
                     WHERE NOT (city_en = ?1 OR city_uk = ?1)
                     GROUP BY city_en, city_uk

--- a/dao/src/main/java/greencity/repository/EventRepo.java
+++ b/dao/src/main/java/greencity/repository/EventRepo.java
@@ -255,25 +255,33 @@ public interface EventRepo extends EventSearchRepo, JpaRepository<Event, Long>, 
     @Query("SELECT e FROM Event e JOIN e.attenders a WHERE a.id = :userId")
     List<Event> findAllAttendedEventsByUserId(Long userId);
 
+    /**
+     * Retrieves cities relevant to the user, such as the user's own city (if
+     * available) and the top three cities with the highest number of events.
+     *
+     * @param userCity {@link String} - represents user's city or empty string if
+     *                 user does not have one.
+     * @author Andrii Danylenko
+     */
     @Query(nativeQuery = true, value = """
-            SELECT * FROM (
-                    (
-                        SELECT city_en AS cityNameEn, city_uk AS cityNameUa, COUNT(*) AS amountOfEvents, 0 as priority
-                        FROM events_dates_locations
-                        WHERE city_en = ?1 OR city_uk = ?1
-                        GROUP BY city_en, city_uk
-                        LIMIT 1
-                    )
-                    UNION
-                    (
-                        SELECT city_en AS cityNameEn, city_uk AS cityNameUa, COUNT(*) AS amountOfEvents, 1 as priority
-                        FROM events_dates_locations
-                        WHERE NOT (city_en = ?1 OR city_uk = ?1)
-                        GROUP BY city_en, city_uk
-                        ORDER BY COUNT(*) DESC
-                        LIMIT 3
-                    )
-                ) AS combined
-                ORDER BY priority, amountOfEvents DESC""")
+        SELECT * FROM (
+                (
+                    SELECT city_en AS cityNameEn, city_uk AS cityNameUa, COUNT(*) AS amountOfEvents, 0 as priority
+                    FROM events_dates_locations
+                    WHERE city_en = ?1 OR city_uk = ?1
+                    GROUP BY city_en, city_uk
+                    LIMIT 1
+                )
+                UNION
+                (
+                    SELECT city_en AS cityNameEn, city_uk AS cityNameUa, COUNT(*) AS amountOfEvents, 1 as priority
+                    FROM events_dates_locations
+                    WHERE NOT (city_en = ?1 OR city_uk = ?1)
+                    GROUP BY city_en, city_uk
+                    ORDER BY COUNT(*) DESC
+                    LIMIT 3
+                )
+            ) AS combined
+            ORDER BY priority, amountOfEvents DESC""")
     List<EventCityDtoProjection> findRelevantCitiesForUser(String userCity);
 }

--- a/dao/src/main/java/greencity/repository/EventRepo.java
+++ b/dao/src/main/java/greencity/repository/EventRepo.java
@@ -278,7 +278,6 @@ public interface EventRepo extends EventSearchRepo, JpaRepository<Event, Long>, 
                     FROM events_dates_locations
                     WHERE NOT (city_en = ?1 OR city_uk = ?1)
                     GROUP BY city_en, city_uk
-                    ORDER BY COUNT(*) DESC
                     LIMIT 3
                 )
             ) AS combined

--- a/service-api/src/main/java/greencity/dto/event/EventCityDto.java
+++ b/service-api/src/main/java/greencity/dto/event/EventCityDto.java
@@ -1,0 +1,12 @@
+package greencity.dto.event;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class EventCityDto {
+    private String cityNameEn;
+    private String cityNameUa;
+    private Long amountOfEvents;
+}

--- a/service-api/src/main/java/greencity/dto/event/EventCityDto.java
+++ b/service-api/src/main/java/greencity/dto/event/EventCityDto.java
@@ -7,6 +7,6 @@ import lombok.Data;
 @Builder
 public class EventCityDto {
     private String cityNameEn;
-    private String cityNameUa;
+    private String cityNameUk;
     private Long amountOfEvents;
 }

--- a/service-api/src/main/java/greencity/dto/event/EventCityDtoProjection.java
+++ b/service-api/src/main/java/greencity/dto/event/EventCityDtoProjection.java
@@ -1,0 +1,7 @@
+package greencity.dto.event;
+
+public interface EventCityDtoProjection {
+    String getCityNameEn();
+    String getCityNameUa();
+    Long getAmountOfEvents();
+}

--- a/service-api/src/main/java/greencity/dto/event/EventCityDtoProjection.java
+++ b/service-api/src/main/java/greencity/dto/event/EventCityDtoProjection.java
@@ -2,6 +2,8 @@ package greencity.dto.event;
 
 public interface EventCityDtoProjection {
     String getCityNameEn();
+
     String getCityNameUa();
+
     Long getAmountOfEvents();
 }

--- a/service-api/src/main/java/greencity/dto/event/EventCityDtoProjection.java
+++ b/service-api/src/main/java/greencity/dto/event/EventCityDtoProjection.java
@@ -3,7 +3,7 @@ package greencity.dto.event;
 public interface EventCityDtoProjection {
     String getCityNameEn();
 
-    String getCityNameUa();
+    String getCityNameUk();
 
     Long getAmountOfEvents();
 }

--- a/service-api/src/main/java/greencity/service/EventService.java
+++ b/service-api/src/main/java/greencity/service/EventService.java
@@ -381,12 +381,12 @@ public interface EventService {
     List<EventDto> getAllEventsAttendedByUser(Long userId);
 
     /**
-     * Returns a list of cities relevant to the user, including the user's city
-     * (if available) and the top three cities with the most events.
+     * Returns a list of cities relevant to the user, including the user's city (if
+     * available) and the top three cities with the most events.
      *
      * @param userVO {@link UserVO} - represents the current user.
      * @return {@link List} of {@link EventCityDto} containing cities sorted in
-     * descending order based on the number of events.
+     *         descending order based on the number of events.
      * @author Andrii Danylenko
      */
     List<EventCityDto> getAllRelevantEventsCityByUser(UserVO userVO);

--- a/service-api/src/main/java/greencity/service/EventService.java
+++ b/service-api/src/main/java/greencity/service/EventService.java
@@ -5,6 +5,7 @@ import greencity.dto.PageableDto;
 import greencity.dto.event.AddEventDtoRequest;
 import greencity.dto.event.AddressDto;
 import greencity.dto.event.EventAttenderDto;
+import greencity.dto.event.EventCityDto;
 import greencity.dto.event.EventDto;
 import greencity.dto.event.EventResponseDto;
 import greencity.dto.event.EventVO;
@@ -378,4 +379,15 @@ public interface EventService {
      *         user, or an empty list if none are found.
      */
     List<EventDto> getAllEventsAttendedByUser(Long userId);
+
+    /**
+     * Returns a list of cities relevant to the user, including the user's city
+     * (if available) and the top three cities with the most events.
+     *
+     * @param userVO {@link UserVO} - represents the current user.
+     * @return {@link List} of {@link EventCityDto} containing cities sorted in
+     * descending order based on the number of events.
+     * @author Andrii Danylenko
+     */
+    List<EventCityDto> getAllRelevantEventsCityByUser(UserVO userVO);
 }

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -1163,17 +1163,17 @@ public class EventServiceImpl implements EventService {
         if (locationDto != null) {
             if (AppConstant.DEFAULT_LANGUAGE_CODE.equals(userLocale)) {
                 userCity = locationDto.getCityEn();
-            }
-            else {
+            } else {
                 userCity = locationDto.getCityUk();
             }
         }
         return eventRepo.findRelevantCitiesForUser(userCity).stream()
-                .map(eventCityDtoProjection -> EventCityDto.builder()
-                        .cityNameEn(eventCityDtoProjection.getCityNameEn())
-                        .cityNameUa(eventCityDtoProjection.getCityNameUa())
-                        .amountOfEvents(eventCityDtoProjection.getAmountOfEvents())
-                        .build()).toList();
+            .map(eventCityDtoProjection -> EventCityDto.builder()
+                .cityNameEn(eventCityDtoProjection.getCityNameEn())
+                .cityNameUa(eventCityDtoProjection.getCityNameUa())
+                .amountOfEvents(eventCityDtoProjection.getAmountOfEvents())
+                .build())
+            .toList();
     }
 
     private void checkUserIdNotNull(Long userId) {

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -1170,7 +1170,7 @@ public class EventServiceImpl implements EventService {
         return eventRepo.findRelevantCitiesForUser(userCity).stream()
             .map(eventCityDtoProjection -> EventCityDto.builder()
                 .cityNameEn(eventCityDtoProjection.getCityNameEn())
-                .cityNameUa(eventCityDtoProjection.getCityNameUa())
+                .cityNameUk(eventCityDtoProjection.getCityNameUk())
                 .amountOfEvents(eventCityDtoProjection.getAmountOfEvents())
                 .build())
             .toList();

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -11,6 +11,7 @@ import greencity.dto.event.AddEventDtoRequest;
 import greencity.dto.event.AddressDto;
 import greencity.dto.event.EventAttenderDto;
 import greencity.dto.event.EventAuthorDto;
+import greencity.dto.event.EventCityDto;
 import greencity.dto.event.EventDateLocationDto;
 import greencity.dto.event.EventDto;
 import greencity.dto.event.EventResponseDto;
@@ -19,6 +20,7 @@ import greencity.dto.event.UpdateEventDto;
 import greencity.dto.event.UpdateEventRequestDto;
 import greencity.dto.filter.FilterEventDto;
 import greencity.dto.geocoding.AddressLatLngResponse;
+import greencity.dto.location.UserLocationDto;
 import greencity.dto.notification.LikeNotificationDto;
 import greencity.dto.search.SearchEventsDto;
 import greencity.dto.tag.TagDto;
@@ -1148,6 +1150,30 @@ public class EventServiceImpl implements EventService {
         return attendedEvents.stream()
             .map(event -> buildEventDto(event, userId))
             .toList();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<EventCityDto> getAllRelevantEventsCityByUser(UserVO userVO) {
+        String userLocale = userVO.getLanguageVO().getCode();
+        String userCity = AppConstant.EMPTY_STRING;
+        UserLocationDto locationDto = userVO.getUserLocationDto();
+        if (locationDto != null) {
+            if (AppConstant.DEFAULT_LANGUAGE_CODE.equals(userLocale)) {
+                userCity = locationDto.getCityEn();
+            }
+            else {
+                userCity = locationDto.getCityUk();
+            }
+        }
+        return eventRepo.findRelevantCitiesForUser(userCity).stream()
+                .map(eventCityDtoProjection -> EventCityDto.builder()
+                        .cityNameEn(eventCityDtoProjection.getCityNameEn())
+                        .cityNameUa(eventCityDtoProjection.getCityNameUa())
+                        .amountOfEvents(eventCityDtoProjection.getAmountOfEvents())
+                        .build()).toList();
     }
 
     private void checkUserIdNotNull(Long userId) {

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -1162,9 +1162,9 @@ public class EventServiceImpl implements EventService {
         UserLocationDto locationDto = userVO.getUserLocationDto();
         if (locationDto != null) {
             if (AppConstant.DEFAULT_LANGUAGE_CODE.equals(userLocale)) {
-                userCity = locationDto.getCityEn();
+                userCity = locationDto.getCityEn() != null ? locationDto.getCityEn() : userCity;
             } else {
-                userCity = locationDto.getCityUk();
+                userCity = locationDto.getCityUk() != null ? locationDto.getCityUk() : userCity;
             }
         }
         return eventRepo.findRelevantCitiesForUser(userCity).stream()

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -2560,7 +2560,7 @@ class EventServiceImplTest {
             }
 
             @Override
-            public String getCityNameUa() {
+            public String getCityNameUk() {
                 return cityUa;
             }
 

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -2511,13 +2511,12 @@ class EventServiceImplTest {
         String userCity = "Kyiv";
         userVO.getUserLocationDto().setCityEn(userCity);
         List<EventCityDtoProjection> eventCityDtoProjections = List.of(
-                getProjection(userCity, "Київ", 1L),
-                getProjection("Dnipro", "Дніпро", 3L),
-                getProjection("Lviv", "Львів", 2L),
-                getProjection("Uzhhorod", "Ужгород", 1L)
-        );
+            getProjection(userCity, "Київ", 1L),
+            getProjection("Dnipro", "Дніпро", 3L),
+            getProjection("Lviv", "Львів", 2L),
+            getProjection("Uzhhorod", "Ужгород", 1L));
         when(eventRepo.findRelevantCitiesForUser(userCity))
-                .thenReturn(eventCityDtoProjections);
+            .thenReturn(eventCityDtoProjections);
         assertDoesNotThrow(() -> eventService.getAllRelevantEventsCityByUser(userVO));
         verify(eventRepo, times(1)).findRelevantCitiesForUser(userCity);
     }
@@ -2529,13 +2528,12 @@ class EventServiceImplTest {
         String userCity = "Київ";
         userVO.getUserLocationDto().setCityUk(userCity);
         List<EventCityDtoProjection> eventCityDtoProjections = List.of(
-                getProjection("Kyiv", userCity, 1L),
-                getProjection("Dnipro", "Дніпро", 3L),
-                getProjection("Lviv", "Львів", 2L),
-                getProjection("Uzhhorod", "Ужгород", 1L)
-        );
+            getProjection("Kyiv", userCity, 1L),
+            getProjection("Dnipro", "Дніпро", 3L),
+            getProjection("Lviv", "Львів", 2L),
+            getProjection("Uzhhorod", "Ужгород", 1L));
         when(eventRepo.findRelevantCitiesForUser(userCity))
-                .thenReturn(eventCityDtoProjections);
+            .thenReturn(eventCityDtoProjections);
         assertDoesNotThrow(() -> eventService.getAllRelevantEventsCityByUser(userVO));
         verify(eventRepo, times(1)).findRelevantCitiesForUser(userCity);
     }
@@ -2545,12 +2543,11 @@ class EventServiceImplTest {
         UserVO userVO = ModelUtils.getUserVO();
         userVO.setUserLocationDto(null);
         List<EventCityDtoProjection> eventCityDtoProjections = List.of(
-                getProjection("Dnipro", "Дніпро", 3L),
-                getProjection("Lviv", "Львів", 2L),
-                getProjection("Uzhhorod", "Ужгород", 1L)
-        );
+            getProjection("Dnipro", "Дніпро", 3L),
+            getProjection("Lviv", "Львів", 2L),
+            getProjection("Uzhhorod", "Ужгород", 1L));
         when(eventRepo.findRelevantCitiesForUser(anyString()))
-                .thenReturn(eventCityDtoProjections);
+            .thenReturn(eventCityDtoProjections);
         assertDoesNotThrow(() -> eventService.getAllRelevantEventsCityByUser(userVO));
         verify(eventRepo, times(1)).findRelevantCitiesForUser(anyString());
     }

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -11,6 +11,7 @@ import greencity.dto.PageableDto;
 import greencity.dto.event.AddEventDtoRequest;
 import greencity.dto.event.AddressDto;
 import greencity.dto.event.EventAttenderDto;
+import greencity.dto.event.EventCityDtoProjection;
 import greencity.dto.event.EventDateLocationDto;
 import greencity.dto.event.EventDto;
 import greencity.dto.event.EventResponseDto;
@@ -72,6 +73,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
+
 import static greencity.ModelUtils.getAuthorVO;
 import static greencity.ModelUtils.getEvent;
 import static greencity.ModelUtils.getEventPreviewDtos;
@@ -83,6 +85,7 @@ import static greencity.ModelUtils.getUserVO;
 import static greencity.ModelUtils.getUsersHashSet;
 import static greencity.ModelUtils.testUserVo;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -2336,9 +2339,7 @@ class EventServiceImplTest {
         when(eventRepo.findAllUserEventsByUserId(userId)).thenReturn(userEvents);
         when(modelMapper.map(any(Event.class), eq(EventDto.class))).thenThrow(new RuntimeException("Mapping error"));
 
-        assertThrows(RuntimeException.class, () -> {
-            eventService.getAllEventsOrganizedByUser(userId);
-        });
+        assertThrows(RuntimeException.class, () -> eventService.getAllEventsOrganizedByUser(userId));
 
         verify(eventRepo).findAllUserEventsByUserId(userId);
         verify(modelMapper, times(1)).map(any(Event.class), eq(EventDto.class));
@@ -2502,5 +2503,74 @@ class EventServiceImplTest {
         verify(eventRepo).findAllAttendedEventsByUserId(userId);
         verify(modelMapper, times(1)).map(any(Event.class), eq(EventDto.class));
         verifyNoInteractions(userRepo);
+    }
+
+    @Test
+    void getAllRelevantEventsCityByUserReturnsListWithUserCityIfUsersCityEnExists() {
+        UserVO userVO = ModelUtils.getUserVO();
+        String userCity = "Kyiv";
+        userVO.getUserLocationDto().setCityEn(userCity);
+        List<EventCityDtoProjection> eventCityDtoProjections = List.of(
+                getProjection(userCity, "Київ", 1L),
+                getProjection("Dnipro", "Дніпро", 3L),
+                getProjection("Lviv", "Львів", 2L),
+                getProjection("Uzhhorod", "Ужгород", 1L)
+        );
+        when(eventRepo.findRelevantCitiesForUser(userCity))
+                .thenReturn(eventCityDtoProjections);
+        assertDoesNotThrow(() -> eventService.getAllRelevantEventsCityByUser(userVO));
+        verify(eventRepo, times(1)).findRelevantCitiesForUser(userCity);
+    }
+
+    @Test
+    void getAllRelevantEventsCityByUserReturnsListWithUserCityIfUsersCityUaExists() {
+        UserVO userVO = ModelUtils.getUserVO();
+        userVO.getLanguageVO().setCode("ua");
+        String userCity = "Київ";
+        userVO.getUserLocationDto().setCityUk(userCity);
+        List<EventCityDtoProjection> eventCityDtoProjections = List.of(
+                getProjection("Kyiv", userCity, 1L),
+                getProjection("Dnipro", "Дніпро", 3L),
+                getProjection("Lviv", "Львів", 2L),
+                getProjection("Uzhhorod", "Ужгород", 1L)
+        );
+        when(eventRepo.findRelevantCitiesForUser(userCity))
+                .thenReturn(eventCityDtoProjections);
+        assertDoesNotThrow(() -> eventService.getAllRelevantEventsCityByUser(userVO));
+        verify(eventRepo, times(1)).findRelevantCitiesForUser(userCity);
+    }
+
+    @Test
+    void getAllRelevantEventsCityByUserDoesNotThrowAnExceptionIfUserLocationIsNull() {
+        UserVO userVO = ModelUtils.getUserVO();
+        userVO.setUserLocationDto(null);
+        List<EventCityDtoProjection> eventCityDtoProjections = List.of(
+                getProjection("Dnipro", "Дніпро", 3L),
+                getProjection("Lviv", "Львів", 2L),
+                getProjection("Uzhhorod", "Ужгород", 1L)
+        );
+        when(eventRepo.findRelevantCitiesForUser(anyString()))
+                .thenReturn(eventCityDtoProjections);
+        assertDoesNotThrow(() -> eventService.getAllRelevantEventsCityByUser(userVO));
+        verify(eventRepo, times(1)).findRelevantCitiesForUser(anyString());
+    }
+
+    private EventCityDtoProjection getProjection(String cityEn, String cityUa, Long amountOfEvents) {
+        return new EventCityDtoProjection() {
+            @Override
+            public String getCityNameEn() {
+                return cityEn;
+            }
+
+            @Override
+            public String getCityNameUa() {
+                return cityUa;
+            }
+
+            @Override
+            public Long getAmountOfEvents() {
+                return amountOfEvents;
+            }
+        };
     }
 }


### PR DESCRIPTION
**GIT**
[main GIT ticket](https://github.com/ita-social-projects/GreenCity/issues/8312)

**Added**
Added ability to retrieve a list of cities relevant to the user, including the user's city and the top three cities with the most events and tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a public endpoint that returns relevant city addresses based on your profile, including your own city (if available) and the top event cities.
	- Enhanced API documentation to clearly describe the new functionality.
	- Enabled access without authentication for this endpoint.

- **Tests**
	- Added comprehensive tests to ensure proper functionality across various user location scenarios, including different language settings and cases with missing location data.
	- Improved test coverage for the event service's handling of user location and relevant events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->