### PR TITLE
8277/add external dependency greencity dev

### DIFF
--- a/az-cd-pipeline.yml
+++ b/az-cd-pipeline.yml
@@ -31,6 +31,25 @@ stages:
     pool:
       vmImage: $(agentOS)
     steps:
+    - task: AzureKeyVault@1
+      inputs:
+        azureSubscription: '$(azureSub)'
+        KeyVaultName: 'greencity-app'
+        SecretsFilter: 'LOGGING-ITA-TOKEN'
+        RunAsPreJob: false
+
+    - script: |
+        echo "<settings>" > $(Build.SourcesDirectory)/settings.xml
+        echo "  <servers>" >> $(Build.SourcesDirectory)/settings.xml
+        echo "    <server>" >> $(Build.SourcesDirectory)/settings.xml
+        echo "      <id>github</id>" >> $(Build.SourcesDirectory)/settings.xml
+        echo "      <username>ita-social-projects</username>" >> $(Build.SourcesDirectory)/settings.xml
+        echo "      <password>$(LOGGING-ITA-TOKEN)</password>" >> $(Build.SourcesDirectory)/settings.xml
+        echo "    </server>" >> $(Build.SourcesDirectory)/settings.xml
+        echo "  </servers>" >> $(Build.SourcesDirectory)/settings.xml
+        echo "</settings>" >> $(Build.SourcesDirectory)/settings.xml
+        displayName: "Create temporary settings.xml"
+
     - task: Maven@3
       displayName: Maven package
       inputs:
@@ -38,10 +57,14 @@ stages:
         javaHomeOption: 'JDKVersion'
         jdkVersionOption: '1.21'
         mavenVersionOption: 'Default'
-        options: '-Dmaven.test.skip=true'
+        options: '-Dmaven.test.skip=true -s $(Build.SourcesDirectory)/settings.xml'
 
     - script: mv $(coreRepoName)/target/*.jar $(coreRepoName)/target/$(onbootJarName)
       displayName: Rename core jar to app
+
+    - script: |
+        rm -f $(Build.SourcesDirectory)/settings.xml
+        displayName: "Delete temporary settings.xml"
 
     - task: CopyFiles@2
       displayName: Copy Files

--- a/az-cd-pipeline.yml
+++ b/az-cd-pipeline.yml
@@ -48,7 +48,7 @@ stages:
         echo "    </server>" >> $(Build.SourcesDirectory)/settings.xml
         echo "  </servers>" >> $(Build.SourcesDirectory)/settings.xml
         echo "</settings>" >> $(Build.SourcesDirectory)/settings.xml
-        displayName: "Create temporary settings.xml"
+      displayName: "Create temporary settings.xml"
 
     - task: Maven@3
       displayName: Maven package
@@ -64,7 +64,7 @@ stages:
 
     - script: |
         rm -f $(Build.SourcesDirectory)/settings.xml
-        displayName: "Delete temporary settings.xml"
+      displayName: "Delete temporary settings.xml"
 
     - task: CopyFiles@2
       displayName: Copy Files

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,7 +30,16 @@
         <test.containers.version>1.19.3</test.containers.version>
         <net.java.dev.jna.version>5.13.0</net.java.dev.jna.version>
         <apache.commons.version>3.13.0</apache.commons.version>
+        <ldm.version>0.21.8-SNAPSHOT</ldm.version>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <name>GitHub Repository</name>
+            <url>https://maven.pkg.github.com/Warded120/LDM-spring-boot-starter</url>
+        </repository>
+    </repositories>
 
     <dependencies>
         <dependency>
@@ -261,6 +270,11 @@
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <version>1.18.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.ivan.softserve</groupId>
+            <artifactId>ldm-spring-boot-starter</artifactId>
+            <version>${ldm.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,24 @@
         <commons.lang3.version>3.13.0</commons.lang3.version>
         <org.eclipse.jgit.version>7.1.0.202411261347-r</org.eclipse.jgit.version>
         <apache.poi.version>5.4.0</apache.poi.version>
+        <ldm.version>0.21.8-SNAPSHOT</ldm.version>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.ivan.softserve</groupId>
+            <artifactId>ldm-spring-boot-starter</artifactId>
+            <version>${ldm.version}</version>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <name>GitHub Repository</name>
+            <url>https://maven.pkg.github.com/Warded120/LDM-spring-boot-starter</url>
+        </repository>
+    </repositories>
 
     <profiles>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -46,24 +46,7 @@
         <commons.lang3.version>3.13.0</commons.lang3.version>
         <org.eclipse.jgit.version>7.1.0.202411261347-r</org.eclipse.jgit.version>
         <apache.poi.version>5.4.0</apache.poi.version>
-        <ldm.version>0.21.8-SNAPSHOT</ldm.version>
     </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>com.ivan.softserve</groupId>
-            <artifactId>ldm-spring-boot-starter</artifactId>
-            <version>${ldm.version}</version>
-        </dependency>
-    </dependencies>
-
-    <repositories>
-        <repository>
-            <id>github</id>
-            <name>GitHub Repository</name>
-            <url>https://maven.pkg.github.com/Warded120/LDM-spring-boot-starter</url>
-        </repository>
-    </repositories>
 
     <profiles>
         <profile>


### PR DESCRIPTION
Part of task [#8277](https://github.com/ita-social-projects/GreenCity/issues/8277)

Most likely, it will not deploy now, but we need this to be in the dev brunch before we add the needed access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated build pipeline to securely retrieve and use secrets for Maven authentication during packaging.
	- Enhanced Maven configuration to support a new dependency and repository for improved functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->