### PR TITLE
Hotfix - Removed Old Fields from User Entity and Mutual Friends Query

### DIFF
--- a/dao/src/main/java/greencity/entity/User.java
+++ b/dao/src/main/java/greencity/entity/User.java
@@ -63,7 +63,6 @@ import java.util.Set;
                     @ColumnResult(name = "longitude", type = Double.class),
                     @ColumnResult(name = "mutualFriends", type = Long.class),
                     @ColumnResult(name = "profilePicturePath", type = String.class),
-                    @ColumnResult(name = "chatId", type = Long.class),
                     @ColumnResult(name = "friendStatus", type = String.class),
                     @ColumnResult(name = "requesterId", type = Long.class)
                 })
@@ -119,13 +118,6 @@ import java.util.Set;
                         )
                     ) AS mutualFriends,
                     u.profile_picture AS profilePicturePath,
-                    (
-                        SELECT p.room_id
-                        FROM chat_rooms_participants p
-                        WHERE p.participant_id IN (u.id, :userId)
-                        GROUP BY p.room_id
-                        HAVING COUNT(DISTINCT p.participant_id) = 2 LIMIT 1
-                    ) AS chatId,
                     (
                         SELECT uf2.status
                         FROM users_friends uf2

--- a/service-api/src/main/java/greencity/dto/friends/UserFriendDto.java
+++ b/service-api/src/main/java/greencity/dto/friends/UserFriendDto.java
@@ -9,7 +9,7 @@ import lombok.experimental.SuperBuilder;
 
 @NoArgsConstructor
 @AllArgsConstructor
-@Sortable(fields = {"id", "name", "email", "rating", "mutualFriends", "chatId"})
+@Sortable(fields = {"id", "name", "email", "rating", "mutualFriends"})
 @SuperBuilder
 @Data
 @SuppressWarnings("java:S107")
@@ -20,7 +20,6 @@ public class UserFriendDto {
     private Double rating;
     private Long mutualFriends;
     private String profilePicturePath;
-    private Long chatId;
     private String friendStatus;
     private Long requesterId;
     private UserLocationDto userLocationDto;
@@ -30,14 +29,13 @@ public class UserFriendDto {
      */
     public UserFriendDto(Long id, String name, Double rating, Long ulId, String cityEn,
         String cityUa, String regionEn, String regionUa, String countryEn, String countryUa,
-        Double latitude, Double longitude, Long mutualFriends, String profilePicturePath, Long chatId,
+        Double latitude, Double longitude, Long mutualFriends, String profilePicturePath,
         String friendStatus, Long requesterId) {
         this.id = id;
         this.name = name;
         this.rating = rating;
         this.mutualFriends = mutualFriends;
         this.profilePicturePath = profilePicturePath;
-        this.chatId = chatId;
         this.friendStatus = friendStatus;
         this.requesterId = requesterId;
         if (ulId != null) {

--- a/service-api/src/test/java/greencity/dto/friends/UserFriendDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/friends/UserFriendDtoTest.java
@@ -23,7 +23,7 @@ class UserFriendDtoTest {
         UserFriendDto userFriendDto = new UserFriendDto(id, name, rating, uLocation.getId(),
             uLocation.getCityEn(), uLocation.getCityUk(), uLocation.getRegionEn(), uLocation.getRegionUk(),
             uLocation.getCountryEn(), uLocation.getCountryUk(), uLocation.getLatitude(), uLocation.getLongitude(),
-            mutualFriends, profilePicture, chatId, friendStatus, requesterId);
+            mutualFriends, profilePicture, friendStatus, requesterId);
         userFriendDto.setEmail(email);
 
         assertEquals(id, userFriendDto.getId());
@@ -33,7 +33,6 @@ class UserFriendDtoTest {
         assertEquals(rating, userFriendDto.getRating());
         assertEquals(mutualFriends, userFriendDto.getMutualFriends());
         assertEquals(profilePicture, userFriendDto.getProfilePicturePath());
-        assertEquals(chatId, userFriendDto.getChatId());
         assertEquals(friendStatus, userFriendDto.getFriendStatus());
         assertEquals(requesterId, userFriendDto.getRequesterId());
     }
@@ -52,7 +51,7 @@ class UserFriendDtoTest {
 
         UserFriendDto userFriendDto = new UserFriendDto(
             id, name, rating, ulId, null, null, null, null, null, null,
-            null, null, mutualFriends, profilePicturePath, chatId, friendStatus, requesterId);
+            null, null, mutualFriends, profilePicturePath, friendStatus, requesterId);
 
         assertNull(userFriendDto.getUserLocationDto());
     }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -2883,7 +2883,6 @@ public class ModelUtils {
             .rating(10.0)
             .mutualFriends(3L)
             .profilePicturePath("path-to-picture")
-            .chatId(4L)
             .build();
     }
 
@@ -2896,7 +2895,6 @@ public class ModelUtils {
             .rating(10.0)
             .mutualFriends(3L)
             .profilePicturePath("path-to-picture")
-            .chatId(4L)
             .build();
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Friends list responses no longer include chat ID.
  - Sorting options for friends lists updated to remove chat ID as a sort key.
  - Data mapping streamlined to match the updated friends payload.

- Tests
  - Updated unit tests and test data to reflect the adjusted friends DTO shape.

- Chores
  - Internal mappings and queries aligned with the new friends list structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->