### PR TITLE
Fix GreenCity eco-news unauthorized users cannot view eco-news or events with comments

### DIFF
--- a/core/src/main/java/greencity/controller/EcoNewsCommentController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsCommentController.java
@@ -128,7 +128,7 @@ public class EcoNewsCommentController {
     public ResponseEntity<PageableDto<CommentDto>> getAllActiveReplies(
         @Parameter(hidden = true) Pageable pageable,
         @PathVariable Long parentCommentId,
-        @Parameter(hidden = true) @CurrentUserId Long userId) {
+        @Parameter(hidden = true) @CurrentUserId(required = false) Long userId) {
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(commentService.getAllActiveReplies(pageable, parentCommentId, userId));
@@ -276,7 +276,7 @@ public class EcoNewsCommentController {
     public ResponseEntity<PageableDto<CommentDto>> getAllActiveComments(
         @Parameter(hidden = true) Pageable pageable,
         @PathVariable Long ecoNewsId,
-        @Parameter(hidden = true) @CurrentUserId Long userId) {
+        @Parameter(hidden = true) @CurrentUserId(required = false) Long userId) {
         return ResponseEntity.status(HttpStatus.OK)
             .body(commentService.getAllActiveComments(pageable, userId, ecoNewsId, ArticleType.ECO_NEWS));
     }
@@ -299,7 +299,7 @@ public class EcoNewsCommentController {
     })
     @GetMapping("/comments/{id}")
     public ResponseEntity<CommentDto> getCommentById(@PathVariable Long id,
-        @Parameter(hidden = true) @CurrentUserId Long userId) {
+        @Parameter(hidden = true) @CurrentUserId(required = false) Long userId) {
         return ResponseEntity.status(HttpStatus.OK)
             .body(commentService.getCommentById(ArticleType.ECO_NEWS, id, userId));
     }

--- a/core/src/main/java/greencity/controller/EventCommentController.java
+++ b/core/src/main/java/greencity/controller/EventCommentController.java
@@ -98,7 +98,7 @@ public class EventCommentController {
     })
     @GetMapping("/comments/{commentId}")
     public ResponseEntity<CommentDto> getCommentById(@PathVariable Long commentId,
-        @Parameter(hidden = true) @CurrentUserId Long userId) {
+        @Parameter(hidden = true) @CurrentUserId(required = false) Long userId) {
         return ResponseEntity.ok()
             .body(commentService.getCommentById(ArticleType.EVENT, commentId, userId));
     }
@@ -141,7 +141,7 @@ public class EventCommentController {
     public ResponseEntity<PageableDto<CommentDto>> getAllActiveComments(
         @Parameter(hidden = true) Pageable pageable,
         @PathVariable Long eventId,
-        @Parameter(hidden = true) @CurrentUserId Long userId) {
+        @Parameter(hidden = true) @CurrentUserId(required = false) Long userId) {
         return ResponseEntity.ok()
             .body(commentService.getAllActiveComments(pageable, userId, eventId, ArticleType.EVENT));
     }
@@ -218,7 +218,7 @@ public class EventCommentController {
     public ResponseEntity<PageableDto<CommentDto>> findAllActiveReplies(
         @Parameter(hidden = true) Pageable pageable,
         @PathVariable Long parentCommentId,
-        @Parameter(hidden = true) @CurrentUserId Long userId) {
+        @Parameter(hidden = true) @CurrentUserId(required = false) Long userId) {
         return ResponseEntity.ok()
             .body(commentService.getAllActiveReplies(pageable, parentCommentId, userId));
     }

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -78,6 +78,7 @@ import greencity.entity.event.EventImages;
 import greencity.entity.event.Event_;
 import greencity.enums.AchievementAction;
 import greencity.enums.AchievementCategoryType;
+import greencity.enums.EventStatus;
 import greencity.enums.EventType;
 import greencity.enums.NotificationType;
 import greencity.enums.Role;
@@ -1498,9 +1499,15 @@ public class EventServiceImpl implements EventService {
     private List<SearchCriteria> createEventSearchCriteria(FilterEventDto filter) {
         List<SearchCriteria> criteriaList = new ArrayList<>();
         setValueIfNotEmpty(criteriaList, "eventTime", filter.getTime());
-        setValueIfNotEmpty(criteriaList, "cities", filter.getCities().toArray());
-        setValueIfNotEmpty(criteriaList, "statuses", filter.getStatuses().toArray());
-        setValueIfNotEmpty(criteriaList, Event_.TAGS, filter.getTags().toArray());
+        if (filter.getCities() != null) {
+            setValueIfNotEmpty(criteriaList, "cities", filter.getCities().toArray(new String[0]));
+        }
+        if (filter.getStatuses() != null) {
+            setValueIfNotEmpty(criteriaList, "statuses", filter.getStatuses().toArray(new EventStatus[0]));
+        }
+        if (filter.getTags() != null) {
+            setValueIfNotEmpty(criteriaList, Event_.TAGS, filter.getTags().toArray(new String[0]));
+        }
         setValueIfNotEmpty(criteriaList, Event_.TITLE, filter.getTitle());
         setValueIfNotEmpty(criteriaList, "dateRange", new ZonedDateTime[] {filter.getFrom(), filter.getTo()});
         return criteriaList;

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -1184,6 +1184,9 @@ class EventServiceImplTest {
     void getEventsForUnauthorizedUserTest() {
         Pageable pageable = PageRequest.of(0, 6);
         FilterEventDto filterEventDto = getFilterEventDto();
+        filterEventDto.setCities(null);
+        filterEventDto.setStatuses(null);
+        filterEventDto.setTags(null);
         Page<Event> eventsPage = mock(Page.class);
         Page<Long> idsPage = new PageImpl<>(List.of(3L, 1L), pageable, 2);
         TupleElement<?>[] elements = getTupleElements();


### PR DESCRIPTION
## Changes

* updated CurrentUserId parameters with required=false for permitted all endpoints;

* fixed exception with null value in event's filter dto in EventServiceImpl;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Improvements
  * Comment endpoints now work without a user context, enabling viewing comments, replies, and comment details without signing in.
* Bug Fixes
  * Event search no longer errors when cities, statuses, or tags are not provided; filters gracefully handle empty or missing criteria.
* Tests
  * Updated tests to reflect behavior for unauthorized event queries and empty filter inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->