### PR TITLE
Added endpoint access for users in SecurityConfig

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -87,6 +87,7 @@ public class SecurityConfig {
     private static final String INVITATION_ID = "/{invitationId}";
     private static final String COMMIT_INFO = "/commit-info";
     public static final String LOGS = "/logs/**";
+    private static final String DISLIKE_V2 = "/dislikeV2";
     private final JwtTool jwtTool;
     private final UserService userService;
     private final AuthenticationConfiguration authenticationConfiguration;
@@ -227,7 +228,7 @@ public class SecurityConfig {
                     ECO_NEWS + COUNT,
                     ECO_NEWS + ECO_NEWS_ID + "/summary",
                     ECO_NEWS + ECO_NEWS_ID + LIKES + "/{userId}",
-                    ECO_NEWS + ECO_NEWS_ID + "/dislikeV2",
+                    ECO_NEWS + ECO_NEWS_ID + DISLIKE_V2,
                     ECO_NEWS + ECO_NEWS_ID + "/likeV2",
                     "/favorite_place/",
                     "/to-do-list-items",
@@ -353,9 +354,9 @@ public class SecurityConfig {
                     ECO_NEWS + "/{ecoNewsId}/favorites",
                     "/habit/assign/{habitId}/invite",
                     "place/v2/save",
-                    EVENTS + COMMENTS + "/dislikeV2" + COMMENT_ID,
+                    EVENTS + COMMENTS + DISLIKE_V2 + COMMENT_ID,
                     EVENTS + COMMENTS + "/likeV2" + COMMENT_ID,
-                    ECO_NEWS + COMMENTS + "/dislikeV2",
+                    ECO_NEWS + COMMENTS + DISLIKE_V2,
                     LOGS)
                 .hasAnyRole(USER, ADMIN, MODERATOR, UBS_EMPLOYEE)
                 .requestMatchers(HttpMethod.PUT,

--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -355,6 +355,7 @@ public class SecurityConfig {
                     "place/v2/save",
                     EVENTS + COMMENTS + "/dislikeV2" + COMMENT_ID,
                     EVENTS + COMMENTS + "/likeV2" + COMMENT_ID,
+                    ECO_NEWS + COMMENTS + "/dislikeV2",
                     LOGS)
                 .hasAnyRole(USER, ADMIN, MODERATOR, UBS_EMPLOYEE)
                 .requestMatchers(HttpMethod.PUT,


### PR DESCRIPTION
**Summary**
I have added endpoint access for users in SecurityConfig for front-end team.

**Changes**
SecurityConfig was modified according to the needs of the frontend team.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added role-based access control for the `/eco-news/comments/dislikeV2` endpoint, ensuring only authorized users can access this feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->