### PR TITLE
Removed default values for env variables from properties files

### DIFF
--- a/core/src/main/resources/application-dev.properties
+++ b/core/src/main/resources/application-dev.properties
@@ -65,7 +65,7 @@ azure.container.name=${AZURE_CONTAINER_NAME}
 
 pg.dump.path=pg_dump
 
-google.maps.api.key=${GOOGLE_MAP_API_KEY:AIzaSyCU0ArzZlZ3n0pLq4o9MJy29LPT5DBMk4Y}
+google.maps.api.key=${GOOGLE_MAP_API_KEY}
 
 # Cron
 cron.sendContentToSubscribers=${CRON_SEND_CONTENT_TO_SUBSCRIBERS:0 0 20 * * SAT}

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -23,7 +23,7 @@ ribbon.ConnectTimeout=20000
 ribbon.ReadTimeout=20000
 
 greencity.authorization.googleApiKey=${GOOGLE_API_KEY:default-key}
-google.maps.api.key=${GOOGLE_MAP_API_KEY:AIzaSyCU0ArzZlZ3n0pLq4o9MJy29LPT5DBMk4Y}
+google.maps.api.key=${GOOGLE_MAP_API_KEY}
 
 # Swagger configuration
 springdoc.paths-to-match=/**

--- a/greencity-chart/templates/ClusterExternalSecret.yaml
+++ b/greencity-chart/templates/ClusterExternalSecret.yaml
@@ -290,4 +290,23 @@ spec:
       remoteRef:
         key: GREEN-OFFICE-EMAIL-ADDRESS
 
+    - secretKey: GOOGLE-MAP-API-KEY
+      remoteRef:
+        key: GOOGLE-MAP-API-KEY
+
+    - secretKey: SIGN-IN-TOKEN
+      remoteRef:
+        key: SIGN-IN-TOKEN
+
+    - secretKey: CLOUND-FLARE-SECRET-KEY
+      remoteRef:
+        key: CLOUND-FLARE-SECRET-KEY
+
+    - secretKey: WAY-FOR-PAY-LOGIN
+      remoteRef:
+        key: WAY-FOR-PAY-LOGIN
+
+    - secretKey: WAY-FOR-PAY-SECRET
+      remoteRef:
+        key: WAY-FOR-PAY-SECRET
 {{- end }}

--- a/greencity-chart/templates/greencity.yaml
+++ b/greencity-chart/templates/greencity.yaml
@@ -276,6 +276,11 @@ spec:
                   name: {{ .Values.externalSecret.secretName }}
                   key: SPRING-LIQUIBASE-PARAMETERS-SERVICE-EMAIL
 
+            - name: GOOGLE_MAP_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalSecret.secretName }}
+                  key: GOOGLE-MAP-API-KEY
           ports:
             - containerPort: 8080
               name: tomcat


### PR DESCRIPTION
# GreenCity PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/GreenCity/issues/9020">#9020</a>

## Changed
- Removed default values for env variables in properties files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Require Google Maps API key via environment; removed hard-coded default.
  * Added GOOGLE_MAP_API_KEY to the application container environment (sourced from external secret).
  * Expanded production ExternalSecret with entries for GOOGLE-MAP-API-KEY, SIGN-IN-TOKEN, Cloudflare secret, and WayForPay credentials.
  * Deployment note: ensure all referenced secrets are provisioned; the application will not start without GOOGLE_MAP_API_KEY.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->