### PR TITLE
Task #8329 Restrict DB Metadata Endpoints to ADMIN Role Only & Remove .env secretKey Layer

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -87,7 +87,6 @@ public class SecurityConfig {
     private static final String INVITATION_ID = "/{invitationId}";
     private static final String COMMIT_INFO = "/commit-info";
     public static final String LOGS = "/logs/**";
-    public static final String SETTINGS_EXPORT = "/export/settings/**";
     private final JwtTool jwtTool;
     private final UserService userService;
     private final AuthenticationConfiguration authenticationConfiguration;
@@ -295,8 +294,7 @@ public class SecurityConfig {
                     FRIENDS,
                     NOTIFICATIONS,
                     HABIT_ASSIGN_ID + "/friends/habit-duration-info",
-                    "/ai/**",
-                    SETTINGS_EXPORT)
+                    "/ai/**")
                 .hasAnyRole(USER, ADMIN, MODERATOR, UBS_EMPLOYEE)
                 .requestMatchers(HttpMethod.POST,
                     CATEGORIES,

--- a/core/src/main/java/greencity/controller/ExportSettingsController.java
+++ b/core/src/main/java/greencity/controller/ExportSettingsController.java
@@ -23,7 +23,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RequestHeader;
 
 @RequiredArgsConstructor
 @RestController
@@ -48,8 +47,8 @@ public class ExportSettingsController {
             content = @Content(examples = @ExampleObject(HttpStatuses.FORBIDDEN))),
     })
     @GetMapping(value = "/tables", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<TablesMetadataDto> getTablesInfo(@RequestHeader String secretKey) {
-        return ResponseEntity.ok(exportSettingsService.getTablesMetadata(secretKey));
+    public ResponseEntity<TablesMetadataDto> getTablesInfo() {
+        return ResponseEntity.ok(exportSettingsService.getTablesMetadata());
     }
 
     /**
@@ -69,9 +68,8 @@ public class ExportSettingsController {
             content = @Content(examples = @ExampleObject(HttpStatuses.FORBIDDEN)))
     })
     @GetMapping("/select")
-    public ResponseEntity<TableRowsDto> selectFromTable(@Valid TableParamsRequestDto tableParams,
-        @RequestHeader String secretKey) {
-        return ResponseEntity.ok(exportSettingsService.selectFromTable(tableParams, secretKey));
+    public ResponseEntity<TableRowsDto> selectFromTable(@Valid TableParamsRequestDto tableParams) {
+        return ResponseEntity.ok(exportSettingsService.selectFromTable(tableParams));
     }
 
     /**
@@ -92,8 +90,7 @@ public class ExportSettingsController {
             content = @Content(examples = @ExampleObject(HttpStatuses.FORBIDDEN))),
     })
     @GetMapping("/download-table-data")
-    public ResponseEntity<InputStreamResource> exportTableRowsAsExcel(@Valid TableParamsRequestDto tableParams,
-        @RequestHeader String secretKey) {
+    public ResponseEntity<InputStreamResource> exportTableRowsAsExcel(@Valid TableParamsRequestDto tableParams) {
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.CONTENT_DISPOSITION,
             String.format("attachment; filename= %s(%d - %d).xlsx", tableParams.tableName(), tableParams.offset(),
@@ -103,7 +100,7 @@ public class ExportSettingsController {
         return ResponseEntity.ok()
             .headers(headers)
             .body(new InputStreamResource(
-                exportSettingsService.getExcelFileAsResource(tableParams, secretKey)));
+                exportSettingsService.getExcelFileAsResource(tableParams)));
     }
 
     /**
@@ -121,7 +118,7 @@ public class ExportSettingsController {
             content = @Content(examples = @ExampleObject(HttpStatuses.FORBIDDEN))),
     })
     @GetMapping("/env")
-    public ResponseEntity<EnvironmentDto> getEnvVariables(@RequestHeader String secretKey) {
-        return ResponseEntity.ok(exportSettingsService.getEnvironmentVariables(secretKey));
+    public ResponseEntity<EnvironmentDto> getEnvVariables() {
+        return ResponseEntity.ok(exportSettingsService.getEnvironmentVariables());
     }
 }

--- a/core/src/test/java/greencity/controller/ExportSettingsControllerTest.java
+++ b/core/src/test/java/greencity/controller/ExportSettingsControllerTest.java
@@ -7,7 +7,6 @@ import greencity.dto.exportsettings.EnvironmentDto;
 import greencity.dto.exportsettings.TableParamsRequestDto;
 import greencity.dto.exportsettings.TableRowsDto;
 import greencity.dto.exportsettings.TablesMetadataDto;
-import greencity.exception.exceptions.BadSecretKeyException;
 import greencity.exception.exceptions.DatabaseMetadataException;
 import greencity.exception.handler.CustomExceptionHandler;
 import greencity.service.ExportSettingsService;
@@ -43,8 +42,6 @@ class ExportSettingsControllerTest {
     private static final String NOT_EXISTS_TABLE_NAME = "usersssssss";
     private static final int LIMIT = tableParams.limit();
     private static final int OFFSET = tableParams.offset();
-    private static final String SECRET_KEY = "SomeSecretKey";
-    private static final String NOT_VALID_SECRET_KEY = "NotValidSecretKey";
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final ErrorAttributes errorAttributes = new DefaultErrorAttributes();
     private final TableParamsRequestDto tableParamsWithNotValidTableName =
@@ -62,13 +59,12 @@ class ExportSettingsControllerTest {
     }
 
     @Test
-    void getTablesInfoWithValidParamsTest() throws Exception {
+    void getTablesInfoTest() throws Exception {
         TablesMetadataDto tablesMetadataDto = ModelUtils.getTablesMetadataDto();
-        when(exportSettingsService.getTablesMetadata(SECRET_KEY)).thenReturn(tablesMetadataDto);
+        when(exportSettingsService.getTablesMetadata()).thenReturn(tablesMetadataDto);
         String expectedJson = objectMapper.writeValueAsString(tablesMetadataDto);
 
         mockMvc.perform(get(SETTINGS_CONTROLLER_LINK + "/tables")
-            .header("secretKey", SECRET_KEY)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().json(expectedJson));
@@ -77,14 +73,13 @@ class ExportSettingsControllerTest {
     @Test
     void getSelectedWithValidParamsTest() throws Exception {
         TableRowsDto tableRowsDto = ModelUtils.getTableRowsDto();
-        when(exportSettingsService.selectFromTable(tableParams, SECRET_KEY)).thenReturn(tableRowsDto);
+        when(exportSettingsService.selectFromTable(tableParams)).thenReturn(tableRowsDto);
         String expectedJson = objectMapper.writeValueAsString(tableRowsDto);
 
         mockMvc.perform(get(SETTINGS_CONTROLLER_LINK + "/select")
             .param("tableName", TABLE_NAME)
             .param("limit", String.valueOf(LIMIT))
             .param("offset", String.valueOf(OFFSET))
-            .header("secretKey", SECRET_KEY)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().json(expectedJson));
@@ -96,7 +91,6 @@ class ExportSettingsControllerTest {
             .param("tableName", INVALID_TABLE_NAME)
             .param("limit", String.valueOf(LIMIT))
             .param("offset", String.valueOf(OFFSET))
-            .header("secretKey", SECRET_KEY)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
             .andReturn();
@@ -106,13 +100,12 @@ class ExportSettingsControllerTest {
     void getSelectedWithNonExistentTableNameTest() throws Exception {
         doThrow(new DatabaseMetadataException(ErrorMessage.SQL_METADATA_EXCEPTION_MESSAGE + NOT_EXISTS_TABLE_NAME))
             .when(exportSettingsService)
-            .selectFromTable(tableParamsWithNotValidTableName, SECRET_KEY);
+            .selectFromTable(tableParamsWithNotValidTableName);
 
         mockMvc.perform(get(SETTINGS_CONTROLLER_LINK + "/select")
             .param("tableName", NOT_EXISTS_TABLE_NAME)
             .param("limit", String.valueOf(LIMIT))
             .param("offset", String.valueOf(OFFSET))
-            .header("secretKey", SECRET_KEY)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
             .andReturn();
@@ -126,7 +119,6 @@ class ExportSettingsControllerTest {
             .param("tableName", TABLE_NAME)
             .param("limit", String.valueOf(LIMIT))
             .param("offset", String.valueOf(negativeOffset))
-            .header("secretKey", SECRET_KEY)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
             .andReturn();
@@ -140,7 +132,6 @@ class ExportSettingsControllerTest {
             .param("tableName", TABLE_NAME)
             .param("limit", String.valueOf(negativeLimit))
             .param("offset", String.valueOf(OFFSET))
-            .header("secretKey", SECRET_KEY)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
             .andReturn();
@@ -154,7 +145,6 @@ class ExportSettingsControllerTest {
             .param("tableName", TABLE_NAME)
             .param("limit", String.valueOf(invalidLimit))
             .param("offset", String.valueOf(OFFSET))
-            .header("secretKey", SECRET_KEY)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
             .andReturn();
@@ -163,14 +153,13 @@ class ExportSettingsControllerTest {
     @Test
     void downloadExcelWithValidParamsTest() throws Exception {
         InputStream excelResource = new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5});
-        when(exportSettingsService.getExcelFileAsResource(tableParams, SECRET_KEY))
+        when(exportSettingsService.getExcelFileAsResource(tableParams))
             .thenReturn(excelResource);
 
         mockMvc.perform(get(SETTINGS_CONTROLLER_LINK + "/download-table-data")
             .param("tableName", TABLE_NAME)
             .param("limit", String.valueOf(LIMIT))
             .param("offset", String.valueOf(OFFSET))
-            .header("secretKey", SECRET_KEY)
             .accept(MediaType.APPLICATION_OCTET_STREAM))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_OCTET_STREAM))
@@ -183,7 +172,6 @@ class ExportSettingsControllerTest {
             .param("tableName", INVALID_TABLE_NAME)
             .param("limit", String.valueOf(LIMIT))
             .param("offset", String.valueOf(OFFSET))
-            .header("secretKey", SECRET_KEY)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
             .andReturn();
@@ -193,13 +181,12 @@ class ExportSettingsControllerTest {
     void downloadExcelWithNonExistentTableNameTest() throws Exception {
         doThrow(new DatabaseMetadataException(ErrorMessage.SQL_METADATA_EXCEPTION_MESSAGE + NOT_EXISTS_TABLE_NAME))
             .when(exportSettingsService)
-            .getExcelFileAsResource(tableParamsWithNotValidTableName, SECRET_KEY);
+            .getExcelFileAsResource(tableParamsWithNotValidTableName);
 
         mockMvc.perform(get(SETTINGS_CONTROLLER_LINK + "/download-table-data")
             .param("tableName", NOT_EXISTS_TABLE_NAME)
             .param("limit", String.valueOf(LIMIT))
             .param("offset", String.valueOf(OFFSET))
-            .header("secretKey", SECRET_KEY)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
             .andReturn();
@@ -213,7 +200,6 @@ class ExportSettingsControllerTest {
             .param("tableName", TABLE_NAME)
             .param("limit", String.valueOf(LIMIT))
             .param("offset", String.valueOf(negativeOffset))
-            .header("secretKey", SECRET_KEY)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
             .andReturn();
@@ -227,7 +213,6 @@ class ExportSettingsControllerTest {
             .param("tableName", TABLE_NAME)
             .param("limit", String.valueOf(negativeLimit))
             .param("offset", String.valueOf(OFFSET))
-            .header("secretKey", SECRET_KEY)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
             .andReturn();
@@ -241,32 +226,20 @@ class ExportSettingsControllerTest {
             .param("tableName", TABLE_NAME)
             .param("limit", String.valueOf(invalidLimit))
             .param("offset", String.valueOf(OFFSET))
-            .header("secretKey", SECRET_KEY)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
             .andReturn();
     }
 
     @Test
-    void getEnvVariablesWithValidSecretKeyTest() throws Exception {
+    void getEnvVariablesTest() throws Exception {
         EnvironmentDto environmentDto = ModelUtils.getEnvironmentDto();
-        when(exportSettingsService.getEnvironmentVariables(SECRET_KEY)).thenReturn(environmentDto);
+        when(exportSettingsService.getEnvironmentVariables()).thenReturn(environmentDto);
         String expectedJson = objectMapper.writeValueAsString(environmentDto);
 
         mockMvc.perform(get(SETTINGS_CONTROLLER_LINK + "/env")
-            .header("secretKey", SECRET_KEY)
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().json(expectedJson));
-    }
-
-    @Test
-    void getEnvVariablesWithNotValidSecretKeyTest() throws Exception {
-        when(exportSettingsService.getEnvironmentVariables(NOT_VALID_SECRET_KEY)).thenThrow(new BadSecretKeyException(ErrorMessage.BAD_SECRET_KEY));
-
-        mockMvc.perform(get(SETTINGS_CONTROLLER_LINK + "/env")
-                        .header("secretKey", NOT_VALID_SECRET_KEY)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isForbidden());
     }
 }

--- a/service-api/src/main/java/greencity/service/ExportSettingsService.java
+++ b/service-api/src/main/java/greencity/service/ExportSettingsService.java
@@ -10,24 +10,19 @@ public interface ExportSettingsService {
     /**
      * Method for receiving all DB tables short metadata.
      *
-     * @param secretKey {@link String} is a secret key for getting access to
-     *                  functionality.
-     *
      * @return {@link TablesMetadataDto} instance.
      */
-    TablesMetadataDto getTablesMetadata(String secretKey);
+    TablesMetadataDto getTablesMetadata();
 
     /**
      * Method for receiving rows from table by table name, limit and offset.
      *
      * @param tableParams {@link TableParamsRequestDto} dto with params such as
      *                    tableName, limit and offset.
-     * @param secretKey   {@link String} is a secret key for getting access to
-     *                    functionality.
      *
      * @return {@link TableRowsDto} object with metadata.
      */
-    TableRowsDto selectFromTable(TableParamsRequestDto tableParams, String secretKey);
+    TableRowsDto selectFromTable(TableParamsRequestDto tableParams);
 
     /**
      * Method for receiving an excel file as InputStream with rows from DB by table
@@ -35,20 +30,15 @@ public interface ExportSettingsService {
      *
      * @param tableParams {@link TableParamsRequestDto} dto with params such as
      *                    tableName, limit and offset.
-     * @param secretKey   {@link String} is a secret key for getting access to
-     *                    functionality.
      *
      * @return {@link InputStream} InputStream with file.
      */
-    InputStream getExcelFileAsResource(TableParamsRequestDto tableParams, String secretKey);
+    InputStream getExcelFileAsResource(TableParamsRequestDto tableParams);
 
     /**
      * Method for receiving all environment variables.
      *
-     * @param secretKey {@link String} is a secret key for getting access to
-     *                  functionality.
-     *
      * @return {@link EnvironmentDto} instance.
      */
-    EnvironmentDto getEnvironmentVariables(String secretKey);
+    EnvironmentDto getEnvironmentVariables();
 }

--- a/service/src/main/java/greencity/service/ExportSettingsServiceImpl.java
+++ b/service/src/main/java/greencity/service/ExportSettingsServiceImpl.java
@@ -17,28 +17,22 @@ import java.io.InputStream;
 public class ExportSettingsServiceImpl implements ExportSettingsService {
     private final ExportSettingsRepo exportSettingsRepo;
     private final ExportToFileService exportToFileService;
-    private final DotenvService dotenvService;
 
     @Override
-    public TablesMetadataDto getTablesMetadata(String secretKey) {
-        dotenvService.validateSecretKey(secretKey);
-
+    public TablesMetadataDto getTablesMetadata() {
         return exportSettingsRepo.getTablesMetadata();
     }
 
     @Transactional(readOnly = true)
     @Override
-    public TableRowsDto selectFromTable(TableParamsRequestDto tableParams, String secretKey) {
-        dotenvService.validateSecretKey(secretKey);
-
+    public TableRowsDto selectFromTable(TableParamsRequestDto tableParams) {
         return exportSettingsRepo.selectPortionFromTable(tableParams.tableName(), tableParams.limit(),
             tableParams.offset());
     }
 
     @Transactional(readOnly = true)
     @Override
-    public InputStream getExcelFileAsResource(TableParamsRequestDto tableParams, String secretKey) {
-        dotenvService.validateSecretKey(secretKey);
+    public InputStream getExcelFileAsResource(TableParamsRequestDto tableParams) {
         TableRowsDto data = exportSettingsRepo.selectPortionFromTable(tableParams.tableName(), tableParams.limit(),
             tableParams.offset());
 
@@ -46,9 +40,7 @@ public class ExportSettingsServiceImpl implements ExportSettingsService {
     }
 
     @Override
-    public EnvironmentDto getEnvironmentVariables(String secretKey) {
-        dotenvService.validateSecretKey(secretKey);
-
+    public EnvironmentDto getEnvironmentVariables() {
         return new EnvironmentDto(System.getenv());
     }
 }

--- a/service/src/test/java/greencity/service/ExportSettingsServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ExportSettingsServiceImplTest.java
@@ -1,12 +1,10 @@
 package greencity.service;
 
 import greencity.ModelUtils;
-import greencity.constant.ErrorMessage;
 import greencity.dto.exportsettings.EnvironmentDto;
 import greencity.dto.exportsettings.TableParamsRequestDto;
 import greencity.dto.exportsettings.TableRowsDto;
 import greencity.dto.exportsettings.TablesMetadataDto;
-import greencity.exception.exceptions.BadSecretKeyException;
 import greencity.repository.ExportSettingsRepo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,9 +16,6 @@ import java.io.InputStream;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,8 +25,6 @@ class ExportSettingsServiceImplTest {
     private static final String TABLE_NAME = "users";
     private static final int LIMIT = 10;
     private static final int OFFSET = 1;
-    private static final String SECRET_KEY = "SomeSecretKey";
-    private static final String NOT_VALID_SECRET_KEY = "SomeNotValidSecretKey";
     private final TableParamsRequestDto tableParams = ModelUtils.tableParamsRequestDto();
 
     @InjectMocks
@@ -43,93 +36,45 @@ class ExportSettingsServiceImplTest {
     @Mock
     private ExportToFileService exportToFileService;
 
-    @Mock
-    private DotenvService dotenvService;
-
     @Test
     void getTablesMetadataTest() {
         TablesMetadataDto tablesMetadataDto = ModelUtils.getTablesMetadataDto();
-        doNothing().when(dotenvService).validateSecretKey(SECRET_KEY);
         when(exportSettingsRepo.getTablesMetadata()).thenReturn(tablesMetadataDto);
 
-        TablesMetadataDto result = settingsService.getTablesMetadata(SECRET_KEY);
+        TablesMetadataDto result = settingsService.getTablesMetadata();
 
         assertNotNull(result);
         verify(exportSettingsRepo, times(1)).getTablesMetadata();
     }
 
     @Test
-    void getTablesMetadataWithNotWalidSecretKeyTest() {
-        doThrow(new BadSecretKeyException(ErrorMessage.BAD_SECRET_KEY)).when(dotenvService)
-            .validateSecretKey(NOT_VALID_SECRET_KEY);
-
-        assertThrows(BadSecretKeyException.class,
-            () -> settingsService.getTablesMetadata(NOT_VALID_SECRET_KEY));
-
-        verify(exportSettingsRepo, times(0)).getTablesMetadata();
-    }
-
-    @Test
     void selectFromTableWithValidParamsTest() {
         TableRowsDto tableRowsDto = ModelUtils.getTableRowsDto();
-        doNothing().when(dotenvService).validateSecretKey(SECRET_KEY);
         when(exportSettingsRepo.selectPortionFromTable(TABLE_NAME, LIMIT, OFFSET)).thenReturn(tableRowsDto);
 
-        TableRowsDto result = settingsService.selectFromTable(tableParams, SECRET_KEY);
+        TableRowsDto result = settingsService.selectFromTable(tableParams);
 
         assertNotNull(result);
         verify(exportSettingsRepo, times(1)).selectPortionFromTable(TABLE_NAME, LIMIT, OFFSET);
     }
 
     @Test
-    void selectFromTableWithNotValidSecretKeyTest() {
-        doThrow(new BadSecretKeyException(ErrorMessage.BAD_SECRET_KEY)).when(dotenvService)
-            .validateSecretKey(NOT_VALID_SECRET_KEY);
-
-        assertThrows(BadSecretKeyException.class,
-            () -> settingsService.selectFromTable(tableParams, NOT_VALID_SECRET_KEY));
-
-        verify(exportSettingsRepo, times(0)).selectPortionFromTable(TABLE_NAME, LIMIT, OFFSET);
-    }
-
-    @Test
     void getExcelFileAsResourceWithValidParamsTest() {
         InputStream excelResource = new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5});
         TableRowsDto tableRowsDto = ModelUtils.getTableRowsDto();
-        doNothing().when(dotenvService).validateSecretKey(SECRET_KEY);
         when(exportSettingsRepo.selectPortionFromTable(TABLE_NAME, LIMIT, OFFSET)).thenReturn(tableRowsDto);
         when(exportToFileService.exportTableDataToExcel(tableRowsDto)).thenReturn(excelResource);
 
-        InputStream result = settingsService.getExcelFileAsResource(tableParams, SECRET_KEY);
+        InputStream result = settingsService.getExcelFileAsResource(tableParams);
 
         assertNotNull(result);
         verify(exportToFileService, times(1)).exportTableDataToExcel(tableRowsDto);
     }
 
     @Test
-    void getExcelFileAsResourceWithNotValidSecretKeyTest() {
-        doThrow(new BadSecretKeyException(ErrorMessage.BAD_SECRET_KEY)).when(dotenvService)
-            .validateSecretKey(NOT_VALID_SECRET_KEY);
-
-        assertThrows(BadSecretKeyException.class,
-            () -> settingsService.getExcelFileAsResource(tableParams, NOT_VALID_SECRET_KEY));
-
-        verify(exportSettingsRepo, times(0)).selectPortionFromTable(TABLE_NAME, LIMIT, OFFSET);
-    }
-
-    @Test
-    void getEnvironmentVariablesWithValidSecretKeyTest() {
-        EnvironmentDto result = settingsService.getEnvironmentVariables(SECRET_KEY);
+    void getEnvironmentVariablesTest() {
+        EnvironmentDto result = settingsService.getEnvironmentVariables();
 
         assertFalse(result.variables().isEmpty());
-    }
-
-    @Test
-    void getEnvironmentVariablesWithNotValidSecretKeyTest() {
-        doThrow(new BadSecretKeyException(ErrorMessage.BAD_SECRET_KEY)).when(dotenvService)
-            .validateSecretKey(NOT_VALID_SECRET_KEY);
-
-        assertThrows(BadSecretKeyException.class,
-            () -> settingsService.getEnvironmentVariables(NOT_VALID_SECRET_KEY));
     }
 }


### PR DESCRIPTION
# GreenCity PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/GreenCity/issues/8329">#8329</a>

## Changed

- Removed _/export/settings/**_  from `SecurityConfig`. Now only the role **ADMIN** has access to these functionalities;
- Removed _secretKey_ as a header param from the `ExportSettingsController`;
- Removed _secretKey_ as method pram from the `ExportSettingsService`;
- Refactored JavaDoc in the `ExportSettingsService`;
- Removed security check using .env file from the `ExportSettingsServiceImpl`;
- Refactored tests in the `ExportSettingsControllerTest` and `ExportSettingsServiceImplTest` according to changed functionality;

## Summary Of Changes 🔥
- Temporarily removed .env security layer for the receiving metadata and data from the db and env variables;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Export Settings endpoints are now accessible without requiring a secret key.

- **Bug Fixes**
	- Simplified endpoint usage by removing the need to provide a secret key in requests.

- **Tests**
	- Updated and removed tests related to secret key validation for export settings functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->