### PR TITLE
Fix/#7819#8585/returns multiple error messages

### DIFF
--- a/core/src/test/java/greencity/controller/EventControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventControllerTest.java
@@ -233,6 +233,24 @@ class EventControllerTest {
 
     @Test
     @SneakyThrows
+    void saveBadRequestWithNotValidDescriptionTest() {
+        AddEventDtoRequest addEventDtoRequest = getAddEventDtoRequestBadDescription();
+
+        String json = objectMapper.writeValueAsString(addEventDtoRequest);
+
+        MockMultipartFile jsonFile =
+            new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
+
+        mockMvc.perform(multipart(EVENTS_CONTROLLER_LINK)
+                .file(jsonFile)
+                .principal(principal)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @SneakyThrows
     void saveV2Test() {
         AddEventDtoRequest addEventDtoRequest = getAddEventDtoRequest();
 
@@ -672,6 +690,30 @@ class EventControllerTest {
             {
                 "title":"string",
                 "description":"stringstringstringstringstringstringstringstring",
+                "open":true,
+                "datesLocations":[
+                    {
+                        "startDate":"2023-05-27T15:00:00Z",
+                        "finishDate":"2023-05-27T17:00:00Z",
+                        "coordinates":{
+                            "latitude":1,
+                            "longitude":1
+                        },
+                        "onlineLink":"http://localhost:8080/swagger-ui.html#/events-controller"
+                    }
+                ],
+                "tags":["Social"]
+            }""";
+
+        return objectMapper.readValue(json, AddEventDtoRequest.class);
+    }
+
+    @SneakyThrows
+    private AddEventDtoRequest getAddEventDtoRequestBadDescription() {
+        String json = """
+            {
+                "title":"string",
+                "description":" stringstringstringstringstringstringstringstring",
                 "open":true,
                 "datesLocations":[
                     {

--- a/core/src/test/java/greencity/controller/EventControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventControllerTest.java
@@ -252,10 +252,10 @@ class EventControllerTest {
             new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
 
         mockMvc.perform(multipart(EVENTS_CONTROLLER_LINK)
-                .file(jsonFile)
-                .principal(principal)
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .file(jsonFile)
+            .principal(principal)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
             .andExpect(status().isBadRequest());
 
         verify(eventService, times(0)).save(any(), any(), any());
@@ -324,10 +324,10 @@ class EventControllerTest {
         MockMultipartFile jsonFile =
             new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
         mockMvc.perform(multipart("/events/createV2")
-                .file(jsonFile)
-                .principal(principal)
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .file(jsonFile)
+            .principal(principal)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
             .andExpect(status().isBadRequest());
 
         verify(eventService, times(0)).save(any(), any(), any());

--- a/core/src/test/java/greencity/controller/EventControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventControllerTest.java
@@ -278,7 +278,7 @@ class EventControllerTest {
     @Test
     @SneakyThrows
     void saveV2BadRequestWithNotValidDescriptionTest() {
-        AddEventDtoRequest addEventDtoRequest = buildAddEventDto("String", " Example of description for testing");
+        AddEventDtoRequest addEventDtoRequest = buildAddEventDto("String V2", " Example of description for testing V2");
 
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 

--- a/core/src/test/java/greencity/controller/EventControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventControllerTest.java
@@ -1,11 +1,23 @@
 package greencity.controller;
 
+import static greencity.ModelUtils.*;
+import static greencity.TestConst.EVENT_ID;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import greencity.ModelUtils;
 import greencity.constant.ErrorMessage;
 import greencity.converters.UserArgumentResolver;
 import greencity.dto.PageableAdvancedDto;
-import greencity.dto.event.*;
+import greencity.dto.event.AddEventDtoRequest;
+import greencity.dto.event.EventDto;
+import greencity.dto.event.EventResponseDto;
+import greencity.dto.event.UpdateEventRequestDto;
 import greencity.dto.filter.FilterEventDto;
 import greencity.dto.user.UserVO;
 import greencity.enums.EventStatus;
@@ -36,28 +48,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
-import static greencity.ModelUtils.getCreateJsonFile;
-import static greencity.ModelUtils.getEventDtoPageableAdvancedDto;
-import static greencity.ModelUtils.getPrincipal;
-import static greencity.ModelUtils.getUserVO;
-import static greencity.TestConst.EVENT_ID;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -234,7 +224,7 @@ class EventControllerTest {
     @Test
     @SneakyThrows
     void saveBadRequestWithNotValidDescriptionTest() {
-        AddEventDtoRequest addEventDtoRequest = getAddEventDtoRequestBadDescription();
+        AddEventDtoRequest addEventDtoRequest = buildAddEventDto("String", " Example of description for testing");
 
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
@@ -247,6 +237,8 @@ class EventControllerTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
             .andExpect(status().isBadRequest());
+
+        verify(eventService, times(0)).save(any(), any(), any());
     }
 
     @Test
@@ -281,6 +273,25 @@ class EventControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
             .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @SneakyThrows
+    void saveV2BadRequestWithNotValidDescriptionTest() {
+        AddEventDtoRequest addEventDtoRequest = buildAddEventDto("String", " Example of description for testing");
+
+        String json = objectMapper.writeValueAsString(addEventDtoRequest);
+
+        MockMultipartFile jsonFile =
+            new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
+        mockMvc.perform(multipart("/events/createV2")
+                .file(jsonFile)
+                .principal(principal)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .andExpect(status().isBadRequest());
+
+        verify(eventService, times(0)).save(any(), any(), any());
     }
 
     @Test
@@ -709,11 +720,11 @@ class EventControllerTest {
     }
 
     @SneakyThrows
-    private AddEventDtoRequest getAddEventDtoRequestBadDescription() {
-        String json = """
+    private AddEventDtoRequest buildAddEventDto (String title, String description) {
+        String json = String.format("""
             {
-                "title":"string",
-                "description":" stringstringstringstringstringstringstringstring",
+                "title":"%s",
+                "description":"%s",
                 "open":true,
                 "datesLocations":[
                     {
@@ -727,7 +738,7 @@ class EventControllerTest {
                     }
                 ],
                 "tags":["Social"]
-            }""";
+            }""", title, description);
 
         return objectMapper.readValue(json, AddEventDtoRequest.class);
     }

--- a/core/src/test/java/greencity/controller/EventControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventControllerTest.java
@@ -1,6 +1,5 @@
 package greencity.controller;
 
-
 import static greencity.ModelUtils.getCreateJsonFile;
 import static greencity.ModelUtils.getEventDtoPageableAdvancedDto;
 import static greencity.ModelUtils.getPrincipal;

--- a/core/src/test/java/greencity/controller/EventControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventControllerTest.java
@@ -243,6 +243,26 @@ class EventControllerTest {
 
     @Test
     @SneakyThrows
+    void saveBadRequestWithNotValidTitleTest() {
+        AddEventDtoRequest addEventDtoRequest = buildAddEventDto(" Title", "description for testing title");
+
+        String json = objectMapper.writeValueAsString(addEventDtoRequest);
+
+        MockMultipartFile jsonFile =
+            new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
+
+        mockMvc.perform(multipart(EVENTS_CONTROLLER_LINK)
+                .file(jsonFile)
+                .principal(principal)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .andExpect(status().isBadRequest());
+
+        verify(eventService, times(0)).save(any(), any(), any());
+    }
+
+    @Test
+    @SneakyThrows
     void saveV2Test() {
         AddEventDtoRequest addEventDtoRequest = getAddEventDtoRequest();
 
@@ -289,6 +309,25 @@ class EventControllerTest {
             .principal(principal)
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .andExpect(status().isBadRequest());
+
+        verify(eventService, times(0)).save(any(), any(), any());
+    }
+
+    @Test
+    @SneakyThrows
+    void saveV2BadRequestWithNotValidTitleTest() {
+        AddEventDtoRequest addEventDtoRequest = buildAddEventDto(" Title V2", "description for testing Title V2");
+
+        String json = objectMapper.writeValueAsString(addEventDtoRequest);
+
+        MockMultipartFile jsonFile =
+            new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
+        mockMvc.perform(multipart("/events/createV2")
+                .file(jsonFile)
+                .principal(principal)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
             .andExpect(status().isBadRequest());
 
         verify(eventService, times(0)).save(any(), any(), any());

--- a/core/src/test/java/greencity/controller/EventControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventControllerTest.java
@@ -232,10 +232,10 @@ class EventControllerTest {
             new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
 
         mockMvc.perform(multipart(EVENTS_CONTROLLER_LINK)
-                .file(jsonFile)
-                .principal(principal)
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .file(jsonFile)
+            .principal(principal)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
             .andExpect(status().isBadRequest());
 
         verify(eventService, times(0)).save(any(), any(), any());
@@ -285,10 +285,10 @@ class EventControllerTest {
         MockMultipartFile jsonFile =
             new MockMultipartFile("addEventDtoRequest", "", "application/json", json.getBytes());
         mockMvc.perform(multipart("/events/createV2")
-                .file(jsonFile)
-                .principal(principal)
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .file(jsonFile)
+            .principal(principal)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
             .andExpect(status().isBadRequest());
 
         verify(eventService, times(0)).save(any(), any(), any());
@@ -720,7 +720,7 @@ class EventControllerTest {
     }
 
     @SneakyThrows
-    private AddEventDtoRequest buildAddEventDto (String title, String description) {
+    private AddEventDtoRequest buildAddEventDto(String title, String description) {
         String json = String.format("""
             {
                 "title":"%s",

--- a/core/src/test/java/greencity/controller/EventControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventControllerTest.java
@@ -1,12 +1,26 @@
 package greencity.controller;
 
-import static greencity.ModelUtils.*;
+
+import static greencity.ModelUtils.getCreateJsonFile;
+import static greencity.ModelUtils.getEventDtoPageableAdvancedDto;
+import static greencity.ModelUtils.getPrincipal;
+import static greencity.ModelUtils.getUserVO;
 import static greencity.TestConst.EVENT_ID;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -988,7 +1002,7 @@ class EventControllerTest {
     @Test
     @SneakyThrows
     void getAllUserAssignedReturnsPaginatedUserAssignedEventsForValidUserTest() {
-        UserVO userVO = ModelUtils.getUserVO();
+        UserVO userVO = getUserVO();
         when(userService.findByEmail(principal.getName())).thenReturn(userVO);
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/user-data/getAllUserAssigned")
             .principal(principal)
@@ -1003,7 +1017,7 @@ class EventControllerTest {
     @Test
     @SneakyThrows
     void getRelevantAddressesTest() {
-        UserVO userVO = ModelUtils.getUserVO();
+        UserVO userVO = getUserVO();
         when(userService.findByEmail(principal.getName())).thenReturn(userVO);
         mockMvc.perform(get(EVENTS_CONTROLLER_LINK + "/addresses/get-relevant")
             .principal(principal))

--- a/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
+++ b/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Pattern;
 import java.util.List;
 import lombok.*;
 
+
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
@@ -20,6 +21,11 @@ public class AddEventDtoRequest {
     @DecodedSize(min = 1, max = 70)
     private String title;
 
+    /**
+     * 10-63206 chars.
+     * No leading/trailing whitespace.
+     * No consecutive spaces.
+     */
     @Pattern(
         regexp = "^(?!.* {2,})(?!\\s)(?!.*\\s$).{10,63206}$",
         message = "Description must be between 10 and 63206 characters, must not be blank, "

--- a/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
+++ b/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
@@ -9,7 +9,6 @@ import jakarta.validation.constraints.Pattern;
 import java.util.List;
 import lombok.*;
 
-
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter

--- a/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
+++ b/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
@@ -24,7 +24,7 @@ public class AddEventDtoRequest {
      * 10-63206 chars. No leading/trailing whitespace. No consecutive spaces.
      */
     @Pattern(
-        regexp = "^(?!.* {2,})(?!\\s)(?!.*\\s$).{10,63206}$",
+        regexp = "^[^\\s][^\\s](?:[^ ]| (?! )){6,63202}[^\\s][^\\s]$",
         message = "Description must be between 10 and 63206 characters, must not be blank, "
             + "contain leading/trailing spaces, or consecutive spaces.")
     private String description;

--- a/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
+++ b/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
@@ -21,15 +21,12 @@ public class AddEventDtoRequest {
     private String title;
 
     /**
-     * 10-63206 chars.
-     * No leading/trailing whitespace.
-     * No consecutive spaces.
+     * 10-63206 chars. No leading/trailing whitespace. No consecutive spaces.
      */
     @Pattern(
         regexp = "^(?!.* {2,})(?!\\s)(?!.*\\s$).{10,63206}$",
         message = "Description must be between 10 and 63206 characters, must not be blank, "
-            + "contain leading/trailing spaces, or consecutive spaces."
-    )
+            + "contain leading/trailing spaces, or consecutive spaces.")
     private String description;
 
     @NotEmpty

--- a/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
+++ b/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
@@ -4,16 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import greencity.annotations.DecodedSize;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.Builder;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Pattern;
 import java.util.List;
+import lombok.*;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -26,12 +20,11 @@ public class AddEventDtoRequest {
     @DecodedSize(min = 1, max = 70)
     private String title;
 
-    @NotBlank
-    @Size(min = 10, max = 63206)
     @Pattern(
-        regexp = "^(?!\\S*\\s{2,})\\S.{8,}\\S$",
-        message = "Description must be at least 10 characters long (excluding leading / trailing spaces) "
-            + "and must not contain consecutive spaces.")
+        regexp = "^(?!.* {2,})(?!\\s)(?!.*\\s$).{10,63206}$",
+        message = "Description must be between 10 and 63206 characters, must not be blank, "
+            + "contain leading/trailing spaces, or consecutive spaces."
+    )
     private String description;
 
     @NotEmpty

--- a/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
+++ b/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
@@ -1,9 +1,7 @@
 package greencity.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import greencity.annotations.DecodedSize;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import java.util.List;
@@ -16,8 +14,13 @@ import lombok.*;
 @Builder
 @EqualsAndHashCode
 public class AddEventDtoRequest {
-    @NotBlank
-    @DecodedSize(min = 1, max = 70)
+    /**
+     * 1-70 chars. No leading/trailing whitespace. No consecutive spaces.
+     */
+    @Pattern(
+        regexp = "^[^\\s](?:[^ ]| (?! )){0,68}[^\\s]?$",
+        message = "Title must be between 1 and 70 characters, must not be blank, "
+            + "contain leading/trailing spaces, or consecutive spaces.")
     private String title;
 
     /**

--- a/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
+++ b/service-api/src/main/java/greencity/dto/event/AddEventDtoRequest.java
@@ -5,7 +5,12 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import java.util.List;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @NoArgsConstructor
 @AllArgsConstructor


### PR DESCRIPTION
changed validation to send only one message #7819 
changed validation for title: enforce no leading/trailing spaces and no consecutive spaces, length 1-70 chars #8585 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced event title and description validation to disallow leading/trailing spaces, consecutive spaces, and enforce length requirements.  
- **Tests**
  - Added tests to ensure event creation requests with invalid titles and descriptions are properly rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->