### PR TITLE
Bugfix #8738 Fixed email notifications for likes

### DIFF
--- a/service/src/main/java/greencity/service/EcoNewsServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsServiceImpl.java
@@ -801,12 +801,13 @@ public class EcoNewsServiceImpl implements EcoNewsService {
         boolean isLiked = ecoNews.getUsersLikedNews().stream()
             .noneMatch(u -> u.getId().equals(userVO.getId()));
 
+        sendNotification(ecoNews, userVO, isLiked);
+
         ecoNews.getUsersLikedNews().add(modelMapper.map(userVO, User.class));
         achievementCalculation.calculateAchievement(userVO,
             AchievementCategoryType.LIKE_NEWS, AchievementAction.ASSIGN);
         ratingCalculation.ratingCalculation(ratingPointsRepo.findByNameOrThrow("LIKE_NEWS"), userVO);
 
-        sendNotification(ecoNews, userVO, isLiked);
         return modelMapper.map(ecoNews, EcoNewsDto.class);
     }
 

--- a/service/src/main/java/greencity/service/EcoNewsServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsServiceImpl.java
@@ -798,13 +798,13 @@ public class EcoNewsServiceImpl implements EcoNewsService {
 
         removeDislikeIfExists(ecoNews, userVO);
 
+        boolean isLiked = ecoNews.getUsersLikedNews().stream()
+            .noneMatch(u -> u.getId().equals(userVO.getId()));
+
         ecoNews.getUsersLikedNews().add(modelMapper.map(userVO, User.class));
         achievementCalculation.calculateAchievement(userVO,
             AchievementCategoryType.LIKE_NEWS, AchievementAction.ASSIGN);
         ratingCalculation.ratingCalculation(ratingPointsRepo.findByNameOrThrow("LIKE_NEWS"), userVO);
-
-        boolean isLiked = ecoNews.getUsersLikedNews().stream()
-            .noneMatch(u -> u.getId().equals(userVO.getId()));
 
         sendNotification(ecoNews, userVO, isLiked);
         return modelMapper.map(ecoNews, EcoNewsDto.class);

--- a/service/src/main/java/greencity/service/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/NotificationServiceImpl.java
@@ -104,6 +104,8 @@ public class NotificationServiceImpl implements NotificationService {
         sendScheduledNotifications(NotificationType.ECONEWS_LIKE, EmailPreference.LIKES, now);
         log.info(LogMessage.IN_SEND_SCHEDULED_EMAIL, now, NotificationType.EVENT_COMMENT_LIKE);
         sendScheduledNotifications(NotificationType.EVENT_COMMENT_LIKE, EmailPreference.LIKES, now);
+        log.info(LogMessage.IN_SEND_SCHEDULED_EMAIL, now, NotificationType.EVENT_LIKE);
+        sendScheduledNotifications(NotificationType.EVENT_LIKE, EmailPreference.LIKES, now);
         log.info(LogMessage.IN_SEND_SCHEDULED_EMAIL, now, NotificationType.HABIT_LIKE);
         sendScheduledNotifications(NotificationType.HABIT_LIKE, EmailPreference.LIKES, now);
         log.info(LogMessage.IN_SEND_SCHEDULED_EMAIL, now, NotificationType.HABIT_COMMENT_LIKE);
@@ -254,6 +256,7 @@ public class NotificationServiceImpl implements NotificationService {
             NotificationType.ECONEWS_COMMENT_LIKE,
             NotificationType.ECONEWS_LIKE,
             NotificationType.EVENT_COMMENT_LIKE,
+            NotificationType.EVENT_LIKE,
             NotificationType.HABIT_LIKE,
             NotificationType.HABIT_COMMENT_LIKE);
         List<NotificationType> comments = List.of(

--- a/service/src/test/java/greencity/service/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/NotificationServiceImplTest.java
@@ -382,6 +382,9 @@ class NotificationServiceImplTest {
                 .findAllByNotificationByTypeAndViewedIsFalseAndEmailSentIsFalse(NotificationType.EVENT_COMMENT_LIKE))
                 .thenReturn(Collections.singletonList(notification));
             when(notificationRepo
+                .findAllByNotificationByTypeAndViewedIsFalseAndEmailSentIsFalse(NotificationType.EVENT_LIKE))
+                .thenReturn(Collections.singletonList(notification));
+            when(notificationRepo
                 .findAllByNotificationByTypeAndViewedIsFalseAndEmailSentIsFalse(NotificationType.HABIT_LIKE))
                 .thenReturn(Collections.singletonList(notification));
             when(notificationRepo
@@ -399,7 +402,7 @@ class NotificationServiceImplTest {
             notificationService.sendLikeScheduledEmail();
             ArgumentCaptor<ScheduledEmailMessage> captor = ArgumentCaptor.forClass(ScheduledEmailMessage.class);
             await().atMost(5, SECONDS)
-                .untilAsserted(() -> verify(restClient, times(5)).sendScheduledEmailNotification(captor.capture()));
+                .untilAsserted(() -> verify(restClient, times(6)).sendScheduledEmailNotification(captor.capture()));
             List<ScheduledEmailMessage> capturedMessages = captor.getAllValues();
             for (ScheduledEmailMessage capturedMessage : capturedMessages) {
                 assertEquals(notification.getTargetUser().getEmail(), capturedMessage.getEmail());


### PR DESCRIPTION
# GreenCity PR
[#8738](https://github.com/ita-social-projects/GreenCity/issues/8738)

## Summary Of Changes :fire:
Email notifications for likes are now being sent as intended.

## Added
* Added missing functionality for `EVENT_LIKE` notifications.

## Changed
* Fixed logical order of like notification creation in `EcoNewsServiceImpl`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for sending email notifications for the "like" event type.

* **Tests**
  * Updated tests to cover email notifications for the new "like" event type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->