### PR TITLE
Fix locale issues on management eco news page

### DIFF
--- a/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
+++ b/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
@@ -41,7 +41,6 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.web.error.ErrorAttributeOptions;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
-import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -108,7 +107,7 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
             httpClientResponseBody = objectMapper.readValue(ex.getResponseBodyAsString(),
                 new TypeReference<List<Map<String, String>>>() {
                 })
-                .get(0);
+                .getFirst();
         } else {
             httpClientResponseBody = objectMapper.readValue(ex.getResponseBodyAsString(), new TypeReference<>() {
             });
@@ -652,24 +651,5 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
         exceptionResponse.setMessage(ex.getMessage());
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(exceptionResponse);
-    }
-
-    /**
-     * Method intercepts exception {@link PropertyReferenceException}. Thrown when
-     * an invalid property is used in the sort parameter for a Pageable request.
-     *
-     * @param ex      Exception that should be intercepted.
-     * @param request Contains details about the occurred exception.
-     * @return {@code ResponseEntity} which contains the HTTP status and body with
-     *         the exception message.
-     */
-    @ExceptionHandler(PropertyReferenceException.class)
-    public final ResponseEntity<Object> handlePropertyReferenceException(PropertyReferenceException ex,
-        WebRequest request) {
-        log.error(ex.getMessage(), ex);
-        ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
-        exceptionResponse.setMessage(String.format(ErrorMessage.INVALID_SORT_VALUE_EXCEPTION, ex.getPropertyName()));
-
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionResponse);
     }
 }

--- a/core/src/main/java/greencity/webcontroller/ManagementEcoNewsController.java
+++ b/core/src/main/java/greencity/webcontroller/ManagementEcoNewsController.java
@@ -131,7 +131,7 @@ public class ManagementEcoNewsController {
      * @param id of {@link EcoNewsVO}.
      * @return {@link EcoNewsDto}.
      */
-    @Operation(summary = "Find econews by id.")
+    @Operation(summary = "Find eco-news by id.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK,
             content = @Content(schema = @Schema(implementation = EcoNewsDto.class))),
@@ -152,7 +152,7 @@ public class ManagementEcoNewsController {
      * @param id of {@link EcoNewsVO}.
      * @return {@link EcoNewsDto}.
      */
-    @Operation(summary = "Find econew's page by id.")
+    @Operation(summary = "Find eco-new's page by id.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK,
             content = @Content(schema = @Schema(implementation = EcoNewsDto.class))),
@@ -163,9 +163,9 @@ public class ManagementEcoNewsController {
     @GetMapping("/{id}")
     public String getEcoNewsPage(@PathVariable("id") Long id,
         @Parameter(hidden = true) Locale locale, Model model) {
-        EcoNewsDto econew = ecoNewsService.findDtoByIdAndLanguage(id, locale.getLanguage());
-        model.addAttribute("econew", econew);
-        ZonedDateTime time = econew.getCreationDate();
+        EcoNewsDto ecoNews = ecoNewsService.findDtoByIdAndLanguage(id, locale.getLanguage());
+        model.addAttribute("ecoNews", ecoNews);
+        ZonedDateTime time = ecoNews.getCreationDate();
         DateTimeFormatter format = DateTimeFormatter.ofPattern("MMM dd , yyyy");
         model.addAttribute("time", time.format(format));
         model.addAttribute("ecoNewsTag", tagsService.findAllEcoNewsTags("en"));
@@ -173,7 +173,7 @@ public class ManagementEcoNewsController {
     }
 
     /**
-     * Method for getting all econews tag.
+     * Method for getting all eco-news tag.
      *
      * @return {@link TagDto} instance.
      */
@@ -214,7 +214,7 @@ public class ManagementEcoNewsController {
      * @param file                 of {@link MultipartFile}.
      * @return {@link GenericResponseDto} with of operation and errors fields.
      */
-    @Operation(summary = "Update Econews.")
+    @Operation(summary = "Update Eco-news.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN)

--- a/core/src/main/java/greencity/webcontroller/ManagementHabitController.java
+++ b/core/src/main/java/greencity/webcontroller/ManagementHabitController.java
@@ -108,7 +108,7 @@ public class ManagementHabitController {
     @GetMapping("/{id}")
     public String getHabitPage(@PathVariable("id") Long id,
         @Parameter(hidden = true) Model model) {
-        model.addAttribute("htodos", toDoListItemService.getToDoListByHabitId(id));
+        model.addAttribute("todos", toDoListItemService.getToDoListByHabitId(id));
         model.addAttribute("habit", managementHabitService.getById(id));
         model.addAttribute("acquired",
             habitAssignService.getNumberHabitAssignsByHabitIdAndStatus(id, HabitAssignStatus.ACQUIRED));

--- a/core/src/main/resources/templates/core/management_eco_new.html
+++ b/core/src/main/resources/templates/core/management_eco_new.html
@@ -47,36 +47,42 @@
                     </a>
                 </div>
                 <div class="button-edit" style="display: flex; gap: 5px">
-                    <div class="button-text id">№[[${econew.id}]]</div>
+                    <div class="button-text id">№[[${ecoNews.id}]]</div>
                     <a href="#editEcoNewsModal" editEcoNewsForm id="editEcoNewsModalBtn"
                        data-toggle="modal" th:onclick="editBtnDisabled()">
                         <img src="/img/habit_advices_dark.png">
                     </a>
-                    <div th:if="${econew.hidden eq false}">
-                        <a class="edit eHideBtn" style="color: #FF9310" th:href="@{/management/eco-news/hide(id=${econew.id})}"><i
+                    <div th:if="${ecoNews.hidden eq false}">
+                        <a class="edit eHideBtn" style="color: #FF9310" th:href="@{/management/eco-news/hide(id=${ecoNews.id})}"><i
                                 class="material-icons" data-toggle="tooltip" th:title="#{greenCity.pages.hide}">&#xE8F5;</i></a>
                     </div>
-                    <div th:if="${econew.hidden eq true}">
-                        <a class="edit eShowBtn" style="color: #FF9310" th:href="@{/management/eco-news/show(id=${econew.id})}"><i
+                    <div th:if="${ecoNews.hidden eq true}">
+                        <a class="edit eShowBtn" style="color: #FF9310" th:href="@{/management/eco-news/show(id=${ecoNews.id})}"><i
                                 class="material-icons" data-toggle="tooltip" th:title="#{greenCity.pages.show}">&#xE8F4;</i></a>
                     </div>
                     <a class="delete eDelBtn" style="color: #E02116" data-toggle="modal"
-                       th:href="@{/management/eco-news/delete(id=${econew.id})}"><i class="material-icons"
+                       th:href="@{/management/eco-news/delete(id=${ecoNews.id})}"><i class="material-icons"
                                                                                     data-toggle="tooltip"
                                                                                     th:title="#{greenCity.pages.delete}">&#xE872;</i></a>
                 </div>
             </div>
-            <div style="margin-top: 20px" th:if="${econew.hidden eq true}">
+            <div style="margin-top: 20px" th:if="${ecoNews.hidden eq true}">
                 <h4 style="color: #B21D15; text-align: center">[[#{greenCity.pages.popup.hidden.EcoNews}]]</h4>
             </div>
             <div class="tags">
-                <div class="tags-item ng-star-inserted" th:each="tag, iterStatus :${econew.tags}"
-                     th:text="${tag}"></div>
+                <th:block th:if="${#locale.language == 'en'}">
+                    <div class="tags-item ng-star-inserted" th:each="tag : ${ecoNews.tagsEn}"
+                         th:text="${tag}"></div>
+                </th:block>
+                <th:block th:if="${#locale.language == 'uk'}">
+                    <div class="tags-item ng-star-inserted" th:each="tag : ${ecoNews.tagsUk}"
+                         th:text="${tag}"></div>
+                </th:block>
             </div>
             <div class="news-content">
                 <div class="news-title-container">
                     <div class="news-title word-wrap">
-                        <p>[[${econew.title}]]</p>
+                        <p>[[${ecoNews.title}]]</p>
                     </div>
                 </div>
                 <div class="news-info">
@@ -84,16 +90,16 @@
                     <div class="news-info-dot">
                         <img alt="dot" src="/img/ellipse.svg">
                     </div>
-                    <div class="news-info-author">[[${econew.author.getName()}]]</div>
+                    <div class="news-info-author">[[${ecoNews.author.getName()}]]</div>
                     <div class="like_wr">
                         <img alt="like" class="news_like ng-star-inserted" src="/img/like.png">
-                        <span class="numerosity_likes">[[${econew.likes}]]</span>
+                        <span class="numerosity_likes">[[${ecoNews.likes}]]</span>
                     </div>
                 </div>
-                <div th:if="${econew.imagePath ne null}">
-                    <img alt="news-image" class="news-image-img" th:src="${econew.imagePath}">
+                <div th:if="${ecoNews.imagePath ne null}">
+                    <img alt="news-image" class="news-image-img" th:src="${ecoNews.imagePath}">
                 </div>
-                <div th:if="${econew.imagePath eq null}">
+                <div th:if="${ecoNews.imagePath eq null}">
                     <img alt="news-image" class="news-image-img" src="/img/eco-news-default-large.png">
                 </div>
                 <div class="news-text-container">
@@ -105,7 +111,7 @@
                     <div class="news-text">
                         <div class="news-text-content word-wrap ql-snow">
                             <div class="ql-editor">
-                                <p>[[${econew.content}]]</p>
+                                <p>[[${ecoNews.content}]]</p>
                             </div>
                         </div>
                     </div>
@@ -116,7 +122,7 @@
             <div class="counter ng-star-inserted">
                 <div class="wrapper">
                     <p>[[#{greenCity.econews.page.comments}]]</p>
-                    <p> [[${econew.countComments}]] <span
+                    <p> [[${ecoNews.countComments}]] <span
                             class="ng-star-inserted">[[#{greenCity.econews.page.comment}]] </span></p>
                 </div>
                 <hr>
@@ -135,18 +141,18 @@
                         <div class="modal-body">
                             <div class="form-group">
                                 <label for="id">[[#{greenCity.pages.table.id}]]</label>
-                                <input type="text" class="form-control" id="id" name="id" th:value="${econew.id}"
+                                <input type="text" class="form-control" id="id" name="id" th:value="${ecoNews.id}"
                                        readonly required>
                                 <span th:id="errorModalUpdateid" class="errorSpan"></span>
                             </div>
                             <div class="form-group">
                                 <label for="title">[[#{greenCity.pages.table.title}]]</label>
-                                <textarea type="text" class="form-control" id="title" name="title" required>[[${econew.title}]]</textarea>
+                                <textarea type="text" class="form-control" id="title" name="title" required>[[${ecoNews.title}]]</textarea>
                                 <span th:id="errorModalUpdatetitle" class="errorSpan"></span>
                             </div>
                             <div class="form-group">
                                 <label for="text">[[#{greenCity.pages.table.text}]]</label>
-                                <textarea type="text" class="form-control" id="text" name="text" required>[[${econew.content}]]</textarea>
+                                <textarea type="text" class="form-control" id="text" name="text" required>[[${ecoNews.content}]]</textarea>
                                 <span th:id="errorModalUpdatetext" class="errorSpan"></span>
                             </div>
                             <div class="form-group">
@@ -168,7 +174,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="source">[[#{greenCity.pages.table.source}]]</label>
-                                <textarea type="text" class="form-control" id="source" name="source">[[${econew.shortInfo}]]</textarea>
+                                <textarea type="text" class="form-control" id="source" name="source">[[${ecoNews.shortInfo}]]</textarea>
                                 <span th:id="errorModalUpdatesource" class="errorSpan"></span>
                             </div>
                             <div class="form-group" style="justify-content: center">

--- a/core/src/main/resources/templates/core/management_user_habit.html
+++ b/core/src/main/resources/templates/core/management_user_habit.html
@@ -161,7 +161,7 @@
             <!-- To-Do List table-->
             <div class="table-header">
                 <h3>[[#{greenCity.sidebar.habits.toDoList}]]:
-                    <td th:text="${htodos.size()}"/>
+                    <td th:text="${todos.size()}"/>
                 </h3>
                 <div class="hide-button">
                     <button id="button3" value="hide" onclick="hideTable(this.id)">
@@ -198,7 +198,7 @@
                     </thead>
 
                     <tbody id="table3">
-                    <th:block class="list-of" th:each="todoitem, iterStatus :${htodos}">
+                    <th:block class="list-of" th:each="todoitem, iterStatus :${todos}">
                         <tr class="light-text">
                             <td style="width: 20px">
                                     <span class="custom-checkbox" style="">
@@ -237,18 +237,18 @@
         document.getElementById("leftText").value = val + " days"
     }
 
-    var inputLeft = document.getElementById("input-left");
+    let inputLeft = document.getElementById("input-left");
 
-    var thumbLeft = document.querySelector(".slider > .thumb.left");
+    let thumbLeft = document.querySelector(".slider > .thumb.left");
 
     function setLeftValue() {
-        var _this = inputLeft,
+        let _this = inputLeft,
             min = parseInt(_this.min),
             max = parseInt(_this.max);
 
         _this.value = parseInt(_this.value);
 
-        var percent = ((_this.value - min) / (max - min)) * 100;
+        let percent = ((_this.value - min) / (max - min)) * 100;
 
         thumbLeft.style.left = percent + "%";
         range.style.left = percent + "%";

--- a/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
+++ b/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
@@ -1,7 +1,5 @@
 package greencity.exception.handler;
 
-import greencity.constant.ErrorMessage;
-import greencity.entity.Place;
 import greencity.exception.exceptions.*;
 import jakarta.validation.ConstraintDeclarationException;
 import jakarta.validation.ValidationException;
@@ -12,9 +10,6 @@ import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.web.error.ErrorAttributeOptions;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
-import org.springframework.data.mapping.PropertyPath;
-import org.springframework.data.mapping.PropertyReferenceException;
-import org.springframework.data.util.TypeInformation;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,12 +20,9 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MultipartException;
-
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -239,23 +231,5 @@ class CustomExceptionHandlerTest {
             .thenReturn(objectMap);
         assertEquals(customExceptionHandler.handleConversionFailedException(mismatchException, webRequest),
             ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionResponse));
-    }
-
-    @Test
-    void handlePropertyReferenceException() {
-        List<PropertyPath> resolvedPaths = Collections.emptyList();
-        PropertyReferenceException propertyReferenceException =
-            new PropertyReferenceException("string", TypeInformation.of(Place.class), resolvedPaths);
-
-        ExceptionResponse exceptionResponse = new ExceptionResponse(objectMap);
-        exceptionResponse.setMessage(String.format(ErrorMessage.INVALID_SORT_VALUE_EXCEPTION, "string"));
-
-        when(errorAttributes.getErrorAttributes(any(WebRequest.class),
-            any(ErrorAttributeOptions.class))).thenReturn(objectMap);
-
-        ResponseEntity<Object> actual = customExceptionHandler.handlePropertyReferenceException(
-            propertyReferenceException, webRequest);
-
-        assertEquals(ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionResponse), actual);
     }
 }

--- a/core/src/test/java/greencity/webcontroller/ManagementEcoNewsControllerTest.java
+++ b/core/src/test/java/greencity/webcontroller/ManagementEcoNewsControllerTest.java
@@ -143,7 +143,7 @@ class ManagementEcoNewsControllerTest {
         when(ecoNewsService.findDtoByIdAndLanguage(1L, "en")).thenReturn(getEcoNewsDto());
         this.mockMvc.perform(get(managementEcoNewsLink + "/1"))
             .andExpect(view().name("core/management_eco_new"))
-            .andExpect(model().attribute("econew", getEcoNewsDto()))
+            .andExpect(model().attribute("ecoNews", getEcoNewsDto()))
             .andExpect(model().attribute("time", time.format(format)))
             .andExpect(model().attribute("ecoNewsTag", tagsService.findAllEcoNewsTags("en")))
             .andExpect(status().isOk());

--- a/core/src/test/java/greencity/webcontroller/ManagementHabitControllerTest.java
+++ b/core/src/test/java/greencity/webcontroller/ManagementHabitControllerTest.java
@@ -93,7 +93,7 @@ class ManagementHabitControllerTest {
 
     @Test
     void getHabitByIdPage() throws Exception {
-        List<ToDoListItemManagementDto> htodos = toDoListItemService.getToDoListByHabitId(1L);
+        List<ToDoListItemManagementDto> todos = toDoListItemService.getToDoListByHabitId(1L);
         HabitManagementDto habit = managementHabitService.getById(1L);
         Long acquired = habitAssignService.getNumberHabitAssignsByHabitIdAndStatus(1L, HabitAssignStatus.ACQUIRED);
         Long inProgress = habitAssignService.getNumberHabitAssignsByHabitIdAndStatus(1L, HabitAssignStatus.INPROGRESS);
@@ -103,7 +103,7 @@ class ManagementHabitControllerTest {
             .param("page", "0")
             .param("size", "5"))
             .andExpect(view().name("core/management_user_habit"))
-            .andExpect(model().attribute("htodos", htodos))
+            .andExpect(model().attribute("todos", todos))
             .andExpect(model().attribute("habit", habit))
             .andExpect(model().attribute("acquired", acquired))
             .andExpect(model().attribute("inProgress", inProgress))


### PR DESCRIPTION
### 🔗 **Issue:** [#8862](https://github.com/ita-social-projects/GreenCity/issues/8862)

This pull request focuses on improving code consistency and readability by standardizing naming conventions and replacing outdated variable declarations. The changes primarily affect the `ManagementEcoNewsController`, `ManagementHabitController`, and associated HTML templates.

### Code Consistency Improvements:

* Updated naming conventions in `ManagementEcoNewsController.java`:
  - Replaced "econews" with "eco-news" in operation summaries for better readability and consistency. [[1]](diffhunk://#diff-1012da909d483a49943b61cd3c6516f57c900ea81cf7e61db1af09b1a7e374faL134-R134) [[2]](diffhunk://#diff-1012da909d483a49943b61cd3c6516f57c900ea81cf7e61db1af09b1a7e374faL155-R155) [[3]](diffhunk://#diff-1012da909d483a49943b61cd3c6516f57c900ea81cf7e61db1af09b1a7e374faL217-R217)
  - Renamed variables like `econew` to `ecoNews` for clarity and alignment with naming standards.

* Adjusted variable names in `ManagementHabitController.java`:
  - Changed `htodos` to `todos` for a more intuitive naming convention.

### Template Updates:

* Refactored `management_eco_new.html`:
  - Replaced occurrences of `econew` with `ecoNews` across HTML attributes and expressions to align with updated variable names. [[1]](diffhunk://#diff-1810e6474e1c6e2b739217a6ae0aa0d55c67a25c5bba7d8ade79e147c07a8576L108-R114) [[2]](diffhunk://#diff-1810e6474e1c6e2b739217a6ae0aa0d55c67a25c5bba7d8ade79e147c07a8576L138-R155) [[3]](diffhunk://#diff-1810e6474e1c6e2b739217a6ae0aa0d55c67a25c5bba7d8ade79e147c07a8576L171-R177)
  - Added language-specific blocks for eco-news tags, improving localization support.

* Updated `management_user_habit.html`:
  - Renamed `htodos` to `todos` in table headers and iteration blocks for consistency. [[1]](diffhunk://#diff-ef5129f7813f3db9600d33e60501fad7df1e713b8f34dceb53c5768279afce48L164-R164) [[2]](diffhunk://#diff-ef5129f7813f3db9600d33e60501fad7df1e713b8f34dceb53c5768279afce48L201-R201)
  - Replaced `var` declarations with `let` in JavaScript code to modernize syntax.

✅ **This pull request closes** [#8862](https://github.com/ita-social-projects/GreenCity/issues/8862) **once merged.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved consistency and clarity in eco-news terminology across user-facing descriptions and comments.

* **Bug Fixes**
  * Corrected a typo in the to-do list model attribute key to ensure proper display of habit-related tasks.

* **Style**
  * Standardized variable names in templates for eco-news and to-do lists.
  * Updated tag rendering for eco-news to support localization.
  * Modernized JavaScript variable declarations in user habit management for better code quality.

* **Chores**
  * Removed deprecated exception handling for invalid sort parameters to streamline error management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->