### PR TITLE
9026/Remove functionality for facebook

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <powermock.version>2.0.9</powermock.version>
         <tngtech.version>1.13.1</tngtech.version>
-        <facebook.version>2.0.3.RELEASE</facebook.version>
         <socialcore.version>1.1.6.RELEASE</socialcore.version>
         <lombok.version>1.18.30</lombok.version>
         <commons.io.version>2.15.0</commons.io.version>
@@ -195,17 +194,6 @@
             <groupId>org.springframework.social</groupId>
             <artifactId>spring-social-core</artifactId>
             <version>${socialcore.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.social</groupId>
-            <artifactId>spring-social-facebook</artifactId>
-            <version>${facebook.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework.social</groupId>
-                    <artifactId>spring-social-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/core/src/main/resources/application-prod.properties
+++ b/core/src/main/resources/application-prod.properties
@@ -50,9 +50,6 @@ spring.cache.caffeine.spec=${CACHE_SPEC}
 #Cloud Storage
 bucketName=${BUCKET_NAME}
 staticUrl=${STATIC_URL}
-# Facebook
-spring.social.facebook.app-id=1583587788483701
-spring.social.facebook.app-secret=00d1c3ae739dac5b3a7a72abdaca5d80
 
 # Time after a user last activity time to check if a user is online
 greencity.time.after.last.activity=300000

--- a/greencity-chart/README.md
+++ b/greencity-chart/README.md
@@ -82,8 +82,6 @@
 | DIALECT | "org.hibernate.dialect.PostgreSQLDialect" |
 | DRIVER | "org.postgresql.Driver" |
 | ECO_NEWS_ADDRESS |  |
-| FACEBOOK_APP_ID |  |
-| FACEBOOK_APP_SECRET |  |
 | GREENCITYUSER_SERVER_ADDRESS |  |
 | HIBERNATE_CONFIG |  |
 | JAWSDB_URL |  |

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -92,12 +92,6 @@
             <version>${commons-io.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.social</groupId>
-            <artifactId>spring-social-facebook</artifactId>
-            <version>${org.springframework.social.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons.lang3.version}</version>


### PR DESCRIPTION
# GreenCity PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/GreenCity/issues/9026">#9026</a>

## Changed
- Remove all Facebook-related functionality from the GreenCity module.
- Clean up configuration files, environment variables, and dependencies related to Facebook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Chores
  - Removed Facebook integration and related dependencies, disabling Facebook-based functionality (e.g., login/sharing).
  - Cleaned production configuration by removing Facebook app credentials. No other dependencies changed.

- Documentation
  - Updated deployment README to remove Facebook environment variables from the required list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->