### PR TITLE
Fixed 500 status on eco news comments like/dislike

### DIFF
--- a/dao/src/main/resources/db/changelog/logs/ch-add-table-comments-users-likes-Fedotov.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-add-table-comments-users-likes-Fedotov.xml
@@ -52,4 +52,9 @@
                                  referencedColumnNames="id"
                                  referencedTableName="users"/>
     </changeSet>
+    <changeSet id="1747142053687-1" author="Andrii Danylenko">
+        <addPrimaryKey tableName="comments_users_likes"
+                       columnNames="user_id, comment_id"
+                       constraintName="PK_comments_users_likes"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-add-table-notification-Mladonov.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-add-table-notification-Mladonov.xml
@@ -31,4 +31,9 @@
             </column>
         </createTable>
     </changeSet>
+    <changeSet id="Andrii-1" author="Andrii Danylenko">
+        <addPrimaryKey tableName="notifications_users"
+                       columnNames="notification_id, user_id"
+                       constraintName="PK_notifications_users"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-comments-users-dislike-table.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-comments-users-dislike-table.xml
@@ -39,4 +39,9 @@
                                  referencedColumnNames="id"
                                  referencedTableName="comments"/>
     </changeSet>
+    <changeSet id="1747141984482-1" author="Andrii Danylenko">
+        <addPrimaryKey tableName="comments_users_dislikes"
+                       columnNames="user_id, comment_id"
+                       constraintName="PK_comments_users_dislikes"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
**Summary**
During testing, I came across a bug related to the presence of duplicates when trying to retrieve records from the database.

**Changes**
I cleared the database of duplicates and added primary key constraints on tables to prevent duplicates in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added primary key constraints to the comments_users_likes, comments_users_dislikes, and notifications_users tables to ensure uniqueness of user and comment/notification combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->