### PR TITLE
use another method to block the endpoint /actuator/prometheus

### DIFF
--- a/greencity-chart/templates/ingress-greencity.yaml
+++ b/greencity-chart/templates/ingress-greencity.yaml
@@ -5,16 +5,10 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: 150m
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost:4200, https://www.greencity.cx.ua"
     nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
-    allow-snippet-annotations: "true"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($request_uri ~* "^/actuator/prometheus") {
-        return 403;
-      }
 spec:
   tls:
   - hosts:
@@ -24,6 +18,15 @@ spec:
   - host: {{ .Values.ingress.hostname }}
     http:
       paths:
+      # fake service to block /actuator/prometheus and allow all other endpoint
+      - path: /actuator/prometheus
+        pathType: Exact
+        backend:
+          service:
+            name: actuator-prometheus-blocker
+            port:
+              number: 80
+
       - path: /
         pathType: Prefix
         backend:

--- a/greencity-chart/values.yaml
+++ b/greencity-chart/values.yaml
@@ -16,10 +16,6 @@ externalSecret:
 service:
   type: ClusterIP
 
-# enable configuration-snippet to allow endpoint /actuator/prometheus only in cluster
-controller:
-  allowSnippetAnnotations: true
-
 # You need Nginx ingress controller and cert manager already installed
 # https://kubernetes.github.io/ingress-nginx/deploy/
 # https://cert-manager.io/docs/installation/helm/#3-install-customresourcedefinitions


### PR DESCRIPTION
Link Issue
[8077](https://github.com/orgs/ita-social-projects/projects/44/views/1?pane=issue&itemId=95640281&issue=ita-social-projects%7CGreenCity%7C8077)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated access control mechanism for the `/actuator/prometheus` endpoint. Changed from a snippet-based approach to a dedicated backend service. Other ingress paths and routing behavior remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->