### PR TITLE
Fix/#8017/greencity api incorrect 404 not found response in swagger documentation for greencity api endpoints

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -459,7 +459,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.DELETE,
                     COMMENTS)
                 .hasAnyRole(ADMIN)
-                .anyRequest().hasAnyRole(ADMIN))
+                .anyRequest().permitAll())
             .logout(logout -> logout.logoutUrl("/logout")
                 .logoutRequestMatcher(new AntPathRequestMatcher("/management/logout", HttpMethod.GET.name()))
                 .clearAuthentication(true)

--- a/core/src/main/java/greencity/controller/AIController.java
+++ b/core/src/main/java/greencity/controller/AIController.java
@@ -33,9 +33,7 @@ public class AIController {
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST,
             content = @Content(examples = @ExampleObject(HttpStatuses.BAD_REQUEST))),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED,
-            content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED))),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND,
-            content = @Content(examples = @ExampleObject(HttpStatuses.NOT_FOUND)))
+            content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED)))
     })
     @ApiLocale
     @GetMapping("/forecast")
@@ -51,9 +49,7 @@ public class AIController {
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST,
             content = @Content(examples = @ExampleObject(HttpStatuses.BAD_REQUEST))),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED,
-            content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED))),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND,
-            content = @Content(examples = @ExampleObject(HttpStatuses.NOT_FOUND)))
+            content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED)))
     })
     @ApiLocale
     @GetMapping("/generate/eco-news")

--- a/core/src/main/java/greencity/controller/AchievementController.java
+++ b/core/src/main/java/greencity/controller/AchievementController.java
@@ -40,9 +40,7 @@ public class AchievementController {
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST,
             content = @Content(examples = @ExampleObject(HttpStatuses.BAD_REQUEST))),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED,
-            content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED))),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND,
-            content = @Content(examples = @ExampleObject(HttpStatuses.NOT_FOUND)))
+            content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED)))
     })
     @GetMapping
     public ResponseEntity<List<AchievementVO>> getAll(@Parameter(hidden = true) Principal principal,
@@ -75,9 +73,7 @@ public class AchievementController {
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST,
             content = @Content(examples = @ExampleObject(HttpStatuses.BAD_REQUEST))),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED,
-            content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED))),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND,
-            content = @Content(examples = @ExampleObject(HttpStatuses.NOT_FOUND)))
+            content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED)))
     })
     @GetMapping("/count")
     public ResponseEntity<Integer> getAchievementCount(@Parameter(hidden = true) Principal principal,

--- a/core/src/main/java/greencity/controller/CategoryController.java
+++ b/core/src/main/java/greencity/controller/CategoryController.java
@@ -54,9 +54,7 @@ public class CategoryController {
      */
     @Operation(summary = "View a list of available categories")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Successfully retrieved list"),
-        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN,
-            content = @Content(examples = @ExampleObject(HttpStatuses.FORBIDDEN))),
+        @ApiResponse(responseCode = "200", description = "Successfully retrieved list")
     })
     @GetMapping
     public ResponseEntity<List<CategoryDto>> findAllCategory() {

--- a/core/src/main/java/greencity/controller/CustomToDoListItemController.java
+++ b/core/src/main/java/greencity/controller/CustomToDoListItemController.java
@@ -47,6 +47,8 @@ public class CustomToDoListItemController {
             content = @Content(examples = @ExampleObject(HttpStatuses.BAD_REQUEST))),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED,
             content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED))),
+        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN,
+            content = @Content(examples = @ExampleObject(HttpStatuses.FORBIDDEN))),
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND,
             content = @Content(examples = @ExampleObject(HttpStatuses.NOT_FOUND)))
     })
@@ -72,6 +74,8 @@ public class CustomToDoListItemController {
             content = @Content(examples = @ExampleObject(HttpStatuses.BAD_REQUEST))),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED,
             content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED))),
+        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN,
+            content = @Content(examples = @ExampleObject(HttpStatuses.FORBIDDEN))),
     })
     @PostMapping("/{userId}/{habitAssignId}/custom-to-do-list-items")
     public ResponseEntity<List<CustomToDoListItemResponseDto>> saveUserCustomToDoListItems(
@@ -99,6 +103,8 @@ public class CustomToDoListItemController {
             content = @Content(examples = @ExampleObject(HttpStatuses.BAD_REQUEST))),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED,
             content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED))),
+        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN,
+            content = @Content(examples = @ExampleObject(HttpStatuses.FORBIDDEN))),
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND,
             content = @Content(examples = @ExampleObject(HttpStatuses.NOT_FOUND)))
     })
@@ -123,7 +129,9 @@ public class CustomToDoListItemController {
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST,
             content = @Content(examples = @ExampleObject(HttpStatuses.BAD_REQUEST))),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED,
-            content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED)))
+            content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED))),
+        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN,
+            content = @Content(examples = @ExampleObject(HttpStatuses.FORBIDDEN))),
     })
     @PatchMapping("/{userId}/done")
     public void updateItemStatusToDone(@PathVariable @CurrentUserId Long userId,
@@ -145,6 +153,8 @@ public class CustomToDoListItemController {
             content = @Content(examples = @ExampleObject(HttpStatuses.BAD_REQUEST))),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED,
             content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED))),
+        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN,
+            content = @Content(examples = @ExampleObject(HttpStatuses.FORBIDDEN))),
     })
     @DeleteMapping("/{userId}/custom-to-do-list-items")
     public ResponseEntity<List<Long>> bulkDeleteCustomToDoListItems(

--- a/core/src/main/java/greencity/controller/DataBaseBackUpController.java
+++ b/core/src/main/java/greencity/controller/DataBaseBackUpController.java
@@ -39,9 +39,7 @@ public class DataBaseBackUpController {
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST,
             content = @Content(examples = @ExampleObject(HttpStatuses.BAD_REQUEST))),
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN,
-            content = @Content(examples = @ExampleObject(HttpStatuses.FORBIDDEN))),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND,
-            content = @Content(examples = @ExampleObject(HttpStatuses.NOT_FOUND)))
+            content = @Content(examples = @ExampleObject(HttpStatuses.FORBIDDEN)))
     })
     @GetMapping("/backup")
     public ResponseEntity<String> backupDatabase() {
@@ -63,9 +61,7 @@ public class DataBaseBackUpController {
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST,
             content = @Content(examples = @ExampleObject(HttpStatuses.BAD_REQUEST))),
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN,
-            content = @Content(examples = @ExampleObject(HttpStatuses.FORBIDDEN))),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND,
-            content = @Content(examples = @ExampleObject(HttpStatuses.NOT_FOUND)))
+            content = @Content(examples = @ExampleObject(HttpStatuses.FORBIDDEN)))
     })
     @GetMapping("/backupFiles")
     public ResponseEntity<List<String>> getBackupFiles(

--- a/core/src/main/java/greencity/controller/ToDoListItemController.java
+++ b/core/src/main/java/greencity/controller/ToDoListItemController.java
@@ -229,6 +229,8 @@ public class ToDoListItemController {
             content = @Content(examples = @ExampleObject(HttpStatuses.BAD_REQUEST))),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED,
             content = @Content(examples = @ExampleObject(HttpStatuses.UNAUTHORIZED))),
+        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN,
+            content = @Content(examples = @ExampleObject(HttpStatuses.FORBIDDEN)))
     })
     @GetMapping("/{userId}/get-all-inprogress")
     public ResponseEntity<List<ToDoListItemDto>> findInProgressByUserId(

--- a/service/src/main/java/greencity/service/FactOfTheDayServiceImpl.java
+++ b/service/src/main/java/greencity/service/FactOfTheDayServiceImpl.java
@@ -204,7 +204,11 @@ public class FactOfTheDayServiceImpl implements FactOfTheDayService {
     @Override
     public FactOfTheDayTranslationDTO getRandomFactOfTheDayForUser(String userEmail) {
         Set<Long> userTagIds = tagsRepo.findTagsIdByUserHabitsInProgress(userEmail);
-        return getRandomFactOfTheDayByTags(userTagIds);
+        try {
+            return getRandomFactOfTheDayByTags(userTagIds);
+        } catch (NotFoundException e) {
+            return null;
+        }
     }
 
     /**

--- a/service/src/main/java/greencity/service/FactOfTheDayServiceImpl.java
+++ b/service/src/main/java/greencity/service/FactOfTheDayServiceImpl.java
@@ -204,11 +204,7 @@ public class FactOfTheDayServiceImpl implements FactOfTheDayService {
     @Override
     public FactOfTheDayTranslationDTO getRandomFactOfTheDayForUser(String userEmail) {
         Set<Long> userTagIds = tagsRepo.findTagsIdByUserHabitsInProgress(userEmail);
-        try {
-            return getRandomFactOfTheDayByTags(userTagIds);
-        } catch (NotFoundException e) {
-            return null;
-        }
+        return getRandomFactOfTheDayByTags(userTagIds);
     }
 
     /**


### PR DESCRIPTION
### 🔗 **Issue:** [#8017](https://github.com/ita-social-projects/GreenCity/issues/8017)

This pull request makes several adjustments to security configurations and API response annotations across multiple controllers. Key changes include modifying access permissions in the security filter chain, removing or adding specific API response codes, and simplifying exception handling in the `FactOfTheDayServiceImpl`.

### Security Configuration Updates:
* [`core/src/main/java/greencity/config/SecurityConfig.java`](diffhunk://#diff-f153504e909a9c7019db4c607f1eda06f185ea43f04fbc8086c7ca2364fe2516L462-R462): Changed `.anyRequest()` access from `hasAnyRole(ADMIN)` to `permitAll` to allow unrestricted access to all endpoints.

### API Response Annotation Adjustments:
* [`core/src/main/java/greencity/controller/AIController.java`](diffhunk://#diff-7ad44976da428d11757a56ff9da442262185f3feb626e027030899e80a9d46b6L36-R36): Removed the `404 NOT_FOUND` response annotation from multiple endpoints, simplifying the API response definitions. [[1]](diffhunk://#diff-7ad44976da428d11757a56ff9da442262185f3feb626e027030899e80a9d46b6L36-R36) [[2]](diffhunk://#diff-7ad44976da428d11757a56ff9da442262185f3feb626e027030899e80a9d46b6L54-R52)
* [`core/src/main/java/greencity/controller/AchievementController.java`](diffhunk://#diff-3fdf51c0eef35d70bfae47657058d94277ebed7349033cf75729434dec496449L43-R43): Similar removal of `404 NOT_FOUND` response annotations for endpoints in the AchievementController. [[1]](diffhunk://#diff-3fdf51c0eef35d70bfae47657058d94277ebed7349033cf75729434dec496449L43-R43) [[2]](diffhunk://#diff-3fdf51c0eef35d70bfae47657058d94277ebed7349033cf75729434dec496449L78-R76)
* [`core/src/main/java/greencity/controller/CustomToDoListItemController.java`](diffhunk://#diff-8c7e9051802c4d073e3344b9287d156b72adc62d246fbbb492a007b34a72c135R50-R51): Added `403 FORBIDDEN` response annotations to endpoints for more comprehensive error handling. [[1]](diffhunk://#diff-8c7e9051802c4d073e3344b9287d156b72adc62d246fbbb492a007b34a72c135R50-R51) [[2]](diffhunk://#diff-8c7e9051802c4d073e3344b9287d156b72adc62d246fbbb492a007b34a72c135R77-R78) [[3]](diffhunk://#diff-8c7e9051802c4d073e3344b9287d156b72adc62d246fbbb492a007b34a72c135R106-R107) [[4]](diffhunk://#diff-8c7e9051802c4d073e3344b9287d156b72adc62d246fbbb492a007b34a72c135L126-R134) [[5]](diffhunk://#diff-8c7e9051802c4d073e3344b9287d156b72adc62d246fbbb492a007b34a72c135R156-R157)
* [`core/src/main/java/greencity/controller/DataBaseBackUpController.java`](diffhunk://#diff-784a53b7912ad1b6daeae668cbd864b79174bc9002ee7c490c0a894c7d1a0cf0L42-R42): Removed the `404 NOT_FOUND` response annotation from database backup-related endpoints. [[1]](diffhunk://#diff-784a53b7912ad1b6daeae668cbd864b79174bc9002ee7c490c0a894c7d1a0cf0L42-R42) [[2]](diffhunk://#diff-784a53b7912ad1b6daeae668cbd864b79174bc9002ee7c490c0a894c7d1a0cf0L66-R64)
* [`core/src/main/java/greencity/controller/ToDoListItemController.java`](diffhunk://#diff-e3ac465aebb3ab1251cd0bb9b37df121a95a03ec488ced4995fe7a1d9d1dcc56R232-R233): Added `403 FORBIDDEN` response annotation for the `bulkDeleteUserToDoListItems` endpoint.

✅ **This pull request closes** [#8017](https://github.com/ita-social-projects/GreenCity/issues/8017) **once merged.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation for several controllers by adding or removing response codes (such as 403 Forbidden and 404 Not Found) to better reflect the actual responses of endpoints.
- **Refactor**
  - Modified security settings to allow all users access to unspecified endpoints, making access less restrictive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->