### PR TITLE
Remove habit_status table as it's no longer used

### DIFF
--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -264,5 +264,6 @@
     <include file="db/changelog/logs/ch-insert-into-empolyee-authority-Haliara.xml"/>
     <include file="db/changelog/logs/ch-update-column-names-Bulhakova.xml"/>
     <include file="db/changelog/logs/ch-update-column-names-positions-Bulhakova.xml"/>
+    <include file="db/changelog/logs/ch-drop-table-habit-status-Popovych.xml"/>
 
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-drop-table-habit-status-Popovych.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-drop-table-habit-status-Popovych.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="dropHabitStatus" author="Oleh Popovych">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="habit_status"/>
+        </preConditions>
+        <dropTable tableName="habit_status"
+                   catalogName="greencity"
+                   schemaName="public"/>
+    </changeSet>
+</databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-drop-table-habit-status-Popovych.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-drop-table-habit-status-Popovych.xml
@@ -8,8 +8,6 @@
         <preConditions onFail="MARK_RAN">
             <tableExists tableName="habit_status"/>
         </preConditions>
-        <dropTable tableName="habit_status"
-                   catalogName="greencity"
-                   schemaName="public"/>
+        <dropTable tableName="habit_status"/>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
### 🔗 **Issue:** [#8733](https://github.com/ita-social-projects/GreenCity/issues/8733)

This pull request updates the database changelog to include a new change set for dropping the `habit_status` table. The most important changes involve adding the new change set file and referencing it in the master changelog file.

Database changelog updates:

* [`dao/src/main/resources/db/changelog/db.changelog-master.xml`](diffhunk://#diff-2edf6df70011167bdc9fcd2ff92f195d0bf196afad2d2cec500687ddc9d23585R267): Added a reference to the new change set file `ch-drop-table-habit-status-Popovych.xml`.
* [`dao/src/main/resources/db/changelog/logs/ch-drop-table-habit-status-Popovych.xml`](diffhunk://#diff-fa6d0248ea99e513524bba4f9d415ff37fbcbbaf63b20e3c8d193d958b7359fdR1-R15): Created a new change set to drop the `habit_status` table, including preconditions to ensure the table exists before attempting the drop.

✅ **This pull request closes** [#8733](https://github.com/ita-social-projects/GreenCity/issues/8733) **once merged.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated database changelog to include a new change for dropping the "habit_status" table if it exists. This helps ensure the database schema remains up to date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->