### PR TITLE
Changed relevance secret value

### DIFF
--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -69,7 +69,7 @@ public class EcoNewsController {
     private final EcoNewsRelevanceService ecoNewsRelevanceService;
 
     @Value("${greencity.relevance.enabled}")
-    private boolean isRelevanceEnabled;
+    private String relevanceServiceStatus;
 
     /**
      * Method for creating {@link EcoNewsVO}.
@@ -225,6 +225,7 @@ public class EcoNewsController {
     })
     @GetMapping("/relevance-enabled")
     public ResponseEntity<Boolean> isRelevanceEnabled() {
+        boolean isRelevanceEnabled = relevanceServiceStatus.equals("enabled");
         return ResponseEntity.status(HttpStatus.OK).body(isRelevanceEnabled);
     }
 

--- a/core/src/main/resources/application-dev.properties
+++ b/core/src/main/resources/application-dev.properties
@@ -90,7 +90,7 @@ spring.quartz.properties.org.quartz.jobStore.driverDelegateClass=org.quartz.impl
 spring.quartz.properties.generation.languages=uk
 
 # EcoNews Relevance
-greencity.relevance.enabled=${RELEVANCE:false}
+greencity.relevance.enabled=${ECONEWS_RELEVANCE_ENABLED:disabled}
 #mix of "strong relevant:weak relevant:non-relevant" news
 greencity.relevant.news.ratio=3:6:1
 #impact of "titles semantics:tags" on relevance calculation

--- a/core/src/main/resources/application-docker.properties
+++ b/core/src/main/resources/application-docker.properties
@@ -88,7 +88,7 @@ spring.quartz.properties.org.quartz.jobStore.driverDelegateClass=org.quartz.impl
 spring.quartz.properties.generation.languages=uk
 
 # EcoNews Relevance
-greencity.relevance.enabled=${RELEVANCE:false}
+greencity.relevance.enabled=${ECONEWS_RELEVANCE_ENABLED:disabled}
 #mix of "strong relevant:weak relevant:non-relevant" news
 greencity.relevant.news.ratio=3:6:1
 #impact of "titles semantics:tags" on relevance calculation

--- a/core/src/main/resources/application-prod.properties
+++ b/core/src/main/resources/application-prod.properties
@@ -94,7 +94,7 @@ spring.quartz.properties.org.quartz.jobStore.driverDelegateClass=org.quartz.impl
 spring.quartz.properties.generation.languages=uk
 
 # EcoNews Relevance
-greencity.relevance.enabled=${RELEVANCE:false}
+greencity.relevance.enabled=${ECONEWS_RELEVANCE_ENABLED:disabled}
 #mix of "strong relevant:weak relevant:non-relevant" news
 greencity.relevant.news.ratio=3:6:1
 #impact of "titles semantics:tags" on relevance calculation

--- a/core/src/main/resources/application-test.properties
+++ b/core/src/main/resources/application-test.properties
@@ -56,7 +56,7 @@ spring.quartz.properties.org.quartz.jobStore.driverDelegateClass=org.quartz.impl
 spring.quartz.properties.generation.languages=uk
 
 # EcoNews Relevance
-greencity.relevance.enabled=${RELEVANCE:false}
+greencity.relevance.enabled=${ECONEWS_RELEVANCE_ENABLED:disabled}
 #mix of "strong relevant:weak relevant:non-relevant" news
 greencity.relevant.news.ratio=3:6:1
 #impact of "titles semantics:tags" on relevance calculation

--- a/greencity-chart/templates/ClusterExternalSecret.yaml
+++ b/greencity-chart/templates/ClusterExternalSecret.yaml
@@ -282,9 +282,9 @@ spec:
       remoteRef:
         key: LDM-SECRET-KEY
 
-    - secretKey: RELEVANCE
+    - secretKey: ECONEWS-RELEVANCE-ENABLED
       remoteRef:
-        key: RELEVANCE
+        key: ECONEWS-RELEVANCE-ENABLED
 
     - secretKey: SPRING-LIQUIBASE-PARAMETERS-SERVICE-EMAIL
       remoteRef:

--- a/greencity-chart/templates/greencity.yaml
+++ b/greencity-chart/templates/greencity.yaml
@@ -270,11 +270,11 @@ spec:
                   name: {{ .Values.externalSecret.secretName }}
                   key: LDM-SECRET-KEY
 
-            - name: RELEVANCE
+            - name: ECONEWS_RELEVANCE_ENABLED
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.externalSecret.secretName }}
-                  key: RELEVANCE
+                  key: ECONEWS-RELEVANCE-ENABLED
 
             - name: SPRING_LIQUIBASE_PARAMETERS_SERVICE_EMAIL
               valueFrom:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined internal handling of the EcoNews relevance status without changing endpoint behavior.
- Chores
  - Standardized configuration for the EcoNews relevance toggle across environments.
  - Default behavior set to “disabled” unless explicitly enabled.
  - Updated deployment and secret mappings to align with the new configuration.
- Notes
  - No user-facing feature changes; functionality remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->