### PR TITLE
Bugfix - Minor relevance algorithm changes

### DIFF
--- a/dao/src/main/java/greencity/repository/EcoNewsRepo.java
+++ b/dao/src/main/java/greencity/repository/EcoNewsRepo.java
@@ -216,13 +216,14 @@ public interface EcoNewsRepo extends JpaRepository<EcoNews, Long>, JpaSpecificat
     List<EcoNews> findAll(Specification<EcoNews> spec, Sort sort);
 
     /**
-     * Method to count all EcoNews before a specified date.
+     * Method to count all EcoNews between specified dates.
      *
-     * @param date the specified {@link ZonedDateTime}.
+     * @param startDate the lower bound of date range {@link ZonedDateTime}.
+     * @param endDate the upper bound of date range {@link ZonedDateTime}.
      * @return the count of EcoNews.
      */
-    @Query("SELECT COUNT(e) FROM EcoNews e WHERE e.creationDate < :date")
-    long countEcoNewsBeforeDate(@Param("date") ZonedDateTime date);
+    @Query("SELECT COUNT(e) FROM EcoNews e WHERE e.creationDate BETWEEN :startDate AND :endDate")
+    long countEcoNewsBetweenDates(@Param("startDate") ZonedDateTime startDate, @Param("endDate") ZonedDateTime endDate);
 
     /**
      * Finds IDs of {@link EcoNews} created on or after the given date.

--- a/dao/src/main/java/greencity/repository/EcoNewsRepo.java
+++ b/dao/src/main/java/greencity/repository/EcoNewsRepo.java
@@ -219,7 +219,7 @@ public interface EcoNewsRepo extends JpaRepository<EcoNews, Long>, JpaSpecificat
      * Method to count all EcoNews between specified dates.
      *
      * @param startDate the lower bound of date range {@link ZonedDateTime}.
-     * @param endDate the upper bound of date range {@link ZonedDateTime}.
+     * @param endDate   the upper bound of date range {@link ZonedDateTime}.
      * @return the count of EcoNews.
      */
     @Query("SELECT COUNT(e) FROM EcoNews e WHERE e.creationDate BETWEEN :startDate AND :endDate")

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -113,6 +113,7 @@ public class ErrorMessage {
     public static final String INCONSISTENT_ORDER_OF_RELEVANT_NEWS = "Requested page hasn't been generated yet."
         + " Relevant news should be generated one by one to ensure consistent relevance. Available pages 0-%d.";
     public static final String RELEVANT_NEWS_FOR_MONTH_NOT_FOUND = "Relevant news for the last month not found.";
+    public static final String NO_MORE_RELEVANT_NEWS = "There is no more relevant news for the last month.";
     public static final String USER_CANNOT_ADD_MORE_THAN_5_SOCIAL_NETWORK_LINKS =
         "User cannot add more than 5 social network links";
     public static final String INVALID_URI = "The string could not be parsed as a URI reference.";

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -108,6 +108,11 @@ public class ErrorMessage {
     public static final String ECO_NEW_NOT_IN_FAVORITES = "This eco new is not in favorites.";
     public static final String USER_HAS_ALREADY_ADDED_ECO_NEW_TO_FAVORITES =
         "User has already added this eco new to favorites.";
+    public static final String USER_HAS_NO_INTERACTIONS_YET =
+        "User has no interactions yet. User's preferences cannot be calculated.";
+    public static final String INCONSISTENT_ORDER_OF_RELEVANT_NEWS = "Requested page hasn't been generated yet."
+        + " Relevant news should be generated one by one to ensure consistent relevance. Available pages 0-%d.";
+    public static final String RELEVANT_NEWS_FOR_MONTH_NOT_FOUND = "Relevant news for the last month not found.";
     public static final String USER_CANNOT_ADD_MORE_THAN_5_SOCIAL_NETWORK_LINKS =
         "User cannot add more than 5 social network links";
     public static final String INVALID_URI = "The string could not be parsed as a URI reference.";

--- a/service-api/src/main/java/greencity/dto/cache/CachedUserRelevantNews.java
+++ b/service-api/src/main/java/greencity/dto/cache/CachedUserRelevantNews.java
@@ -21,5 +21,6 @@ public class CachedUserRelevantNews {
     private Integer lastGeneratedPage;
     private Integer totalPagesCount;
     private Long totalNewsCount;
+    private ZonedDateTime minimumAvailableDate;
     private ZonedDateTime lastRequestedDate;
 }

--- a/service/src/main/java/greencity/service/CacheServiceImpl.java
+++ b/service/src/main/java/greencity/service/CacheServiceImpl.java
@@ -28,6 +28,7 @@ import greencity.repository.TagsRepo;
 import jakarta.annotation.PostConstruct;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -80,15 +81,18 @@ public class CacheServiceImpl implements CacheService {
     public CachedUserRelevantNews getUserRelevantNewsFromCache(RelevantEcoNewsCacheKey key) {
         CachedUserRelevantNews cachedUserRelevantNews = userRelevanceNewsCache.getIfPresent(key);
         if (cachedUserRelevantNews == null) {
-            long totalEcoNewsCount = ecoNewsRepo.count();
             ZoneId zoneId = ZoneId.systemDefault();
+            ZonedDateTime startDate = LocalDate.now().minusMonths(1).atStartOfDay(zoneId);
+            ZonedDateTime endDate = LocalDate.now().plusDays(1).atStartOfDay(zoneId);
+            long totalEcoNewsCount = ecoNewsRepo.countEcoNewsBetweenDates(startDate, endDate);
             cachedUserRelevantNews = new CachedUserRelevantNews(
                 new CachedRelevancePools(new LinkedList<>(), new LinkedList<>(), new LinkedList<>()),
                 new HashMap<>(),
                 -1,
                 (int) Math.ceil((double) totalEcoNewsCount / key.pageSize()),
                 totalEcoNewsCount,
-                LocalDate.now().plusDays(1).atStartOfDay(zoneId));
+                startDate,
+                endDate);
             userRelevanceNewsCache.put(key, cachedUserRelevantNews);
         }
         return cachedUserRelevantNews;

--- a/service/src/main/java/greencity/service/EcoNewsRelevanceServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsRelevanceServiceImpl.java
@@ -200,7 +200,8 @@ public class EcoNewsRelevanceServiceImpl implements EcoNewsRelevanceService {
         CachedRelevancePools pools,
         CachedUserRelevanceProfile userProfile,
         CachedTagsWithCoherence tags) {
-        while (ecoNewsRepo.countEcoNewsBeforeDate(cachedUserNews.getLastRequestedDate()) != 0
+        while (ecoNewsRepo.countEcoNewsBetweenDates(cachedUserNews.getMinimumAvailableDate(),
+            cachedUserNews.getLastRequestedDate()) != 0
             && !hasEnoughNews(requestMetadata, pools)
             && cachedUserNews.getLastGeneratedPage() < cachedUserNews.getTotalPagesCount() - 1) {
             loadMoreNews(requestMetadata, cachedUserNews, pools, userProfile, tags);

--- a/service/src/main/java/greencity/service/EcoNewsRelevanceServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsRelevanceServiceImpl.java
@@ -197,7 +197,7 @@ public class EcoNewsRelevanceServiceImpl implements EcoNewsRelevanceService {
             loadMoreNews(requestMetadata, cachedUserNews, pools, userProfile, tags);
         }
         cachedUserNews.setLastGeneratedPage(cachedUserNews.getLastGeneratedPage() + 1);
-        double[] normalized = RelevanceWeightUtils.normalizeWeights(relevancePoolsRatio);
+        double[] normalized = RelevanceWeightUtils.normalizeWeights(relevancePoolsRatio, pools);
         int[] ratioForPages = RelevanceWeightUtils.distributeCounts(requestMetadata.pageSize(), normalized);
         return getNewsFromPoolsByRatio(pools, ratioForPages);
     }

--- a/service/src/main/java/greencity/service/EcoNewsRelevanceServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsRelevanceServiceImpl.java
@@ -3,9 +3,10 @@ package greencity.service;
 import static greencity.constant.ErrorMessage.INVALID_RELEVANCE_POOLS;
 import static greencity.constant.ErrorMessage.INVALID_SCORES_STRENGTH;
 import static greencity.constant.ErrorMessage.INVALID_SCORES_WEIGHTS;
+import greencity.constant.ErrorMessage;
 import greencity.dto.econews.EcoNewsVO;
-import greencity.entity.EcoNews_;
 import greencity.entity.Tag;
+import greencity.exception.exceptions.NotFoundException;
 import greencity.repository.EcoNewsRelevanceRepo;
 import greencity.repository.EcoNewsRepo;
 import greencity.utils.RelevanceWeightUtils;
@@ -37,7 +38,6 @@ import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -120,30 +120,20 @@ public class EcoNewsRelevanceServiceImpl implements EcoNewsRelevanceService {
 
         if (userProfile.tagsPreferencesVector().length == 0
             && userProfile.titlePreferencesVector().length == 0) {
-            EcoNewsViewDto filter = EcoNewsViewDto.builder()
-                .title(title)
-                .author(author)
-                .tags(tagsString)
-                .build();
-            Pageable pageableForFindAll = PageRequest.of(
-                pageable.getPageNumber(),
-                pageable.getPageSize(),
-                Sort.by(Sort.Direction.DESC, EcoNews_.CREATION_DATE));
-            Page<EcoNews> findResultPage = ecoNewsRepo.findAll(ecoNewsService.getSpecification(filter),
-                pageableForFindAll);
-            findResult = findResultPage.getContent();
-            totalEcoNewsCount = findResultPage.getTotalElements();
+            throw new EcoNewsRelevanceCalculationException(ErrorMessage.USER_HAS_NO_INTERACTIONS_YET);
         } else {
             CachedUserRelevantNews cachedUserRelevantNews = cacheService.getUserRelevantNewsFromCache(key);
             totalEcoNewsCount = cachedUserRelevantNews.getTotalNewsCount();
+            if (totalEcoNewsCount == 0) {
+                throw new NotFoundException(ErrorMessage.RELEVANT_NEWS_FOR_MONTH_NOT_FOUND);
+            }
+
             Map<Integer, List<Long>> relevantNewsPages = cachedUserRelevantNews.getRelevantNewsPages();
             int page = pageable.getPageNumber();
 
             if (page > cachedUserRelevantNews.getLastGeneratedPage() + 1) {
                 throw new EcoNewsRelevanceCalculationException(String.format(
-                    "Requested page hasn't been generated yet."
-                        + " Relevant news should be generated one by one to ensure consistent relevance."
-                        + " Available pages 0-%d.",
+                    ErrorMessage.INCONSISTENT_ORDER_OF_RELEVANT_NEWS,
                     cachedUserRelevantNews.getLastGeneratedPage() + 1));
             } else if (relevantNewsPages.containsKey(page)) {
                 findResult = ecoNewsRepo.findAllById(relevantNewsPages.get(page));

--- a/service/src/main/java/greencity/service/EcoNewsRelevanceServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsRelevanceServiceImpl.java
@@ -126,6 +126,8 @@ public class EcoNewsRelevanceServiceImpl implements EcoNewsRelevanceService {
             totalEcoNewsCount = cachedUserRelevantNews.getTotalNewsCount();
             if (totalEcoNewsCount == 0) {
                 throw new NotFoundException(ErrorMessage.RELEVANT_NEWS_FOR_MONTH_NOT_FOUND);
+            } else if (pageable.getPageNumber() >= cachedUserRelevantNews.getTotalPagesCount()) {
+                throw new NotFoundException(ErrorMessage.NO_MORE_RELEVANT_NEWS);
             }
 
             Map<Integer, List<Long>> relevantNewsPages = cachedUserRelevantNews.getRelevantNewsPages();

--- a/service/src/main/java/greencity/utils/RelevanceWeightUtils.java
+++ b/service/src/main/java/greencity/utils/RelevanceWeightUtils.java
@@ -90,15 +90,26 @@ public class RelevanceWeightUtils {
         double[] normalized = normalizeWeights(weights);
         int[] poolsNewsCounts = new int[] {pools.relevantStrongNewsIds().size(), pools.relevantWeakNewsIds().size(),
             pools.nonRelevantNewsIds().size()};
+        double weightForRedistribution = 0;
+        int presentedPoolsCount = normalized.length;
+
         for (int i = 0; i < normalized.length; i++) {
             if (poolsNewsCounts[i] == 0) {
-                double dividedWeight = normalized[i] / (normalized.length - i - 1);
-                for (int j = i + 1; j < normalized.length; j++) {
-                    normalized[j] += dividedWeight;
-                }
+                weightForRedistribution += normalized[i];
+                presentedPoolsCount--;
                 normalized[i] = 0;
             }
         }
+
+        if (weightForRedistribution > 0) {
+            weightForRedistribution /= presentedPoolsCount;
+            for (int i = 0; i < normalized.length; i++) {
+                if (normalized[i] != 0) {
+                    normalized[i] += weightForRedistribution;
+                }
+            }
+        }
+
         return normalized;
     }
 

--- a/service/src/main/java/greencity/utils/RelevanceWeightUtils.java
+++ b/service/src/main/java/greencity/utils/RelevanceWeightUtils.java
@@ -3,6 +3,7 @@ package greencity.utils;
 import static greencity.constant.ErrorMessage.INVALID_RATIO_FORMAT;
 import static greencity.constant.ErrorMessage.INVALID_RATIO_SUM;
 import static greencity.constant.ErrorMessage.INVALID_RATIO_VALUE;
+import greencity.dto.cache.CachedRelevancePools;
 import java.util.Arrays;
 import java.util.Collections;
 import lombok.experimental.UtilityClass;
@@ -76,6 +77,29 @@ public class RelevanceWeightUtils {
             return new double[weights.length];
         }
         return Arrays.stream(weights).map(w -> w / sum).toArray();
+    }
+
+    /**
+     * Rescale weights to sum up to 1, considering pools content.
+     *
+     * @param weights weights to normalize (sum of elements may be less than 1)
+     * @param pools collections of news with different relevance strength
+     * @return normalized weights (sum of elements is always equal to 1)
+     */
+    public static double[] normalizeWeights(double[] weights, CachedRelevancePools pools) {
+        double[] normalized = normalizeWeights(weights);
+        int[] poolsNewsCounts = new int[] {pools.relevantStrongNewsIds().size(), pools.relevantWeakNewsIds().size(),
+            pools.nonRelevantNewsIds().size()};
+        for (int i = 0; i < normalized.length; i++) {
+            if (poolsNewsCounts[i] == 0) {
+                double dividedWeight = normalized[i] / (normalized.length - i - 1);
+                for (int j = i + 1; j < normalized.length; j++) {
+                    normalized[j] += dividedWeight;
+                }
+                normalized[i] = 0;
+            }
+        }
+        return normalized;
     }
 
     /**

--- a/service/src/main/java/greencity/utils/RelevanceWeightUtils.java
+++ b/service/src/main/java/greencity/utils/RelevanceWeightUtils.java
@@ -83,7 +83,7 @@ public class RelevanceWeightUtils {
      * Rescale weights to sum up to 1, considering pools content.
      *
      * @param weights weights to normalize (sum of elements may be less than 1)
-     * @param pools collections of news with different relevance strength
+     * @param pools   collections of news with different relevance strength
      * @return normalized weights (sum of elements is always equal to 1)
      */
     public static double[] normalizeWeights(double[] weights, CachedRelevancePools pools) {

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -3673,7 +3673,7 @@ public class ModelUtils {
         HashMap<Integer, List<Long>> pagesIds = new HashMap<>();
         pagesIds.put(0, newsIds);
         return new CachedUserRelevantNews(getCachedRelevancePools(), pagesIds, 0, 3,
-            9L, ZonedDateTime.now().plusDays(1));
+            9L, ZonedDateTime.now().minusMonths(1), ZonedDateTime.now().plusDays(1));
     }
 
     public static CachedTagsWithCoherence getCachedTagsWithCoherence() {

--- a/service/src/test/java/greencity/service/CacheServiceImplTest.java
+++ b/service/src/test/java/greencity/service/CacheServiceImplTest.java
@@ -128,7 +128,8 @@ class CacheServiceImplTest {
     @Test
     void testGetUserRelevantNewsFromCacheWhenNotCached() {
         when(userRelevanceNewsCache.getIfPresent(relevantEcoNewsCacheKey)).thenReturn(null);
-        when(ecoNewsRepo.count()).thenReturn(9L);
+        when(ecoNewsRepo.countEcoNewsBetweenDates(any(ZonedDateTime.class), any(ZonedDateTime.class)))
+            .thenReturn(9L);
 
         CachedUserRelevantNews result = cacheService.getUserRelevantNewsFromCache(relevantEcoNewsCacheKey);
         assertNotNull(result);

--- a/service/src/test/java/greencity/service/EcoNewsRelevanceServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EcoNewsRelevanceServiceImplTest.java
@@ -14,6 +14,7 @@ import greencity.dto.user.UserVO;
 import greencity.entity.EcoNews;
 import greencity.entity.EcoNewsRelevance;
 import greencity.exception.exceptions.EcoNewsRelevanceCalculationException;
+import greencity.exception.exceptions.NotFoundException;
 import greencity.filters.EcoNewsSpecification;
 import greencity.mapping.PageableAdvancedDtoMapper;
 import greencity.repository.EcoNewsRelevanceRepo;
@@ -50,11 +51,13 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.never;
@@ -174,31 +177,15 @@ class EcoNewsRelevanceServiceImplTest {
             new Float[0], new Float[0]);
 
         when(cacheService.getUserProfileFromCache(anyLong())).thenReturn(cachedUserRelevanceProfile);
-        when(ecoNewsRepo.findAll(nullable(Specification.class), any(Pageable.class)))
-            .thenReturn(new PageImpl<>(ecoNewsList));
 
         EcoNewsGenericDto dto1 = mock(EcoNewsGenericDto.class);
         EcoNewsGenericDto dto2 = mock(EcoNewsGenericDto.class);
 
-        Mockito.doAnswer(invocation -> {
-            EcoNews source = invocation.getArgument(0);
-            return source.getId().equals(100L) ? dto1 : dto2;
-        }).when(modelMapper).map(Mockito.any(EcoNews.class), Mockito.<Class<EcoNewsGenericDto>>any());
-
-        PageableAdvancedDto<EcoNewsGenericDto> expected = mock(PageableAdvancedDto.class);
-        when(pageableAdvancedDtoMapper.convert(any(Page.class))).thenReturn(expected);
-
-        PageableAdvancedDto<EcoNewsGenericDto> actual = ecoNewsRelevanceService.findRelevantEcoNews(
-            pageable, tags, title, author, user);
-
-        assertEquals(expected, actual);
+        assertThrows(EcoNewsRelevanceCalculationException.class, () -> ecoNewsRelevanceService.findRelevantEcoNews(
+            pageable, tags, title, author, user));
 
         verify(cacheService).getUserProfileFromCache(anyLong());
         verify(cacheService, never()).getUserRelevantNewsFromCache(any());
-        verify(ecoNewsRepo).findAll(nullable(Specification.class), any(Pageable.class));
-        verify(modelMapper, times(2))
-            .map(any(EcoNews.class), (Class<EcoNewsGenericDto>) any(Class.class));
-        verify(pageableAdvancedDtoMapper).convert(any(Page.class));
     }
 
     @Test
@@ -220,9 +207,8 @@ class EcoNewsRelevanceServiceImplTest {
 
         when(cacheService.getUserProfileFromCache(anyLong())).thenReturn(cachedUserRelevanceProfile);
         when(cacheService.getUserRelevantNewsFromCache(any())).thenReturn(cachedUserRelevantNews);
-        when(cachedUserRelevantNews.getRelevantNewsPages()).thenReturn(new HashMap<>());
 
-        assertThrows(EcoNewsRelevanceCalculationException.class, () -> ecoNewsRelevanceService.findRelevantEcoNews(
+        assertThrows(NotFoundException.class, () -> ecoNewsRelevanceService.findRelevantEcoNews(
             pageable, tags, title, author, user));
 
         verify(cacheService).getUserProfileFromCache(anyLong());
@@ -257,8 +243,11 @@ class EcoNewsRelevanceServiceImplTest {
 
         when(cacheService.getUserProfileFromCache(anyLong())).thenReturn(cachedUserRelevanceProfile);
         when(cacheService.getUserRelevantNewsFromCache(any())).thenReturn(cachedUserRelevantNews);
-        when(cachedUserRelevantNews.getRelevantNewsPages()).thenReturn(relevantNewsPages);
         when(ecoNewsRepo.findAllById(newsIds)).thenReturn(ecoNewsList);
+        when(cachedUserRelevantNews.getRelevantNewsPages()).thenReturn(relevantNewsPages);
+        when(cachedUserRelevantNews.getLastGeneratedPage()).thenReturn(-1);
+        when(cachedUserRelevantNews.getTotalNewsCount()).thenReturn(10L);
+        when(cachedUserRelevantNews.getTotalPagesCount()).thenReturn(1);
 
         EcoNewsGenericDto dto1 = mock(EcoNewsGenericDto.class);
         EcoNewsGenericDto dto2 = mock(EcoNewsGenericDto.class);
@@ -299,15 +288,15 @@ class EcoNewsRelevanceServiceImplTest {
 
         CachedUserRelevantNews cachedUserRelevantNews = mock(CachedUserRelevantNews.class);
         Map<Integer, List<Long>> relevantNewsPages = mock(Map.class);
-        when(cachedUserRelevantNews.getRelevantNewsPages()).thenReturn(relevantNewsPages);
-        when(cachedUserRelevantNews.getTotalPagesCount()).thenReturn(2);
-        when(cachedUserRelevantNews.getLastGeneratedPage()).thenReturn(0);
-        when(cachedUserRelevantNews.getLastRequestedDate()).thenReturn(ZonedDateTime.now());
-
         CachedRelevancePools pools = new CachedRelevancePools(
             new LinkedList<>(), new LinkedList<>(), new LinkedList<>());
+        when(cachedUserRelevantNews.getRelevantNewsPages()).thenReturn(relevantNewsPages);
+        when(cachedUserRelevantNews.getLastGeneratedPage()).thenReturn(-1);
+        when(cachedUserRelevantNews.getMinimumAvailableDate()).thenReturn(ZonedDateTime.now().minusMonths(1));
+        when(cachedUserRelevantNews.getLastRequestedDate()).thenReturn(ZonedDateTime.now());
         when(cachedUserRelevantNews.getNewsRelevancePools()).thenReturn(pools);
-
+        when(cachedUserRelevantNews.getTotalNewsCount()).thenReturn(10L);
+        when(cachedUserRelevantNews.getTotalPagesCount()).thenReturn(1);
         when(cacheService.getUserRelevantNewsFromCache(any())).thenReturn(cachedUserRelevantNews);
 
         CachedUserRelevanceProfile userProfile = ModelUtils.getCachedUserRelevanceProfile();
@@ -347,7 +336,7 @@ class EcoNewsRelevanceServiceImplTest {
 
         when(ecoNewsRepo.findAll(eq(mockSpecification), any(Sort.class)))
             .thenReturn(initialFilteredNews);
-        when(ecoNewsRepo.countEcoNewsBeforeDate(any(ZonedDateTime.class)))
+        when(ecoNewsRepo.countEcoNewsBetweenDates(any(ZonedDateTime.class), any(ZonedDateTime.class)))
             .thenReturn((long) initialFilteredNews.size());
 
         when(ecoNewsRelevanceRepo.findAllByEcoNewsIdIn(anyList()))
@@ -407,6 +396,8 @@ class EcoNewsRelevanceServiceImplTest {
             assertEquals(expectedDto, actual);
 
             verify(cacheService).getUserRelevantNewsFromCache(any(RelevantEcoNewsCacheKey.class));
+            verify(cachedUserRelevantNews).getTotalNewsCount();
+            verify(cachedUserRelevantNews, times(2)).getTotalPagesCount();
             verify(cachedUserRelevantNews).getRelevantNewsPages();
             verify(cacheService).getUserProfileFromCache(userId);
             verify(cacheService).getTagsCoherenceFromCache();
@@ -418,7 +409,7 @@ class EcoNewsRelevanceServiceImplTest {
 
             assertEquals(initialFilteredNews.size(), mockedConstruction.constructed().size());
 
-            verify(cachedUserRelevantNews).setLastGeneratedPage(1);
+            verify(cachedUserRelevantNews, atLeastOnce()).setLastGeneratedPage(anyInt());
             verify(ecoNewsRepo).findAllById(expectedNewsIdsInPage);
             verify(relevantNewsPages).put(pageNumber, expectedNewsIdsInPage);
 

--- a/service/src/test/java/greencity/service/EcoNewsRelevanceServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EcoNewsRelevanceServiceImplTest.java
@@ -38,11 +38,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.util.ReflectionTestUtils;
 import java.lang.reflect.Field;
 import java.time.format.DateTimeFormatter;
@@ -56,7 +54,6 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
@@ -168,18 +165,10 @@ class EcoNewsRelevanceServiceImplTest {
 
         UserVO user = new UserVO();
         user.setId(userId);
-
-        List<Long> newsIds = List.of(100L, 101L);
-        List<EcoNews> ecoNewsList = newsIds.stream()
-            .map(id -> EcoNews.builder().id(id).build())
-            .toList();
         CachedUserRelevanceProfile cachedUserRelevanceProfile = new CachedUserRelevanceProfile(
             new Float[0], new Float[0]);
 
         when(cacheService.getUserProfileFromCache(anyLong())).thenReturn(cachedUserRelevanceProfile);
-
-        EcoNewsGenericDto dto1 = mock(EcoNewsGenericDto.class);
-        EcoNewsGenericDto dto2 = mock(EcoNewsGenericDto.class);
 
         assertThrows(EcoNewsRelevanceCalculationException.class, () -> ecoNewsRelevanceService.findRelevantEcoNews(
             pageable, tags, title, author, user));

--- a/service/src/test/java/greencity/utils/RelevanceWeightUtilsTest.java
+++ b/service/src/test/java/greencity/utils/RelevanceWeightUtilsTest.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import greencity.dto.cache.CachedRelevancePools;
 import java.util.Arrays;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/service/src/test/java/greencity/utils/RelevanceWeightUtilsTest.java
+++ b/service/src/test/java/greencity/utils/RelevanceWeightUtilsTest.java
@@ -7,6 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import greencity.dto.cache.CachedRelevancePools;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -163,6 +167,37 @@ class RelevanceWeightUtilsTest {
         }
     }
 
+    @ParameterizedTest
+    @MethodSource("normalizeWeightsProvider")
+    void testNormalizeWeights(double[] inputWeights, long[] strongNews, long[] weakNews, long[] nonRelevantNews,
+        double[] expected, double[] assertions) {
+        LinkedList<Long> strongNewsList = new LinkedList<>(Arrays.stream(strongNews).boxed().toList());
+        LinkedList<Long> weakNewsList = new LinkedList<>(Arrays.stream(weakNews).boxed().toList());
+        LinkedList<Long> nonRelevantNewsList = new LinkedList<>(Arrays.stream(nonRelevantNews).boxed().toList());
+        CachedRelevancePools pools = new CachedRelevancePools(strongNewsList, weakNewsList, nonRelevantNewsList);
+        double[] result = RelevanceWeightUtils.normalizeWeights(inputWeights, pools);
+
+        if (expected != null) {
+            assertArrayEquals(expected, result, PRECISION);
+        } else if (assertions != null) {
+            assertEquals(assertions[0], result[0], PRECISION);
+            assertEquals(assertions[1], result[1], PRECISION);
+            if (result.length > 2)
+                assertEquals(assertions[2], result[2], PRECISION);
+        } else {
+            assertEquals(1.0, Arrays.stream(result).sum(), PRECISION);
+            if (result.length == 3) {
+                assertTrue(result[0] < result[1]);
+                assertTrue(result[1] < result[2]);
+            }
+        }
+
+        if (inputWeights == null) {
+            assertNotNull(result);
+            assertEquals(0, result.length);
+        }
+    }
+
     private static Stream<Arguments> prepareForValidRatios() {
         return Stream.of(
             Arguments.of("0.4:0.6", 2, true),
@@ -180,5 +215,25 @@ class RelevanceWeightUtilsTest {
             Arguments.of("0.6:0.5", 2, false),
             Arguments.of("0.3:0.3", 2, false),
             Arguments.of("", 0, false));
+    }
+
+    private static Stream<Arguments> normalizeWeightsProvider() {
+        return Stream.of(
+            Arguments.of(new double[] {2, 3, 5}, new long[] {1L, 2L}, new long[] {3L, 4L, 5L},
+                new long[] {6L, 7L}, new double[] {0.2, 0.3, 0.5}, null),
+            Arguments.of(new double[] {0.2, 0.3, 0.5}, new long[] {1L, 2L}, new long[] {},
+                new long[] {6L, 7L}, null, new double[] {0.35, 0.0, 0.65}),
+            Arguments.of(new double[] {0.2, 0.3, 0.5}, new long[] {}, new long[] {}, new long[] {6L, 7L},
+                new double[] {0.0, 0.0, 1.0}, null),
+            Arguments.of(new double[] {0.2, 0.3, 0.5}, new long[] {}, new long[] {}, new long[] {},
+                new double[] {0.0, 0.0, 0.0}, null),
+            Arguments.of(new double[] {0.4, 0.3, 0.3}, new long[] {}, new long[] {3L}, new long[] {6L},
+                new double[] {0.0, 0.5, 0.5}, null),
+            Arguments.of(new double[] {0.5, 0.5, 0.0}, new long[] {1L}, new long[] {3L}, new long[] {},
+                new double[] {0.5, 0.5, 0.0}, null),
+            Arguments.of(new double[] {1, 2, 3}, new long[] {1L}, new long[] {3L}, new long[] {6L},
+                null, null),
+            Arguments.of(new double[] {0, 0, 0}, new long[] {1L}, new long[] {3L}, new long[] {6L},
+                new double[] {0.0, 0.0, 0.0}, null));
     }
 }


### PR DESCRIPTION
## Changed:
- narrowed news that are returned by relevance to last month only;
- changed logic when there is no liked news/events/habits by user (user preferences profile hasn't created yet), or when any news weren't published for the last month;
- fixed logic that normalizes ratio when some of news categories are empty (when only relevant or non-relevant news are only presented);
- added exception when page of relevant news is overstated;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recommendations use a bounded recent-date window for timelier, more consistent eco-news and caching.
  * Relevance weighting now redistributes scores when some content categories are empty for fairer results.

* **Bug Fixes**
  * Clearer error responses for users with no interactions, when recent relevant news is missing, or when requested pages are unavailable.
  * Improved validation to prevent out-of-order or inconsistent recommendation pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->