### PR TITLE
hotfix snippet annotations

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -141,7 +141,8 @@ public class SecurityConfig {
                 .requestMatchers("/error").permitAll()
                 .requestMatchers("/", "/management/", "/management/login").permitAll()
                 .requestMatchers("/management/**",
-                    "/actuator/**").hasAnyRole(ADMIN)
+                    "/actuator/**")
+                .hasAnyRole(ADMIN)
                 .requestMatchers("/actuator/prometheus").permitAll()
                 .requestMatchers("/v2/api-docs/**",
                     "/v3/api-docs/**",

--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -140,7 +140,8 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers("/error").permitAll()
                 .requestMatchers("/", "/management/", "/management/login").permitAll()
-                .requestMatchers("/management/**").hasAnyRole(ADMIN)
+                .requestMatchers("/management/**",
+                    "/actuator/**").hasAnyRole(ADMIN)
                 .requestMatchers("/actuator/prometheus").permitAll()
                 .requestMatchers("/v2/api-docs/**",
                     "/v3/api-docs/**",

--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -140,10 +140,10 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers("/error").permitAll()
                 .requestMatchers("/", "/management/", "/management/login").permitAll()
+                .requestMatchers("/actuator/prometheus").permitAll()
                 .requestMatchers("/management/**",
                     "/actuator/**")
                 .hasAnyRole(ADMIN)
-                .requestMatchers("/actuator/prometheus").permitAll()
                 .requestMatchers("/v2/api-docs/**",
                     "/v3/api-docs/**",
                     "/swagger.json",

--- a/greencity-chart/templates/ingress-greencity.yaml
+++ b/greencity-chart/templates/ingress-greencity.yaml
@@ -10,8 +10,9 @@ metadata:
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost:4200, https://www.greencity.cx.ua"
     nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    allow-snippet-annotations: "true"
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($request_uri ~* "^/actuator") {
+      if ($request_uri ~* "^/actuator/prometheus") {
         return 403;
       }
 spec:


### PR DESCRIPTION
Issue
[8077](https://github.com/orgs/ita-social-projects/projects/44/views/1?pane=issue&itemId=95640281&issue=ita-social-projects%7CGreenCity%7C8077)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * ADMIN-only protection now applies to both management and actuator routes, while the specific actuator/prometheus path remains treated separately.
  * Ingress annotations updated to allow snippet annotations and NGINX rules adjusted to target the actuator/prometheus path more precisely.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->