### PR TITLE
Refactor: 9028 remove unused keys

### DIFF
--- a/greencity-chart/templates/ClusterExternalSecret.yaml
+++ b/greencity-chart/templates/ClusterExternalSecret.yaml
@@ -194,10 +194,6 @@ spec:
       remoteRef:
         key: LIQPAY-PRIVATE-KEY
     
-    - secretKey: FONDY-PAYMENT-KEY
-      remoteRef:
-        key: FONDY-PAYMENT-KEY
-    
     - secretKey: TELEGRAM-BOT-TOKEN
       remoteRef:
         key: TELEGRAM-BOT-TOKEN
@@ -257,14 +253,6 @@ spec:
     - secretKey: LIQPAY-REDIRECT
       remoteRef:
         key: LIQPAY-REDIRECT
-
-    - secretKey: FONDY-PERSONAL-CABINET
-      remoteRef:
-        key: FONDY-PERSONAL-CABINET
-
-    - secretKey: FONDY-REDIRECT
-      remoteRef:
-        key: FONDY-REDIRECT
 
     - secretKey: GOOGLE-API-KEY
       remoteRef:


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link
[#9028](https://github.com/ita-social-projects/GreenCity/issues/9028)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Fondy-related secret mappings from configuration; these keys will no longer be synchronized.
  * Impact: Environments relying on Fondy payment/redirect/personal-cabinet settings may see related features disabled until reconfigured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->