### PR TITLE
Fix not working AddEcoNews and Delete buttons in eco news page

### DIFF
--- a/core/src/main/resources/templates/core/management_eco_news.html
+++ b/core/src/main/resources/templates/core/management_eco_news.html
@@ -329,14 +329,14 @@
                                     <td style = "width: 173px">
                                         <div th:switch="${#locale.language}">
                                             <div th:case="en">
-                                                <div th:switch="${econew.tags.isEmpty()}">
+                                                <div th:switch="${econew.tagsEn.isEmpty()}">
                                                     <div th:case="false">
                                                         <div class="dropdown role" style="position: inherit">
-                                                            <button class="dropbtn role" th:text="${econew.tags.get(0)}">
+                                                            <button class="dropbtn role" th:text="${econew.tagsEn.get(0)}">
                                                             </button>
                                                             <img class="rotate" src="/img/arrow-down.svg" alt="arrow-icon">
                                                             <div class="dropdown-content role" style="width:173px; height: auto;">
-                                                                <a th:each="tag, iterStatus :${econew.tags.subList(1, econew.tags.size())}" th:text="${tag}"></a>
+                                                                <a th:each="tag, iterStatus :${econew.tagsEn.subList(1, econew.tagsEn.size())}" th:text="${tag}"></a>
                                                             </div>
                                                         </div>
                                                     </div>
@@ -346,14 +346,14 @@
                                                 </div>
                                             </div>
                                             <div th:case="ua">
-                                                <div th:switch="${econew.tagsUa.isEmpty()}">
+                                                <div th:switch="${econew.tagsUk.isEmpty()}">
                                                     <div th:case="false">
                                                         <div class="dropdown role" style="position: inherit">
-                                                            <button class="dropbtn role" th:text="${econew.tagsUa.get(0)}">
+                                                            <button class="dropbtn role" th:text="${econew.tagsUk.get(0)}">
                                                             </button>
                                                             <img class="rotate" src="/img/arrow-down.svg" alt="arrow-icon">
                                                             <div class="dropdown-content role" style="width:173px; height: auto;">
-                                                                <a th:each="tag, iterStatus :${econew.tagsUa.subList(1, econew.tagsUa.size())}" th:text="${tag}"></a>
+                                                                <a th:each="tag, iterStatus :${econew.tagsUk.subList(1, econew.tagsUk.size())}" th:text="${tag}"></a>
                                                             </div>
                                                         </div>
                                                     </div>

--- a/core/src/main/resources/templates/core/management_eco_news.html
+++ b/core/src/main/resources/templates/core/management_eco_news.html
@@ -345,7 +345,7 @@
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div th:case="ua">
+                                            <div th:case="uk">
                                                 <div th:switch="${econew.tagsUk.isEmpty()}">
                                                     <div th:case="false">
                                                         <div class="dropdown role" style="position: inherit">


### PR DESCRIPTION
This PR updates the `management_eco_news.html` template to use consistent naming for tag variables based on language. The changes ensure that the English and Ukrainian tags are accessed through appropriately named variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the display of eco-news tags in the management table to show the correct tags based on the selected language (English or Ukrainian).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->