### PR TITLE
Restore Facebook secrets

### DIFF
--- a/greencity-chart/templates/ClusterExternalSecret.yaml
+++ b/greencity-chart/templates/ClusterExternalSecret.yaml
@@ -38,6 +38,14 @@ spec:
       remoteRef:
         key: GREENCITY-UBS-SERVER-ADDRESS
 
+    - secretKey: FACEBOOK-APP-SECRET
+      remoteRef:
+        key: FACEBOOK-APP-SECRET
+
+    - secretKey: FACEBOOK-APP-ID
+      remoteRef:
+        key: FACEBOOK-APP-ID
+
     - secretKey: CACHE-SPEC
       remoteRef:
         key: CACHE-SPEC

--- a/greencity-chart/templates/ClusterExternalSecret.yaml
+++ b/greencity-chart/templates/ClusterExternalSecret.yaml
@@ -38,14 +38,6 @@ spec:
       remoteRef:
         key: GREENCITY-UBS-SERVER-ADDRESS
 
-    - secretKey: FACEBOOK-APP-SECRET
-      remoteRef:
-        key: FACEBOOK-APP-SECRET
-
-    - secretKey: FACEBOOK-APP-ID
-      remoteRef:
-        key: FACEBOOK-APP-ID
-
     - secretKey: CACHE-SPEC
       remoteRef:
         key: CACHE-SPEC
@@ -186,14 +178,6 @@ spec:
       remoteRef:
         key: MERCHANT-ID
     
-    - secretKey: LIQPAY-PUBLIC-KEY
-      remoteRef:
-        key: LIQPAY-PUBLIC-KEY
-    
-    - secretKey: LIQPAY-PRIVATE-KEY
-      remoteRef:
-        key: LIQPAY-PRIVATE-KEY
-    
     - secretKey: TELEGRAM-BOT-TOKEN
       remoteRef:
         key: TELEGRAM-BOT-TOKEN
@@ -201,18 +185,6 @@ spec:
     - secretKey: TELEGRAM-BOT-NAME
       remoteRef:
         key: TELEGRAM-BOT-NAME
-    
-    - secretKey: VIBER-BOT-TOKEN
-      remoteRef:
-        key: VIBER-BOT-TOKEN
-    
-    - secretKey: VIBER-BOT-URI
-      remoteRef:
-        key: VIBER-BOT-URI
-    
-    - secretKey: VIBER-BOT-URL
-      remoteRef:
-        key: VIBER-BOT-URL
     
     - secretKey: GREENCITY-CHAT-SERVER-ADDRESS
       remoteRef:
@@ -249,10 +221,6 @@ spec:
     - secretKey: AZURE-CONTAINER
       remoteRef:
         key: AZURE-CONTAINER
-
-    - secretKey: LIQPAY-REDIRECT
-      remoteRef:
-        key: LIQPAY-REDIRECT
 
     - secretKey: GOOGLE-API-KEY
       remoteRef:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Removed LiqPay and Viber secret configurations from the cluster setup, reducing the number of external secrets managed.
  - As a result, LiqPay-related callbacks/redirects and Viber bot connectivity may no longer function if previously relied upon.
  - No other configuration or behavioral changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->