### PR TITLE
8277/Added external dependency to greencity prod

### DIFF
--- a/az-cd-pipeline-prod.yml
+++ b/az-cd-pipeline-prod.yml
@@ -10,20 +10,37 @@ trigger:
 pr: none
 
 variables:
-  agentOS: ubuntu-latest
+- group: 'AzureCredentials'
+- name: agentOS
+  value: ubuntu-latest
   
-  azKeyVault: key-vault-greencity
-  jsonSecret: google-credentials
-  jsonFile: google-creds.json
-  jsonLocation: /site/wwwroot
+- name: azKeyVault
+  value: key-vault-greencity
+- name: jsonSecret
+  value: google-credentials
+- name: jsonFile
+  value: google-creds.json
+- name: jsonLocation
+  value: /site/wwwroot
   
-  artifactName: drop
-  coreRepoName: core
-  onbootJarName: app.jar
+- name: artifactName
+  value: drop
+- name: coreRepoName
+  value: core
+- name: onbootJarName
+  value: app.jar
   
-  azureSub: GreenCity2022
-  resourceGroup: GreenCity
-  coreServiceName: greencity
+- name: azureSub
+  value: GreenCity2022
+- name: resourceGroup
+  value: GreenCity
+- name: coreServiceName
+  value: greencity
+
+- name: KEY_VAULT_NAME
+  value: 'greencity-app'
+- name: GREENCITY_SECRET_KEY_NAME
+  value: 'LOGGING-ITA-TOKEN'
 
 stages:
 - stage: Build
@@ -32,6 +49,30 @@ stages:
     pool:
       vmImage: $(agentOS)
     steps:
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: '$(azureSub)'
+        scriptType: 'bash'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID
+
+          secret=$(az keyvault secret show --vault-name $KEY_VAULT_NAME --name $GREENCITY_SECRET_KEY_NAME --query value -o tsv)
+
+          echo "<settings>" > $(Build.SourcesDirectory)/settings.xml
+          echo "  <servers>" >> $(Build.SourcesDirectory)/settings.xml
+          echo "    <server>" >> $(Build.SourcesDirectory)/settings.xml
+          echo "      <id>github</id>" >> $(Build.SourcesDirectory)/settings.xml
+          echo "      <username>ita-social-projects</username>" >> $(Build.SourcesDirectory)/settings.xml
+          echo "      <password>$secret</password>" >> $(Build.SourcesDirectory)/settings.xml
+          echo "    </server>" >> $(Build.SourcesDirectory)/settings.xml
+          echo "  </servers>" >> $(Build.SourcesDirectory)/settings.xml
+          echo "</settings>" >> $(Build.SourcesDirectory)/settings.xml
+      env:
+        AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
+        AZURE_TENANT_ID: $(AZURE_TENANT_ID)
+        AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
+
     - task: Maven@3
       displayName: Maven package
       inputs:
@@ -39,11 +80,14 @@ stages:
         javaHomeOption: 'JDKVersion'
         jdkVersionOption: '1.21'
         mavenVersionOption: 'Default'
-        options: '-Dmaven.test.skip=true'
+        options: '-Dmaven.test.skip=true -s $(Build.SourcesDirectory)/settings.xml'
 
-        
     - script: mv $(coreRepoName)/target/*.jar $(coreRepoName)/target/$(onbootJarName)
       displayName: Rename core jar to app
+
+    - script: |
+        rm -f $(Build.SourcesDirectory)/settings.xml
+      displayName: "Delete temporary settings.xml"
 
     - task: CopyFiles@2
       displayName: Copy Files

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -31,7 +31,16 @@
         <test.containers.version>1.19.3</test.containers.version>
         <net.java.dev.jna.version>5.13.0</net.java.dev.jna.version>
         <apache.commons.version>3.13.0</apache.commons.version>
+        <ldm.version>0.21.8-SNAPSHOT</ldm.version>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <name>GitHub Repository</name>
+            <url>https://maven.pkg.github.com/Warded120/LDM-spring-boot-starter</url>
+        </repository>
+    </repositories>
 
     <dependencies>
         <dependency>
@@ -262,6 +271,11 @@
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <version>1.18.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.ivan.softserve</groupId>
+            <artifactId>ldm-spring-boot-starter</artifactId>
+            <version>${ldm.version}</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
**!!! DON'T MERGE - IN PROGRESS!!!!**

Part of task [#8277](https://github.com/ita-social-projects/GreenCity/issues/8277)

It will not deploy now, but we need this to be in the prod brunch before we add the needed creds on the client side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated a new external dependency to enhance core functionality.
- **Chores**
  - Improved pipeline security by retrieving secrets from Azure Key Vault during builds.
  - Updated build pipeline to dynamically generate and clean up Maven configuration files for secure credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->