### PR TITLE
Task #8353 Add PageableAdvancedDto as Response Wrapper in the ExportSettingController.

### DIFF
--- a/core/src/main/java/greencity/controller/ExportSettingsController.java
+++ b/core/src/main/java/greencity/controller/ExportSettingsController.java
@@ -1,21 +1,26 @@
 package greencity.controller;
 
+import greencity.constant.ErrorMessage;
 import greencity.constant.HttpStatuses;
+import greencity.dto.PageableAdvancedDto;
 import greencity.dto.exportsettings.EnvironmentDto;
 import greencity.dto.exportsettings.TableParamsRequestDto;
 import greencity.dto.exportsettings.TableRowsDto;
 import greencity.dto.exportsettings.TablesMetadataDto;
 import greencity.service.ExportSettingsService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.io.InputStreamResource;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +28,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @RestController
@@ -54,7 +60,7 @@ public class ExportSettingsController {
     /**
      * Method for receiving rows from DB by table name, limit and offset.
      *
-     * @return dto {@link TableRowsDto}
+     * @return dto {@link PageableAdvancedDto}
      */
     @Operation(summary = "Get table rows by params.")
     @ApiResponses(value = {
@@ -68,20 +74,22 @@ public class ExportSettingsController {
             content = @Content(examples = @ExampleObject(HttpStatuses.FORBIDDEN)))
     })
     @GetMapping("/select")
-    public ResponseEntity<TableRowsDto> selectFromTable(@Valid TableParamsRequestDto tableParams) {
-        return ResponseEntity.ok(exportSettingsService.selectFromTable(tableParams));
+    public ResponseEntity<PageableAdvancedDto<Map<String, String>>> selectFromTable(
+        @Pattern(regexp = "^(?!_)[a-z]+(?:_[a-z]+){0,10}(?<!_)$",
+            message = ErrorMessage.INVALID_TABLE_NAME) String tableName,
+        @Parameter(hidden = true) Pageable pageable) {
+        return ResponseEntity.ok(exportSettingsService.selectFromTable(tableName, pageable));
     }
 
     /**
      * Method for receiving an .xlsx file with rows from DB by table name, limit and
      * offset.
      *
-     * @return dto {@link TableRowsDto}
+     * @return the excel file as stream {@link InputStreamResource}
      */
     @Operation(summary = "Get excel file with table rows by params.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK,
-            content = @Content(schema = @Schema(implementation = TableRowsDto.class))),
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST,
             content = @Content(examples = @ExampleObject(HttpStatuses.BAD_REQUEST))),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED,

--- a/core/src/main/java/greencity/controller/ExportSettingsController.java
+++ b/core/src/main/java/greencity/controller/ExportSettingsController.java
@@ -1,5 +1,6 @@
 package greencity.controller;
 
+import greencity.constant.AppConstant;
 import greencity.constant.ErrorMessage;
 import greencity.constant.HttpStatuses;
 import greencity.dto.PageableAdvancedDto;
@@ -75,7 +76,7 @@ public class ExportSettingsController {
     })
     @GetMapping("/select")
     public ResponseEntity<PageableAdvancedDto<Map<String, String>>> selectFromTable(
-        @Pattern(regexp = "^(?!_)[a-z]+(?:_[a-z]+){0,10}(?<!_)$",
+        @Pattern(regexp = AppConstant.VALID_TABLE_NAME_REGEX,
             message = ErrorMessage.INVALID_TABLE_NAME) String tableName,
         @Parameter(hidden = true) Pageable pageable) {
         return ResponseEntity.ok(exportSettingsService.selectFromTable(tableName, pageable));

--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -705,6 +705,19 @@ public class ModelUtils {
         return new TableRowsDto("users", tableData);
     }
 
+    public static PageableAdvancedDto<Map<String, String>> getPageableAdvancedDtoForTableRows() {
+        return new PageableAdvancedDto<>(
+            getTableRowsDto().tableData(),
+            1,
+            0,
+            1,
+            0,
+            false,
+            true,
+            true,
+            true);
+    }
+
     public static TableParamsRequestDto tableParamsRequestDto() {
         return new TableParamsRequestDto("users", 10, 1);
     }

--- a/core/src/test/java/greencity/controller/ExportSettingsControllerTest.java
+++ b/core/src/test/java/greencity/controller/ExportSettingsControllerTest.java
@@ -2,10 +2,11 @@ package greencity.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import greencity.ModelUtils;
+import greencity.config.CustomPageableHandlerMethodArgumentResolver;
 import greencity.constant.ErrorMessage;
+import greencity.dto.PageableAdvancedDto;
 import greencity.dto.exportsettings.EnvironmentDto;
 import greencity.dto.exportsettings.TableParamsRequestDto;
-import greencity.dto.exportsettings.TableRowsDto;
 import greencity.dto.exportsettings.TablesMetadataDto;
 import greencity.exception.exceptions.DatabaseMetadataException;
 import greencity.exception.handler.CustomExceptionHandler;
@@ -18,12 +19,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.Map;
 
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
@@ -42,6 +46,9 @@ class ExportSettingsControllerTest {
     private static final String NOT_EXISTS_TABLE_NAME = "usersssssss";
     private static final int LIMIT = tableParams.limit();
     private static final int OFFSET = tableParams.offset();
+    private static final int PAGE = 0;
+    private static final int SIZE = 20;
+    Pageable pageable = PageRequest.of(PAGE, SIZE);
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final ErrorAttributes errorAttributes = new DefaultErrorAttributes();
     private final TableParamsRequestDto tableParamsWithNotValidTableName =
@@ -55,6 +62,7 @@ class ExportSettingsControllerTest {
     void setup() {
         this.mockMvc = MockMvcBuilders.standaloneSetup(exportSettingsController)
             .setControllerAdvice(new CustomExceptionHandler(errorAttributes, objectMapper, null))
+            .setCustomArgumentResolvers(new CustomPageableHandlerMethodArgumentResolver())
             .build();
     }
 
@@ -72,14 +80,14 @@ class ExportSettingsControllerTest {
 
     @Test
     void getSelectedWithValidParamsTest() throws Exception {
-        TableRowsDto tableRowsDto = ModelUtils.getTableRowsDto();
-        when(exportSettingsService.selectFromTable(tableParams)).thenReturn(tableRowsDto);
-        String expectedJson = objectMapper.writeValueAsString(tableRowsDto);
+        PageableAdvancedDto<Map<String, String>> pageableResult = ModelUtils.getPageableAdvancedDtoForTableRows();
+        when(exportSettingsService.selectFromTable(tableParams.tableName(), pageable)).thenReturn(pageableResult);
+        String expectedJson = objectMapper.writeValueAsString(pageableResult);
 
         mockMvc.perform(get(SETTINGS_CONTROLLER_LINK + "/select")
             .param("tableName", TABLE_NAME)
-            .param("limit", String.valueOf(LIMIT))
-            .param("offset", String.valueOf(OFFSET))
+            .param("page", String.valueOf(PAGE))
+            .param("size", String.valueOf(SIZE))
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().json(expectedJson));
@@ -87,10 +95,14 @@ class ExportSettingsControllerTest {
 
     @Test
     void getSelectedWithInvalidTableNameTest() throws Exception {
+        doThrow(new DatabaseMetadataException(ErrorMessage.SQL_METADATA_EXCEPTION_MESSAGE + NOT_EXISTS_TABLE_NAME))
+            .when(exportSettingsService)
+            .selectFromTable(INVALID_TABLE_NAME, PageRequest.of(PAGE, SIZE));
+
         mockMvc.perform(get(SETTINGS_CONTROLLER_LINK + "/select")
             .param("tableName", INVALID_TABLE_NAME)
-            .param("limit", String.valueOf(LIMIT))
-            .param("offset", String.valueOf(OFFSET))
+            .param("page", String.valueOf(PAGE))
+            .param("size", String.valueOf(SIZE))
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
             .andReturn();
@@ -100,38 +112,38 @@ class ExportSettingsControllerTest {
     void getSelectedWithNonExistentTableNameTest() throws Exception {
         doThrow(new DatabaseMetadataException(ErrorMessage.SQL_METADATA_EXCEPTION_MESSAGE + NOT_EXISTS_TABLE_NAME))
             .when(exportSettingsService)
-            .selectFromTable(tableParamsWithNotValidTableName);
+            .selectFromTable(NOT_EXISTS_TABLE_NAME, pageable);
 
         mockMvc.perform(get(SETTINGS_CONTROLLER_LINK + "/select")
             .param("tableName", NOT_EXISTS_TABLE_NAME)
-            .param("limit", String.valueOf(LIMIT))
-            .param("offset", String.valueOf(OFFSET))
+            .param("page", String.valueOf(PAGE))
+            .param("size", String.valueOf(SIZE))
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
             .andReturn();
     }
 
     @Test
-    void getSelectedWithNegativeOffsetTest() throws Exception {
-        int negativeOffset = -1;
+    void getSelectedWithNegativePageSizeTest() throws Exception {
+        int negativePageSize = -1;
 
         mockMvc.perform(get(SETTINGS_CONTROLLER_LINK + "/select")
             .param("tableName", TABLE_NAME)
-            .param("limit", String.valueOf(LIMIT))
-            .param("offset", String.valueOf(negativeOffset))
+            .param("page", String.valueOf(PAGE))
+            .param("size", String.valueOf(negativePageSize))
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
             .andReturn();
     }
 
     @Test
-    void getSelectedWithNegativeLimitTest() throws Exception {
-        int negativeLimit = -1;
+    void getSelectedWithNegativePageNumberTest() throws Exception {
+        int negativePageNumber = -1;
 
         mockMvc.perform(get(SETTINGS_CONTROLLER_LINK + "/select")
             .param("tableName", TABLE_NAME)
-            .param("limit", String.valueOf(negativeLimit))
-            .param("offset", String.valueOf(OFFSET))
+            .param("page", String.valueOf(negativePageNumber))
+            .param("size", String.valueOf(SIZE))
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
             .andReturn();
@@ -143,8 +155,8 @@ class ExportSettingsControllerTest {
 
         mockMvc.perform(get(SETTINGS_CONTROLLER_LINK + "/select")
             .param("tableName", TABLE_NAME)
-            .param("limit", String.valueOf(invalidLimit))
-            .param("offset", String.valueOf(OFFSET))
+            .param("page", String.valueOf(PAGE))
+            .param("size", String.valueOf(invalidLimit))
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isBadRequest())
             .andReturn();

--- a/dao/src/main/java/greencity/repository/ExportSettingsRepo.java
+++ b/dao/src/main/java/greencity/repository/ExportSettingsRepo.java
@@ -17,4 +17,13 @@ public interface ExportSettingsRepo {
      * @return dto {@link TableRowsDto}
      */
     TableRowsDto selectPortionFromTable(String tableName, int limit, int offset);
+
+    /**
+     * Method for receiving total number of rows in the db table.
+     *
+     * @param tableName {@link String} DB table name.
+     *
+     * @return int count of rows.
+     */
+    int countRowsInTable(String tableName);
 }

--- a/dao/src/main/java/greencity/repository/impl/ExportSettingsRepoImpl.java
+++ b/dao/src/main/java/greencity/repository/impl/ExportSettingsRepoImpl.java
@@ -78,4 +78,21 @@ public class ExportSettingsRepoImpl implements ExportSettingsRepo {
         }
         return new TableRowsDto(tableName, tableData);
     }
+
+    @Override
+    public int countRowsInTable(String tableName) {
+        String query = String.format(AppConstant.SELECT_COUNT_FROM, tableName);
+
+        try (Connection connection = dataSource.getConnection();
+            PreparedStatement ps = connection.prepareStatement(query);
+            ResultSet rs = ps.executeQuery()) {
+            if (rs.next()) {
+                return rs.getInt(1);
+            }
+        } catch (SQLException e) {
+            log.error(e.getMessage());
+            throw new DatabaseMetadataException(ErrorMessage.SQL_METADATA_EXCEPTION_MESSAGE + tableName, e);
+        }
+        return 0;
+    }
 }

--- a/dao/src/main/java/greencity/repository/impl/ExportSettingsRepoImpl.java
+++ b/dao/src/main/java/greencity/repository/impl/ExportSettingsRepoImpl.java
@@ -86,13 +86,12 @@ public class ExportSettingsRepoImpl implements ExportSettingsRepo {
         try (Connection connection = dataSource.getConnection();
             PreparedStatement ps = connection.prepareStatement(query);
             ResultSet rs = ps.executeQuery()) {
-            if (rs.next()) {
-                return rs.getInt(1);
-            }
+            rs.next();
+
+            return rs.getInt(1);
         } catch (SQLException e) {
             log.error(e.getMessage());
             throw new DatabaseMetadataException(ErrorMessage.SQL_METADATA_EXCEPTION_MESSAGE + tableName, e);
         }
-        return 0;
     }
 }

--- a/dao/src/test/java/greencity/repository/impl/ExportSettingsRepoImplTest.java
+++ b/dao/src/test/java/greencity/repository/impl/ExportSettingsRepoImplTest.java
@@ -111,10 +111,21 @@ class ExportSettingsRepoImplTest {
     }
 
     @Test
-    void countRowsForNotExistsTableThrowExceptionTest() throws Exception {
+    void countRowsThrowExceptionWhenCantCreateConnectionTest() throws Exception {
         when(dataSource.getConnection()).thenThrow(new SQLException());
 
         assertThrows(DatabaseMetadataException.class,
-                () -> settingsRepo.countRowsInTable(NOT_EXISTS_TABLE_NAME));
+                () -> settingsRepo.countRowsInTable(TABLE_NAME));
+    }
+
+    @Test
+    void countRowsForNotExistsTableThrowExceptionTest() throws Exception {
+        String query = String.format("SELECT COUNT(*) FROM %s;", NOT_EXISTS_TABLE_NAME);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement(query)).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenThrow(new SQLException());
+
+        assertThrows(DatabaseMetadataException.class,
+            () -> settingsRepo.countRowsInTable(NOT_EXISTS_TABLE_NAME));
     }
 }

--- a/dao/src/test/java/greencity/repository/impl/ExportSettingsRepoImplTest.java
+++ b/dao/src/test/java/greencity/repository/impl/ExportSettingsRepoImplTest.java
@@ -18,11 +18,13 @@ import java.sql.SQLException;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ExportSettingsRepoImplTest {
     private static final String TABLE_NAME = "users";
+    private static final String NOT_EXISTS_TABLE_NAME = "not_exists_table";
     private static final int LIMIT = 10;
     private static final int OFFSET = 1;
 
@@ -92,5 +94,27 @@ class ExportSettingsRepoImplTest {
 
         assertThrows(DatabaseMetadataException.class,
             () -> settingsRepo.selectPortionFromTable(TABLE_NAME, LIMIT, OFFSET));
+    }
+
+    @Test
+    void countRowsInTableWithValidDbNameTest() throws Exception {
+        String query = String.format("SELECT COUNT(*) FROM %s;", TABLE_NAME);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement(query)).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true, false);
+        when(resultSet.getInt(1)).thenReturn(5);
+
+        int result = settingsRepo.countRowsInTable(TABLE_NAME);
+
+        assertTrue(result > 0);
+    }
+
+    @Test
+    void countRowsForNotExistsTableThrowExceptionTest() throws Exception {
+        when(dataSource.getConnection()).thenThrow(new SQLException());
+
+        assertThrows(DatabaseMetadataException.class,
+                () -> settingsRepo.countRowsInTable(NOT_EXISTS_TABLE_NAME));
     }
 }

--- a/service-api/src/main/java/greencity/constant/AppConstant.java
+++ b/service-api/src/main/java/greencity/constant/AppConstant.java
@@ -35,8 +35,8 @@ public class AppConstant {
     public static final String TABLE_NAME = "TABLE_NAME";
     public static final String COLUMN_NAME = "COLUMN_NAME";
     public static final String SELECT_FROM_WITH_LIMIT_AND_OFFSET = "SELECT * FROM %s LIMIT %d OFFSET %d;";
+    public static final String SELECT_COUNT_FROM = "SELECT COUNT(*) FROM %s;";
     public static final Set<String> supportedLanguages = Set.of(
         DEFAULT_LANGUAGE_CODE,
         LANGUAGE_CODE_UA);
-    public static final String EMPTY_STRING = "";
 }

--- a/service-api/src/main/java/greencity/constant/AppConstant.java
+++ b/service-api/src/main/java/greencity/constant/AppConstant.java
@@ -39,4 +39,5 @@ public class AppConstant {
     public static final Set<String> supportedLanguages = Set.of(
         DEFAULT_LANGUAGE_CODE,
         LANGUAGE_CODE_UA);
+    public static final String EMPTY_STRING = "";
 }

--- a/service-api/src/main/java/greencity/constant/AppConstant.java
+++ b/service-api/src/main/java/greencity/constant/AppConstant.java
@@ -34,6 +34,7 @@ public class AppConstant {
     public static final String TABLE = "TABLE";
     public static final String TABLE_NAME = "TABLE_NAME";
     public static final String COLUMN_NAME = "COLUMN_NAME";
+    public static final String VALID_TABLE_NAME_REGEX = "^(?!_)[a-z]+(?:_[a-z]+){0,10}(?<!_)$";
     public static final String SELECT_FROM_WITH_LIMIT_AND_OFFSET = "SELECT * FROM %s LIMIT %d OFFSET %d;";
     public static final String SELECT_COUNT_FROM = "SELECT COUNT(*) FROM %s;";
     public static final Set<String> supportedLanguages = Set.of(

--- a/service-api/src/main/java/greencity/dto/exportsettings/TableParamsRequestDto.java
+++ b/service-api/src/main/java/greencity/dto/exportsettings/TableParamsRequestDto.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 
 public record TableParamsRequestDto(
-    @Pattern(regexp = "^(?!_)[a-z]+(?:_[a-z]+){0,10}(?<!_)$",
+    @Pattern(regexp = AppConstant.VALID_TABLE_NAME_REGEX,
         message = ErrorMessage.INVALID_TABLE_NAME) String tableName,
 
     @Min(value = 0, message = ErrorMessage.NEGATIVE_LIMIT) @Max(value = AppConstant.SQL_ROW_LIMIT,

--- a/service-api/src/main/java/greencity/service/ExportSettingsService.java
+++ b/service-api/src/main/java/greencity/service/ExportSettingsService.java
@@ -1,10 +1,12 @@
 package greencity.service;
 
+import greencity.dto.PageableAdvancedDto;
 import greencity.dto.exportsettings.EnvironmentDto;
 import greencity.dto.exportsettings.TableParamsRequestDto;
-import greencity.dto.exportsettings.TableRowsDto;
 import greencity.dto.exportsettings.TablesMetadataDto;
+import org.springframework.data.domain.Pageable;
 import java.io.InputStream;
+import java.util.Map;
 
 public interface ExportSettingsService {
     /**
@@ -17,12 +19,13 @@ public interface ExportSettingsService {
     /**
      * Method for receiving rows from table by table name, limit and offset.
      *
-     * @param tableParams {@link TableParamsRequestDto} dto with params such as
-     *                    tableName, limit and offset.
+     * @param tableName {@link String} DB table name.
+     * @param pageable  {@link Pageable} pageable object with params such as page,
+     *                  size, sort etc.
      *
-     * @return {@link TableRowsDto} object with metadata.
+     * @return {@link PageableAdvancedDto} pageable object with data.
      */
-    TableRowsDto selectFromTable(TableParamsRequestDto tableParams);
+    PageableAdvancedDto<Map<String, String>> selectFromTable(String tableName, Pageable pageable);
 
     /**
      * Method for receiving an excel file as InputStream with rows from DB by table

--- a/service/src/main/java/greencity/service/ExportSettingsServiceImpl.java
+++ b/service/src/main/java/greencity/service/ExportSettingsServiceImpl.java
@@ -1,5 +1,6 @@
 package greencity.service;
 
+import greencity.dto.PageableAdvancedDto;
 import greencity.dto.exportsettings.EnvironmentDto;
 import greencity.dto.exportsettings.TableParamsRequestDto;
 import greencity.dto.exportsettings.TableRowsDto;
@@ -7,9 +8,12 @@ import greencity.dto.exportsettings.TablesMetadataDto;
 import greencity.repository.ExportSettingsRepo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Service
@@ -23,11 +27,14 @@ public class ExportSettingsServiceImpl implements ExportSettingsService {
         return exportSettingsRepo.getTablesMetadata();
     }
 
-    @Transactional(readOnly = true)
     @Override
-    public TableRowsDto selectFromTable(TableParamsRequestDto tableParams) {
-        return exportSettingsRepo.selectPortionFromTable(tableParams.tableName(), tableParams.limit(),
-            tableParams.offset());
+    @Transactional(readOnly = true)
+    public PageableAdvancedDto<Map<String, String>> selectFromTable(String tableName, Pageable pageable) {
+        int totalElements = exportSettingsRepo.countRowsInTable(tableName);
+        TableRowsDto data = exportSettingsRepo.selectPortionFromTable(
+            tableName, pageable.getPageSize(), (int) pageable.getOffset());
+
+        return populatePageableDto(totalElements, pageable, data.tableData());
     }
 
     @Transactional(readOnly = true)
@@ -42,5 +49,23 @@ public class ExportSettingsServiceImpl implements ExportSettingsService {
     @Override
     public EnvironmentDto getEnvironmentVariables() {
         return new EnvironmentDto(System.getenv());
+    }
+
+    private PageableAdvancedDto<Map<String, String>> populatePageableDto(int totalElements, Pageable pageable,
+        List<Map<String, String>> data) {
+        int totalPages = (int) Math.ceil((double) totalElements / pageable.getPageSize());
+        boolean isFirst = pageable.getPageNumber() == 0;
+        boolean isLast = pageable.getPageNumber() + 1 >= totalPages;
+
+        return new PageableAdvancedDto<>(
+            data,
+            totalElements,
+            pageable.getPageNumber(),
+            totalPages,
+            pageable.getPageNumber(),
+            pageable.getPageNumber() > 0,
+            !isLast,
+            isFirst,
+            isLast);
     }
 }

--- a/service/src/test/java/greencity/service/ExportSettingsServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ExportSettingsServiceImplTest.java
@@ -107,9 +107,9 @@ class ExportSettingsServiceImplTest {
 
     private TableRowsDto populateTableRowDto() {
         List<Map<String, String>> tableData = new LinkedList<>();
-        Map<String, String> row = new LinkedHashMap<>();
 
         for (int i = 0; i < 10; i++) {
+            Map<String, String> row = new LinkedHashMap<>();
             row.put("id", String.valueOf(i));
             row.put("date_of_registration", "1970-01-01 00:00:00");
             row.put("email", "someemail" + i + "@some.com");

--- a/service/src/test/java/greencity/service/ExportSettingsServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ExportSettingsServiceImplTest.java
@@ -1,6 +1,7 @@
 package greencity.service;
 
 import greencity.ModelUtils;
+import greencity.dto.PageableAdvancedDto;
 import greencity.dto.exportsettings.EnvironmentDto;
 import greencity.dto.exportsettings.TableParamsRequestDto;
 import greencity.dto.exportsettings.TableRowsDto;
@@ -11,8 +12,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -23,8 +27,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ExportSettingsServiceImplTest {
     private static final String TABLE_NAME = "users";
-    private static final int LIMIT = 10;
-    private static final int OFFSET = 1;
+    private static final Pageable pageable = PageRequest.of(0, 10);
     private final TableParamsRequestDto tableParams = ModelUtils.tableParamsRequestDto();
 
     @InjectMocks
@@ -50,19 +53,22 @@ class ExportSettingsServiceImplTest {
     @Test
     void selectFromTableWithValidParamsTest() {
         TableRowsDto tableRowsDto = ModelUtils.getTableRowsDto();
-        when(exportSettingsRepo.selectPortionFromTable(TABLE_NAME, LIMIT, OFFSET)).thenReturn(tableRowsDto);
+        when(exportSettingsRepo.selectPortionFromTable(TABLE_NAME, pageable.getPageSize(), (int) pageable.getOffset()))
+            .thenReturn(tableRowsDto);
 
-        TableRowsDto result = settingsService.selectFromTable(tableParams);
+        PageableAdvancedDto<Map<String, String>> result = settingsService.selectFromTable(TABLE_NAME, pageable);
 
-        assertNotNull(result);
-        verify(exportSettingsRepo, times(1)).selectPortionFromTable(TABLE_NAME, LIMIT, OFFSET);
+        assertFalse(result.getPage().isEmpty());
+        verify(exportSettingsRepo, times(1)).selectPortionFromTable(TABLE_NAME, pageable.getPageSize(),
+            (int) pageable.getOffset());
     }
 
     @Test
     void getExcelFileAsResourceWithValidParamsTest() {
         InputStream excelResource = new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5});
         TableRowsDto tableRowsDto = ModelUtils.getTableRowsDto();
-        when(exportSettingsRepo.selectPortionFromTable(TABLE_NAME, LIMIT, OFFSET)).thenReturn(tableRowsDto);
+        when(exportSettingsRepo.selectPortionFromTable(TABLE_NAME, tableParams.limit(), tableParams.offset()))
+            .thenReturn(tableRowsDto);
         when(exportToFileService.exportTableDataToExcel(tableRowsDto)).thenReturn(excelResource);
 
         InputStream result = settingsService.getExcelFileAsResource(tableParams);

--- a/service/src/test/java/greencity/service/ExportSettingsServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ExportSettingsServiceImplTest.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -32,7 +31,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ExportSettingsServiceImplTest {
     private static final String TABLE_NAME = "users";
-    private static final Pageable pageable = PageRequest.of(0, 10);
+    private static final Pageable pageable = PageRequest.of(2, 2);
     private final TableParamsRequestDto tableParams = ModelUtils.tableParamsRequestDto();
 
     @InjectMocks
@@ -71,7 +70,6 @@ class ExportSettingsServiceImplTest {
     @Test
     void selectFromTableWithValidParamsAndResultMoreThenOnePageTest() {
         TableRowsDto tableRowsDto = populateTableRowDto();
-        Pageable pageable = PageRequest.of(2, 2);
         when(exportSettingsRepo.selectPortionFromTable(TABLE_NAME, pageable.getPageSize(), (int) pageable.getOffset()))
             .thenReturn(tableRowsDto);
         when(exportSettingsRepo.countRowsInTable(TABLE_NAME)).thenReturn(tableRowsDto.tableData().size());

--- a/service/src/test/java/greencity/service/ExportSettingsServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ExportSettingsServiceImplTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ExportSettingsServiceImplTest {
     private static final String TABLE_NAME = "users";
-    private static final Pageable pageable = PageRequest.of(2, 2);
+    private static final Pageable pageable = PageRequest.of(0, 10);
     private final TableParamsRequestDto tableParams = ModelUtils.tableParamsRequestDto();
 
     @InjectMocks
@@ -70,15 +70,18 @@ class ExportSettingsServiceImplTest {
     @Test
     void selectFromTableWithValidParamsAndResultMoreThenOnePageTest() {
         TableRowsDto tableRowsDto = populateTableRowDto();
-        when(exportSettingsRepo.selectPortionFromTable(TABLE_NAME, pageable.getPageSize(), (int) pageable.getOffset()))
+        Pageable pageableForSecondPage = PageRequest.of(2, 2);
+        when(exportSettingsRepo.selectPortionFromTable(TABLE_NAME, pageableForSecondPage.getPageSize(),
+            (int) pageableForSecondPage.getOffset()))
             .thenReturn(tableRowsDto);
         when(exportSettingsRepo.countRowsInTable(TABLE_NAME)).thenReturn(tableRowsDto.tableData().size());
 
-        PageableAdvancedDto<Map<String, String>> result = settingsService.selectFromTable(TABLE_NAME, pageable);
+        PageableAdvancedDto<Map<String, String>> result =
+            settingsService.selectFromTable(TABLE_NAME, pageableForSecondPage);
 
         assertEquals(result.getTotalElements(), tableRowsDto.tableData().size());
-        verify(exportSettingsRepo, times(1)).selectPortionFromTable(TABLE_NAME, pageable.getPageSize(),
-            (int) pageable.getOffset());
+        verify(exportSettingsRepo, times(1)).selectPortionFromTable(TABLE_NAME, pageableForSecondPage.getPageSize(),
+            (int) pageableForSecondPage.getOffset());
     }
 
     @Test

--- a/service/src/test/java/greencity/service/ExportSettingsServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ExportSettingsServiceImplTest.java
@@ -16,10 +16,15 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -64,6 +69,21 @@ class ExportSettingsServiceImplTest {
     }
 
     @Test
+    void selectFromTableWithValidParamsAndResultMoreThenOnePageTest() {
+        TableRowsDto tableRowsDto = populateTableRowDto();
+        Pageable pageable = PageRequest.of(2, 2);
+        when(exportSettingsRepo.selectPortionFromTable(TABLE_NAME, pageable.getPageSize(), (int) pageable.getOffset()))
+            .thenReturn(tableRowsDto);
+        when(exportSettingsRepo.countRowsInTable(TABLE_NAME)).thenReturn(tableRowsDto.tableData().size());
+
+        PageableAdvancedDto<Map<String, String>> result = settingsService.selectFromTable(TABLE_NAME, pageable);
+
+        assertEquals(result.getTotalElements(), tableRowsDto.tableData().size());
+        verify(exportSettingsRepo, times(1)).selectPortionFromTable(TABLE_NAME, pageable.getPageSize(),
+            (int) pageable.getOffset());
+    }
+
+    @Test
     void getExcelFileAsResourceWithValidParamsTest() {
         InputStream excelResource = new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5});
         TableRowsDto tableRowsDto = ModelUtils.getTableRowsDto();
@@ -82,5 +102,20 @@ class ExportSettingsServiceImplTest {
         EnvironmentDto result = settingsService.getEnvironmentVariables();
 
         assertFalse(result.variables().isEmpty());
+    }
+
+    private TableRowsDto populateTableRowDto() {
+        List<Map<String, String>> tableData = new LinkedList<>();
+        Map<String, String> row = new LinkedHashMap<>();
+
+        for (int i = 0; i < 10; i++) {
+            row.put("id", String.valueOf(i));
+            row.put("date_of_registration", "1970-01-01 00:00:00");
+            row.put("email", "someemail" + i + "@some.com");
+            row.put("name", "Name" + i);
+            row.put("role", "ROLE_USER");
+            tableData.add(row);
+        }
+        return new TableRowsDto("users", tableData);
     }
 }


### PR DESCRIPTION
# GreenCity PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/GreenCity/issues/8353">#8353</a>

## Changed

- Added _Pageble_ as method param in the method _selectFromTable_ in the `ExportSettingsController`;
- Refactored unit tests due to new method params in the `ExportSettingsControllerTest` class;
- Added method for receiving `PageableAdvancedDto` as TableRows in the `ModelUtils`;
- Refactored _selectFromTable_ method in the `ExportSettingsService` interface;
- Refactored realisation of the method _selectFromTable_ in the `ExportSettingsServiceImpl` and added private helping method _populatePageableDto_;
- Added method `countRowsInTable` in the `ExportSettingsRepo` interface and implementation in the `ExportSettingsRepoImpl`;
- Added new integration tests in the `ExportSettingsRepoImplTest` for covering the new method;
- Added constant _SELECT_COUNT_FROM_ in the `AppConstant` class;

## Summary Of Changes 🔥
Added pageable functionality for selecting data from the DB;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to count rows in any database table for export settings.
  - Responses for table data export are now paginated and provide advanced pagination metadata.

- **Refactor**
  - Updated endpoints and service methods to use standard pagination parameters (`page` and `size`) instead of custom limit/offset.
  - Improved response structure for table data export to a more flexible and generic format.

- **Bug Fixes**
  - Enhanced validation for table names in API requests.

- **Tests**
  - Added and updated tests to cover new pagination logic and row-counting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->