### PR TITLE
Hotfix - Changed Eco-News Relevance Enabled Secret Value in QuartConfig

### DIFF
--- a/service/src/main/java/greencity/config/QuartzConfig.java
+++ b/service/src/main/java/greencity/config/QuartzConfig.java
@@ -89,7 +89,7 @@ public class QuartzConfig {
     }
 
     @Bean
-    @ConditionalOnProperty(name = "greencity.relevance.enabled", havingValue = "true")
+    @ConditionalOnProperty(name = "greencity.relevance.enabled", havingValue = "enabled")
     public JobDetail ecoNewsRelevanceJobDetail() {
         return JobBuilder.newJob(EcoNewsRelevanceJob.class)
             .withIdentity("ecoNewsRelevanceJob")
@@ -98,7 +98,7 @@ public class QuartzConfig {
     }
 
     @Bean
-    @ConditionalOnProperty(name = "greencity.relevance.enabled", havingValue = "true")
+    @ConditionalOnProperty(name = "greencity.relevance.enabled", havingValue = "enabled")
     public Trigger ecoNewsRelevanceTrigger() {
         String fixedCron = fixCronExpression(calculateRelevanceCron);
         try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration toggle for Eco News relevance scheduling. The feature now activates only when greencity.relevance.enabled is set to "enabled" (not "true"). Admins should update environment configs to ensure the scheduler runs as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->